### PR TITLE
Fix identity details payload parsing and endpoint diagnostics

### DIFF
--- a/Source/AuthProxy/Identity/IdentityDetailsResolver.cs
+++ b/Source/AuthProxy/Identity/IdentityDetailsResolver.cs
@@ -60,6 +60,8 @@ public class IdentityDetailsResolver(
                 continue;
             }
 
+            logger.CallingIdentityEndpointWithPrincipal(name, principalForIdentityResolution.UserId, hasPendingInviteToken);
+
             var result = await CallIdentityEndpoint(
                 name,
                 microservice.Backend.BaseUrl,
@@ -169,7 +171,8 @@ public class IdentityDetailsResolver(
 
         if (!httpResponse.IsSuccessStatusCode)
         {
-            logger.IdentityEndpointUnsuccessful(microserviceName, (int)httpResponse.StatusCode);
+            var errorBody = await httpResponse.Content.ReadAsStringAsync();
+            logger.IdentityEndpointUnsuccessful(microserviceName, (int)httpResponse.StatusCode, errorBody);
             return new JsonObject();
         }
 
@@ -181,7 +184,8 @@ public class IdentityDetailsResolver(
 
         try
         {
-            return JsonNode.Parse(body)?.AsObject() ?? new JsonObject();
+            var parsed = JsonNode.Parse(body)?.AsObject() ?? new JsonObject();
+            return parsed["details"]?.AsObject() ?? parsed;
         }
         catch (Exception ex)
         {

--- a/Source/AuthProxy/Identity/IdentityDetailsResolverLogging.cs
+++ b/Source/AuthProxy/Identity/IdentityDetailsResolverLogging.cs
@@ -11,14 +11,17 @@ internal static partial class IdentityDetailsResolverLogging
     [LoggerMessage(LogLevel.Debug, "Calling identity endpoint {Url} for microservice '{Microservice}'")]
     internal static partial void CallingIdentityEndpoint(this ILogger logger, string url, string microservice);
 
+    [LoggerMessage(LogLevel.Debug, "Calling identity endpoint for microservice '{Microservice}' with UserId={UserId} (InviteToken present: {HasInviteToken})")]
+    internal static partial void CallingIdentityEndpointWithPrincipal(this ILogger logger, string microservice, string userId, bool hasInviteToken);
+
     [LoggerMessage(LogLevel.Error, "Error calling identity endpoint for microservice '{Microservice}'")]
     internal static partial void ErrorCallingIdentityEndpoint(this ILogger logger, Exception exception, string microservice);
 
     [LoggerMessage(LogLevel.Warning, "Microservice '{Microservice}' returned 403 for user {UserId} - access denied")]
     internal static partial void IdentityEndpointForbidden(this ILogger logger, string microservice, string userId);
 
-    [LoggerMessage(LogLevel.Warning, "Identity endpoint for '{Microservice}' returned {StatusCode}. Identity details skipped")]
-    internal static partial void IdentityEndpointUnsuccessful(this ILogger logger, string microservice, int statusCode);
+    [LoggerMessage(LogLevel.Warning, "Identity endpoint for '{Microservice}' returned {StatusCode}. Identity details skipped. Response body: {Body}")]
+    internal static partial void IdentityEndpointUnsuccessful(this ILogger logger, string microservice, int statusCode, string body);
 
     [LoggerMessage(LogLevel.Warning, "Could not parse identity response from '{Microservice}'")]
     internal static partial void CouldNotParseIdentityResponse(this ILogger logger, Exception exception, string microservice);

--- a/Source/AuthProxy/appsettings.json
+++ b/Source/AuthProxy/appsettings.json
@@ -1,9 +1,10 @@
 {
     "Logging": {
         "LogLevel": {
-            "Default": "Information",
+            "Default": "Debug",
             "Microsoft": "Warning",
             "Microsoft.Hosting.Lifetime": "Information",
+            "System.Net.Http": "Warning",
             "Yarp": "Warning"
         }
     },


### PR DESCRIPTION
## Changed
- Added debug logging that records which principal is used when calling each microservice identity endpoint.
- Enhanced warning logs for unsuccessful identity endpoint calls to include the response body for faster troubleshooting.
- Updated identity response parsing to use the nested details object when present while preserving support for flat payloads.
- Tuned default logging configuration to Debug and set System.Net.Http to Warning to keep HTTP noise under control.
