### PR TITLE
Fix invite identity detail refresh with existing identity cookie

### DIFF
--- a/Source/Ingress.Specs/Identity/for_IdentityDetailsResolver/when_identity_cookie_is_present_and_invite_cookie_exists.cs
+++ b/Source/Ingress.Specs/Identity/for_IdentityDetailsResolver/when_identity_cookie_is_present_and_invite_cookie_exists.cs
@@ -1,12 +1,13 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Net;
 using Cratis.Arc.Identity;
 using Cratis.Ingress.Invites;
 
 namespace Cratis.Ingress.Identity.for_IdentityDetailsResolver;
 
-public class when_identity_cookie_is_already_present : Specification
+public class when_identity_cookie_is_present_and_invite_cookie_exists : Specification
 {
     IdentityDetailsResolver _resolver;
     DefaultHttpContext _context;
@@ -26,16 +27,25 @@ public class when_identity_cookie_is_already_present : Specification
         optionsMonitor.CurrentValue.Returns(config);
 
         _httpClientFactory = Substitute.For<IHttpClientFactory>();
+        _httpClientFactory.CreateClient(Arg.Any<string>()).Returns(
+            new HttpClient(new FakeHttpMessageHandler(HttpStatusCode.OK, /*lang=json,strict*/ "{\"displayName\":\"John Doe\"}")));
+
         var inviteTokenValidator = Substitute.For<IInviteTokenValidator>();
+        inviteTokenValidator.TryGetClaim("invite-token", "jti", out Arg.Any<string>())
+            .Returns(callInfo =>
+            {
+                callInfo[2] = "7cf1cec4-3fdf-4dc1-9b0c-04d42d928f6e";
+                return true;
+            });
 
         _resolver = new IdentityDetailsResolver(optionsMonitor, _httpClientFactory, inviteTokenValidator, Substitute.For<ILogger<IdentityDetailsResolver>>());
 
         _context = new DefaultHttpContext();
-        _context.Request.Headers.Cookie = $"{Cookies.Identity}=existing-value";
+        _context.Request.Headers.Cookie = $"{Cookies.Identity}=existing-value; {Cookies.InviteToken}=invite-token";
     }
 
     async Task Because() => _result = await _resolver.Resolve(_context, new ClientPrincipal { UserId = "user-1" }, Guid.NewGuid());
 
-    [Fact] void should_be_authorized() => Assert.True(_result.IsAuthorized);
-    [Fact] void should_not_call_the_http_client() => _httpClientFactory.DidNotReceive().CreateClient(Arg.Any<string>());
+    [Fact] void should_be_authorized() => _result.IsAuthorized.ShouldBeTrue();
+    [Fact] void should_call_the_http_client_to_refresh_details() => _httpClientFactory.Received(1).CreateClient(Arg.Any<string>());
 }

--- a/Source/Ingress.Specs/Identity/for_IdentityDetailsResolver/when_microservice_returns_forbidden.cs
+++ b/Source/Ingress.Specs/Identity/for_IdentityDetailsResolver/when_microservice_returns_forbidden.cs
@@ -3,6 +3,7 @@
 
 using System.Net;
 using Cratis.Arc.Identity;
+using Cratis.Ingress.Invites;
 
 namespace Cratis.Ingress.Identity.for_IdentityDetailsResolver;
 
@@ -27,8 +28,9 @@ public class when_microservice_returns_forbidden : Specification
         var httpClientFactory = Substitute.For<IHttpClientFactory>();
         httpClientFactory.CreateClient(Arg.Any<string>()).Returns(
             new HttpClient(new FakeHttpMessageHandler(HttpStatusCode.Forbidden)));
+        var inviteTokenValidator = Substitute.For<IInviteTokenValidator>();
 
-        _resolver = new IdentityDetailsResolver(optionsMonitor, httpClientFactory, Substitute.For<ILogger<IdentityDetailsResolver>>());
+        _resolver = new IdentityDetailsResolver(optionsMonitor, httpClientFactory, inviteTokenValidator, Substitute.For<ILogger<IdentityDetailsResolver>>());
         _context = new DefaultHttpContext();
     }
 

--- a/Source/Ingress.Specs/Identity/for_IdentityDetailsResolver/when_microservice_returns_identity_details.cs
+++ b/Source/Ingress.Specs/Identity/for_IdentityDetailsResolver/when_microservice_returns_identity_details.cs
@@ -3,6 +3,7 @@
 
 using System.Net;
 using Cratis.Arc.Identity;
+using Cratis.Ingress.Invites;
 
 namespace Cratis.Ingress.Identity.for_IdentityDetailsResolver;
 
@@ -27,8 +28,9 @@ public class when_microservice_returns_identity_details : Specification
         var httpClientFactory = Substitute.For<IHttpClientFactory>();
         httpClientFactory.CreateClient(Arg.Any<string>()).Returns(
             new HttpClient(new FakeHttpMessageHandler(HttpStatusCode.OK, /*lang=json,strict*/ "{\"displayName\":\"John Doe\"}")));
+        var inviteTokenValidator = Substitute.For<IInviteTokenValidator>();
 
-        _resolver = new IdentityDetailsResolver(optionsMonitor, httpClientFactory, Substitute.For<ILogger<IdentityDetailsResolver>>());
+        _resolver = new IdentityDetailsResolver(optionsMonitor, httpClientFactory, inviteTokenValidator, Substitute.For<ILogger<IdentityDetailsResolver>>());
         _context = new DefaultHttpContext();
     }
 

--- a/Source/Ingress.Specs/Identity/for_IdentityDetailsResolver/when_multiple_microservices_return_details.cs
+++ b/Source/Ingress.Specs/Identity/for_IdentityDetailsResolver/when_multiple_microservices_return_details.cs
@@ -3,6 +3,7 @@
 
 using System.Net;
 using Cratis.Arc.Identity;
+using Cratis.Ingress.Invites;
 
 namespace Cratis.Ingress.Identity.for_IdentityDetailsResolver;
 
@@ -28,8 +29,9 @@ public class when_multiple_microservices_return_details : Specification
         var httpClientFactory = Substitute.For<IHttpClientFactory>();
         httpClientFactory.CreateClient(Arg.Any<string>()).Returns(
             new HttpClient(new FakeHttpMessageHandler(HttpStatusCode.OK, /*lang=json,strict*/ "{\"propA\":\"valueA\",\"propB\":\"valueB\"}")));
+        var inviteTokenValidator = Substitute.For<IInviteTokenValidator>();
 
-        _resolver = new IdentityDetailsResolver(optionsMonitor, httpClientFactory, Substitute.For<ILogger<IdentityDetailsResolver>>());
+        _resolver = new IdentityDetailsResolver(optionsMonitor, httpClientFactory, inviteTokenValidator, Substitute.For<ILogger<IdentityDetailsResolver>>());
         _context = new DefaultHttpContext();
     }
 

--- a/Source/Ingress/Identity/IdentityDetailsResolver.cs
+++ b/Source/Ingress/Identity/IdentityDetailsResolver.cs
@@ -6,6 +6,7 @@ using System.Text.Encodings.Web;
 using System.Text.Json.Nodes;
 using Cratis.Arc.Identity;
 using Cratis.Ingress.Configuration;
+using Cratis.Ingress.Invites;
 using Cratis.Json;
 using Microsoft.Extensions.Options;
 
@@ -18,10 +19,12 @@ namespace Cratis.Ingress.Identity;
 /// </summary>
 /// <param name="config">The ingress configuration.</param>
 /// <param name="httpClientFactory">The HTTP client factory.</param>
+/// <param name="inviteTokenValidator">The invite token validator.</param>
 /// <param name="logger">The logger.</param>
 public class IdentityDetailsResolver(
     IOptionsMonitor<IngressConfig> config,
     IHttpClientFactory httpClientFactory,
+    IInviteTokenValidator inviteTokenValidator,
     ILogger<IdentityDetailsResolver> logger) : IIdentityDetailsResolver
 {
     static readonly JsonSerializerOptions _cookieSerializerOptions = new()
@@ -34,11 +37,15 @@ public class IdentityDetailsResolver(
     /// <inheritdoc/>
     public async Task<IdentityProviderResult> Resolve(HttpContext context, ClientPrincipal principal, Guid tenantId)
     {
-        // Skip when the identity cookie is already present for this request.
-        if (context.Request.Cookies.ContainsKey(Cookies.Identity))
+        var hasPendingInviteToken = context.Request.Cookies.ContainsKey(Cookies.InviteToken);
+
+        // Skip only when identity is already present and we are not in an invite flow.
+        if (context.Request.Cookies.ContainsKey(Cookies.Identity) && !hasPendingInviteToken)
         {
             return BuildAuthorizedResult(principal, details: null);
         }
+
+        var principalForIdentityResolution = CreatePrincipalForIdentityResolution(context, principal);
 
         var mergedDetails = new JsonObject();
         var microservices = config.CurrentValue.Microservices;
@@ -56,7 +63,7 @@ public class IdentityDetailsResolver(
             var result = await CallIdentityEndpoint(
                 name,
                 microservice.Backend.BaseUrl,
-                principal,
+                principalForIdentityResolution,
                 tenantId,
                 context.Response);
 
@@ -78,6 +85,30 @@ public class IdentityDetailsResolver(
         logger.IdentityDetailsCookieWritten(principal.UserId);
 
         return identityResult;
+    }
+
+    ClientPrincipal CreatePrincipalForIdentityResolution(HttpContext context, ClientPrincipal principal)
+    {
+        if (!context.Request.Cookies.TryGetValue(Cookies.InviteToken, out var inviteToken)
+            || string.IsNullOrWhiteSpace(inviteToken))
+        {
+            return principal;
+        }
+
+        if (!inviteTokenValidator.TryGetClaim(inviteToken, "jti", out var invitationId)
+            || string.IsNullOrWhiteSpace(invitationId))
+        {
+            return principal;
+        }
+
+        return new ClientPrincipal
+        {
+            IdentityProvider = principal.IdentityProvider,
+            UserId = invitationId,
+            UserDetails = principal.UserDetails,
+            UserRoles = principal.UserRoles,
+            Claims = principal.Claims,
+        };
     }
 
     IdentityProviderResult BuildAuthorizedResult(ClientPrincipal principal, object? details) =>


### PR DESCRIPTION
## Fixed
- Keep identity detail resolution active during invite flow even when an identity cookie already exists.
- Resolve invite-flow identity details using the invitation token id claim and add regression specs for this behavior.