### PR TITLE
Add invite token claim forwarding pipeline for identity details

### DIFF
--- a/Documentation/configuration/invites.md
+++ b/Documentation/configuration/invites.md
@@ -1,6 +1,6 @@
 # Invites & Lobby
 
-Ingress includes a two-phase invite flow that lets you onboard new users via signed JWT invite
+AuthProxy includes a two-phase invite flow that lets you onboard new users via signed JWT invite
 tokens, and an optional **lobby** service to which users without a resolved tenant are
 redirected while they complete the onboarding process.
 
@@ -11,20 +11,20 @@ redirected while they complete the onboarding process.
 ### Phase 1 – Invite link
 
 1. A user receives a link in the form `https://your-authproxy/invite/<token>`.
-2. Ingress validates the token against the configured RSA public key.
+2. AuthProxy validates the token against the configured RSA public key.
 3. If the token is **valid**, it is stored in a short-lived HTTP-only cookie.
    - If **only one** identity provider is configured, the user is redirected directly to that provider's login.
-   - If **multiple** identity providers are configured, Ingress serves `invitation-select-provider.html`
+  - If **multiple** identity providers are configured, AuthProxy serves `invitation-select-provider.html`
      with a `.cratis-providers` cookie so the user can choose which provider to log in with.
-4. If the token has **expired** (valid signature but past its `exp` claim), Ingress serves
+4. If the token has **expired** (valid signature but past its `exp` claim), AuthProxy serves
    `invitation-expired.html` with HTTP 401.
-5. If the token is **invalid** (malformed, bad signature, or unparseable), Ingress serves
+5. If the token is **invalid** (malformed, bad signature, or unparseable), AuthProxy serves
    `invitation-invalid.html` with HTTP 401.
 
 ### Phase 2 – Post-login exchange
 
 1. After a successful OIDC login the user is redirected back.
-2. Ingress detects the invite cookie, calls the configured `ExchangeUrl` with the token and the
+2. AuthProxy detects the invite cookie, calls the configured `ExchangeUrl` with the token and the
    authenticated user's subject, then deletes the cookie.
 3. If the exchange succeeds and a **lobby** service is configured, the user is redirected to
    the lobby's frontend so they can enter the application with their newly assigned tenant.
@@ -32,12 +32,12 @@ redirected while they complete the onboarding process.
 ### Lobby – no-tenant redirect
 
 Tenancy is resolved **before** the invite system.  
-When Ingress cannot resolve a tenant for a request it checks whether a lobby is configured:
+When AuthProxy cannot resolve a tenant for a request it checks whether a lobby is configured:
 
 - **Lobby configured** – the user is redirected to the lobby's frontend URL, unless the request
   is already an invite path (`/invite/...`) or the user already holds a pending invite cookie (so
   that the Phase 2 exchange can complete).
-- **No lobby** – Ingress returns `401 Unauthorized` when `TenantResolutions` is non-empty,
+- **No lobby** – AuthProxy returns `401 Unauthorized` when `TenantResolutions` is non-empty,
   or proceeds without a tenant when no resolutions are configured.
 
 ---
@@ -50,21 +50,29 @@ All invite and lobby settings live under `Cratis:AuthProxy:Invite`:
 {
   "Cratis": {
     "AuthProxy": {
-    "Invite": {
-      "PublicKeyPem": "-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----",
-      "Issuer": "https://studio.example.com",
-      "Audience": "authproxy",
-      "ExchangeUrl": "https://studio.example.com/internal/invites/exchange",
-      "Lobby": {
-        "Frontend": { "BaseUrl": "http://lobby-service:3000/" },
-        "Backend":  { "BaseUrl": "http://lobby-service:8080/" }
+      "Invite": {
+        "PublicKeyPem": "-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----",
+        "Issuer": "https://studio.example.com",
+        "Audience": "authproxy",
+        "ExchangeUrl": "https://studio.example.com/internal/invites/exchange",
+        "TenantClaim": "tenant_id",
+        "AppendInvitationIdToQueryString": true,
+        "InvitationIdQueryStringKey": "invitationId",
+        "ClaimsToForward": [
+          { "FromClaimType": "organization_id", "ToClaimType": "organization" },
+          { "FromClaimType": "invited_by" }
+        ],
+        "Lobby": {
+          "Frontend": { "BaseUrl": "http://lobby-service:3000/" },
+          "Backend":  { "BaseUrl": "http://lobby-service:8080/" }
+        }
       }
     }
   }
 }
 ```
 
-### InviteConfig properties
+### Invite properties
 
 | Property | Type | Description |
 |----------|------|-------------|
@@ -72,11 +80,33 @@ All invite and lobby settings live under `Cratis:AuthProxy:Invite`:
 | `Issuer` | `string` | Expected `iss` claim. Leave empty to skip issuer validation. |
 | `Audience` | `string` | Expected `aud` claim. Leave empty to skip audience validation. |
 | `ExchangeUrl` | `string` | Absolute URL of the invite-exchange endpoint, e.g. `https://studio.example.com/internal/invites/exchange`. |
-| `Lobby` | `ServiceConfig` | Optional lobby service. See below. |
+| `TenantClaim` | `string` | Claim in the invite token that contains tenant ID for tenant-issued invite detection. |
+| `AppendInvitationIdToQueryString` | `bool` | Appends `jti` from the invite token to the lobby redirect query string when enabled. |
+| `InvitationIdQueryStringKey` | `string` | Query string key used when appending invitation ID. |
+| `ClaimsToForward` | `InviteClaimForwarding[]` | Claim mappings forwarded from invite token into the principal sent to identity details providers. |
+| `Lobby` | `Service` | Optional lobby service. See below. |
+
+### Invite claim forwarding
+
+When `ClaimsToForward` is configured and a pending invite token cookie exists, AuthProxy reads the configured
+invite-token claims and adds them to the principal payload sent to each `/.cratis/me` identity details endpoint.
+
+- Existing identity-provider claims are preserved.
+- Mapped invite claims are appended if present.
+- If `ToClaimType` is empty, the original `FromClaimType` is used.
+
+This gives you a decoupled extension point for propagating invitation context into identity resolution.
+
+### InviteClaimForwarding properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `FromClaimType` | `string` | Claim type to read from the invite token payload. |
+| `ToClaimType` | `string` | Claim type to emit in the principal sent to identity details providers. Defaults to `FromClaimType` when empty. |
 
 ### Lobby service
 
-The `Lobby` property accepts a standard [`ServiceConfig`](microservices.md) object.
+The `Lobby` property accepts a standard [`Service`](services.md) object.
 Only the `Frontend.BaseUrl` is required for the lobby redirect; a `Backend` endpoint is optional
 and can be used if the lobby needs an API.
 
@@ -113,7 +143,7 @@ Recommended claims:
 
 ## Invitation error pages
 
-Ingress distinguishes between two token failure modes and serves a dedicated page for each:
+AuthProxy distinguishes between two token failure modes and serves a dedicated page for each:
 
 | Page file | Condition |
 |-----------|-----------|

--- a/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_invite_claim_forwarding_is_configured.cs
+++ b/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_invite_claim_forwarding_is_configured.cs
@@ -1,0 +1,117 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Invites;
+
+namespace Cratis.AuthProxy.Identity.for_IdentityDetailsResolver;
+
+public class when_invite_claim_forwarding_is_configured : Specification
+{
+    IdentityDetailsResolver _resolver;
+    DefaultHttpContext _context;
+    CapturingHttpMessageHandler _handler;
+
+    void Establish()
+    {
+        var config = new C.AuthProxy
+        {
+            Invite = new C.Invite
+            {
+                ClaimsToForward =
+                [
+                    new C.InviteClaimForwarding { FromClaimType = "organization_id", ToClaimType = "organization" },
+                    new C.InviteClaimForwarding { FromClaimType = "invited_by" }
+                ]
+            },
+            Services = new Dictionary<string, C.Service>
+            {
+                ["main"] = new() { Backend = new C.ServiceEndpoint { BaseUrl = "http://backend/" } }
+            }
+        };
+        var optionsMonitor = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        optionsMonitor.CurrentValue.Returns(config);
+
+        _handler = new CapturingHttpMessageHandler();
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        httpClientFactory.CreateClient(Arg.Any<string>()).Returns(new HttpClient(_handler));
+
+        var tokenValidator = Substitute.For<IInviteTokenValidator>();
+        tokenValidator.TryGetClaim("invite-token", "jti", out Arg.Any<string>())
+            .Returns(callInfo =>
+            {
+                callInfo[2] = "invite-jti";
+                return true;
+            });
+        tokenValidator.TryGetClaim("invite-token", "organization_id", out Arg.Any<string>())
+            .Returns(callInfo =>
+            {
+                callInfo[2] = "org-123";
+                return true;
+            });
+        tokenValidator.TryGetClaim("invite-token", "invited_by", out Arg.Any<string>())
+            .Returns(callInfo =>
+            {
+                callInfo[2] = "system-user";
+                return true;
+            });
+
+        var enrichers = new IIdentityDetailsPrincipalEnricher[]
+        {
+            new InviteTokenInvitationIdPrincipalEnricher(tokenValidator),
+            new InviteTokenClaimsPrincipalEnricher(tokenValidator, optionsMonitor)
+        };
+
+        _resolver = new IdentityDetailsResolver(
+            optionsMonitor,
+            httpClientFactory,
+            tokenValidator,
+            Substitute.For<ILogger<IdentityDetailsResolver>>(),
+            enrichers);
+
+        _context = new DefaultHttpContext();
+        _context.Request.Headers.Cookie = $"{Cookies.InviteToken}=invite-token";
+    }
+
+    Task Because() =>
+        _resolver.Resolve(
+            _context,
+            new ClientPrincipal
+            {
+                UserId = "identity-user-id",
+                Claims =
+                [
+                    new ClientPrincipalClaim { Type = "given_name", Value = "Alice" }
+                ]
+            },
+            Guid.NewGuid());
+
+    [Fact] void should_replace_user_id_with_invitation_id() => _handler.Principal?.UserId.ShouldEqual("invite-jti");
+
+    [Fact] void should_forward_mapped_invite_claim() =>
+        _handler.Principal?.Claims.Any(_ => _.Type == "organization" && _.Value == "org-123").ShouldBeTrue();
+
+    [Fact] void should_forward_invite_claim_with_original_type_when_target_is_not_set() =>
+        _handler.Principal?.Claims.Any(_ => _.Type == "invited_by" && _.Value == "system-user").ShouldBeTrue();
+
+    [Fact] void should_preserve_existing_identity_provider_claims() =>
+        _handler.Principal?.Claims.Any(_ => _.Type == "given_name" && _.Value == "Alice").ShouldBeTrue();
+
+    class CapturingHttpMessageHandler : HttpMessageHandler
+    {
+        public ClientPrincipal? Principal { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.Headers.TryGetValues(Headers.Principal, out var values))
+            {
+                ClientPrincipal.TryFromBase64(values.Single(), out var principal);
+                Principal = principal;
+            }
+
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent(/*lang=json,strict*/ "{}")
+            });
+        }
+    }
+}

--- a/Source/AuthProxy.Specs/Identity/for_IdentityServiceCollectionExtensions/when_adding_identity_resolution.cs
+++ b/Source/AuthProxy.Specs/Identity/for_IdentityServiceCollectionExtensions/when_adding_identity_resolution.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.AuthProxy.Invites;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -14,6 +15,12 @@ public class when_adding_identity_resolution : Specification
     void Establish()
     {
         var builder = WebApplication.CreateBuilder();
+        var authProxyConfig = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        authProxyConfig.CurrentValue.Returns(new C.AuthProxy());
+
+        builder.Services.AddSingleton(Substitute.For<IInviteTokenValidator>());
+        builder.Services.AddSingleton(authProxyConfig);
+
         builder.AddIdentityResolution();
         _services = builder.Services;
         _serviceProvider = builder.Services.BuildServiceProvider();
@@ -25,6 +32,11 @@ public class when_adding_identity_resolution : Specification
             _.ServiceType == typeof(IIdentityDetailsResolver)
             && _.ImplementationType == typeof(IdentityDetailsResolver)
             && _.Lifetime == ServiceLifetime.Singleton).ShouldBeTrue();
+
+    [Fact]
+    void should_register_identity_principal_enrichers() =>
+        _serviceProvider.GetRequiredService<IEnumerable<IIdentityDetailsPrincipalEnricher>>().ToList().Exists(_ =>
+            _ is InviteTokenInvitationIdPrincipalEnricher or InviteTokenClaimsPrincipalEnricher).ShouldBeTrue();
 
     [Fact] void should_register_http_client_factory() =>
         _serviceProvider.GetRequiredService<IHttpClientFactory>().ShouldNotBeNull();

--- a/Source/AuthProxy/Configuration/Invite.cs
+++ b/Source/AuthProxy/Configuration/Invite.cs
@@ -54,6 +54,13 @@ public class Invite
     public string InvitationIdQueryStringKey { get; set; } = "invitationId";
 
     /// <summary>
+    /// Gets or sets claim mappings to forward values from the invite token into
+    /// the principal sent to the identity details provider.
+    /// This allows invite claims and identity-provider claims to be combined in a configurable way.
+    /// </summary>
+    public IList<InviteClaimForwarding> ClaimsToForward { get; set; } = [];
+
+    /// <summary>
     /// Gets or sets the lobby service configuration.
     /// When set, requests from users without a resolved tenant are forwarded to this service's frontend,
     /// and users are redirected here after a successful invite exchange.

--- a/Source/AuthProxy/Configuration/InviteClaimForwarding.cs
+++ b/Source/AuthProxy/Configuration/InviteClaimForwarding.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Configuration;
+
+/// <summary>
+/// Maps one claim from the invite token to a claim in the principal
+/// sent to the identity details provider.
+/// </summary>
+public class InviteClaimForwarding
+{
+    /// <summary>
+    /// Gets or sets the claim type to read from the invite token.
+    /// </summary>
+    public string FromClaimType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the claim type to emit in the outbound principal.
+    /// When empty, <see cref="FromClaimType"/> is used.
+    /// </summary>
+    public string ToClaimType { get; set; } = string.Empty;
+}

--- a/Source/AuthProxy/Identity/IIdentityDetailsPrincipalEnricher.cs
+++ b/Source/AuthProxy/Identity/IIdentityDetailsPrincipalEnricher.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Identity;
+
+/// <summary>
+/// Enriches the principal payload used when calling the identity details provider.
+/// </summary>
+public interface IIdentityDetailsPrincipalEnricher
+{
+    /// <summary>
+    /// Enriches the current <paramref name="principal"/> for the active request context.
+    /// </summary>
+    /// <param name="context">The current HTTP context.</param>
+    /// <param name="principal">The principal to enrich.</param>
+    /// <returns>An enriched principal payload.</returns>
+    ClientPrincipal Enrich(HttpContext context, ClientPrincipal principal);
+}

--- a/Source/AuthProxy/Identity/IdentityDetailsResolver.cs
+++ b/Source/AuthProxy/Identity/IdentityDetailsResolver.cs
@@ -21,11 +21,13 @@ namespace Cratis.AuthProxy.Identity;
 /// <param name="httpClientFactory">The HTTP client factory.</param>
 /// <param name="inviteTokenValidator">The invite token validator.</param>
 /// <param name="logger">The logger.</param>
+/// <param name="principalEnrichers">Optional custom enrichers for the principal used during identity details resolution.</param>
 public class IdentityDetailsResolver(
     IOptionsMonitor<C.AuthProxy> config,
     IHttpClientFactory httpClientFactory,
     IInviteTokenValidator inviteTokenValidator,
-    ILogger<IdentityDetailsResolver> logger) : IIdentityDetailsResolver
+    ILogger<IdentityDetailsResolver> logger,
+    IEnumerable<IIdentityDetailsPrincipalEnricher>? principalEnrichers = null) : IIdentityDetailsResolver
 {
     static readonly JsonSerializerOptions _cookieSerializerOptions = new()
     {
@@ -45,7 +47,7 @@ public class IdentityDetailsResolver(
             return BuildAuthorizedResult(principal, details: null);
         }
 
-        var principalForIdentityResolution = CreatePrincipalForIdentityResolution(context, principal);
+        var principalForIdentityResolution = EnrichPrincipalForIdentityResolution(context, principal);
 
         var mergedDetails = new JsonObject();
         var services = config.CurrentValue.Services;
@@ -89,28 +91,31 @@ public class IdentityDetailsResolver(
         return identityResult;
     }
 
-    ClientPrincipal CreatePrincipalForIdentityResolution(HttpContext context, ClientPrincipal principal)
+    static ClientPrincipal EnrichPrincipalForIdentityResolution(
+        HttpContext context,
+        ClientPrincipal principal,
+        IEnumerable<IIdentityDetailsPrincipalEnricher> principalEnrichers)
     {
-        if (!context.Request.Cookies.TryGetValue(Cookies.InviteToken, out var inviteToken)
-            || string.IsNullOrWhiteSpace(inviteToken))
+        var enriched = principal;
+
+        foreach (var enricher in principalEnrichers)
         {
-            return principal;
+            enriched = enricher.Enrich(context, enriched);
         }
 
-        if (!inviteTokenValidator.TryGetClaim(inviteToken, "jti", out var invitationId)
-            || string.IsNullOrWhiteSpace(invitationId))
-        {
-            return principal;
-        }
+        return enriched;
+    }
 
-        return new ClientPrincipal
-        {
-            IdentityProvider = principal.IdentityProvider,
-            UserId = invitationId,
-            UserDetails = principal.UserDetails,
-            UserRoles = principal.UserRoles,
-            Claims = principal.Claims,
-        };
+    ClientPrincipal EnrichPrincipalForIdentityResolution(HttpContext context, ClientPrincipal principal)
+    {
+        var enrichers = principalEnrichers
+            ??
+            [
+                new InviteTokenInvitationIdPrincipalEnricher(inviteTokenValidator),
+                new InviteTokenClaimsPrincipalEnricher(inviteTokenValidator, config)
+            ];
+
+        return EnrichPrincipalForIdentityResolution(context, principal, enrichers);
     }
 
     IdentityProviderResult BuildAuthorizedResult(ClientPrincipal principal, object? details) =>

--- a/Source/AuthProxy/Identity/IdentityServiceCollectionExtensions.cs
+++ b/Source/AuthProxy/Identity/IdentityServiceCollectionExtensions.cs
@@ -16,6 +16,8 @@ public static class IdentityServiceCollectionExtensions
     public static WebApplicationBuilder AddIdentityResolution(this WebApplicationBuilder builder)
     {
         builder.Services.AddHttpClient();
+        builder.Services.AddSingleton<IIdentityDetailsPrincipalEnricher, InviteTokenInvitationIdPrincipalEnricher>();
+        builder.Services.AddSingleton<IIdentityDetailsPrincipalEnricher, InviteTokenClaimsPrincipalEnricher>();
         builder.Services.AddSingleton<IIdentityDetailsResolver, IdentityDetailsResolver>();
 
         return builder;

--- a/Source/AuthProxy/Identity/InviteTokenClaimsPrincipalEnricher.cs
+++ b/Source/AuthProxy/Identity/InviteTokenClaimsPrincipalEnricher.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Invites;
+using Microsoft.Extensions.Options;
+using C = Cratis.AuthProxy.Configuration;
+
+namespace Cratis.AuthProxy.Identity;
+
+/// <summary>
+/// Adds configured invite-token claim mappings to the outbound principal
+/// sent to the identity details provider.
+/// </summary>
+/// <param name="inviteTokenValidator">The invite token validator used to read claims from the invite token.</param>
+/// <param name="config">The auth proxy configuration monitor.</param>
+public class InviteTokenClaimsPrincipalEnricher(
+    IInviteTokenValidator inviteTokenValidator,
+    IOptionsMonitor<C.AuthProxy> config) : IIdentityDetailsPrincipalEnricher
+{
+    /// <inheritdoc/>
+    public ClientPrincipal Enrich(HttpContext context, ClientPrincipal principal)
+    {
+        if (!context.Request.Cookies.TryGetValue(Cookies.InviteToken, out var inviteToken)
+            || string.IsNullOrWhiteSpace(inviteToken))
+        {
+            return principal;
+        }
+
+        var mappings = config.CurrentValue.Invite?.ClaimsToForward ?? [];
+        if (mappings.Count == 0)
+        {
+            return principal;
+        }
+
+        var claims = principal.Claims.ToList();
+        var changed = false;
+
+        foreach (var mapping in mappings)
+        {
+            if (string.IsNullOrWhiteSpace(mapping.FromClaimType))
+            {
+                continue;
+            }
+
+            if (!inviteTokenValidator.TryGetClaim(inviteToken, mapping.FromClaimType, out var value)
+                || string.IsNullOrWhiteSpace(value))
+            {
+                continue;
+            }
+
+            var targetClaimType = string.IsNullOrWhiteSpace(mapping.ToClaimType)
+                ? mapping.FromClaimType
+                : mapping.ToClaimType;
+
+            if (claims.Exists(_ => _.Type == targetClaimType && _.Value == value))
+            {
+                continue;
+            }
+
+            claims.Add(new ClientPrincipalClaim
+            {
+                Type = targetClaimType,
+                Value = value,
+            });
+            changed = true;
+        }
+
+        if (!changed)
+        {
+            return principal;
+        }
+
+        return new ClientPrincipal
+        {
+            IdentityProvider = principal.IdentityProvider,
+            UserId = principal.UserId,
+            UserDetails = principal.UserDetails,
+            UserRoles = principal.UserRoles,
+            Claims = claims,
+        };
+    }
+}

--- a/Source/AuthProxy/Identity/InviteTokenInvitationIdPrincipalEnricher.cs
+++ b/Source/AuthProxy/Identity/InviteTokenInvitationIdPrincipalEnricher.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Invites;
+
+namespace Cratis.AuthProxy.Identity;
+
+/// <summary>
+/// Replaces the outbound principal user ID with the invite token invitation ID (<c>jti</c>)
+/// when an invite token cookie is present.
+/// </summary>
+/// <param name="inviteTokenValidator">The invite token validator used to read the invitation ID claim.</param>
+public class InviteTokenInvitationIdPrincipalEnricher(IInviteTokenValidator inviteTokenValidator) : IIdentityDetailsPrincipalEnricher
+{
+    /// <inheritdoc/>
+    public ClientPrincipal Enrich(HttpContext context, ClientPrincipal principal)
+    {
+        if (!context.Request.Cookies.TryGetValue(Cookies.InviteToken, out var inviteToken)
+            || string.IsNullOrWhiteSpace(inviteToken))
+        {
+            return principal;
+        }
+
+        if (!inviteTokenValidator.TryGetClaim(inviteToken, "jti", out var invitationId)
+            || string.IsNullOrWhiteSpace(invitationId))
+        {
+            return principal;
+        }
+
+        return new ClientPrincipal
+        {
+            IdentityProvider = principal.IdentityProvider,
+            UserId = invitationId,
+            UserDetails = principal.UserDetails,
+            UserRoles = principal.UserRoles,
+            Claims = principal.Claims,
+        };
+    }
+}


### PR DESCRIPTION
## Added
- Added configurable invite-token claim forwarding mappings in invite configuration (`ClaimsToForward`).
- Added an injectable principal enrichment pipeline for identity-details resolution.
- Added default enrichers for invite `jti` user-id override and configurable invite-claim forwarding.

## Changed
- Updated identity details resolution to enrich and merge principal claims through registered enrichers before calling `/.cratis/me`.
- Registered principal enrichers in identity service wiring.
- Added specs covering forwarding behavior and DI registration.
- Updated invite configuration documentation with examples and claim-forwarding reference.
