### PR TITLE
Support string tenant IDs and SubHost verification strategy

### DIFF
--- a/Documentation/configuration/invites.md
+++ b/Documentation/configuration/invites.md
@@ -80,7 +80,7 @@ All invite and lobby settings live under `Cratis:AuthProxy:Invite`:
 | `Issuer` | `string` | Expected `iss` claim. Leave empty to skip issuer validation. |
 | `Audience` | `string` | Expected `aud` claim. Leave empty to skip audience validation. |
 | `ExchangeUrl` | `string` | Absolute URL of the invite-exchange endpoint, e.g. `https://studio.example.com/internal/invites/exchange`. |
-| `TenantClaim` | `string` | Claim in the invite token that contains tenant ID for tenant-issued invite detection. |
+| `TenantClaim` | `string` | Claim in the invite token that contains the tenant ID string for tenant-issued invite detection. |
 | `AppendInvitationIdToQueryString` | `bool` | Appends `jti` from the invite token to the lobby redirect query string when enabled. |
 | `InvitationIdQueryStringKey` | `string` | Query string key used when appending invitation ID. |
 | `ClaimsToForward` | `InviteClaimForwarding[]` | Claim mappings forwarded from invite token into the principal sent to identity details providers. |

--- a/Documentation/configuration/tenancy.md
+++ b/Documentation/configuration/tenancy.md
@@ -1,23 +1,24 @@
 # Tenancy
 
-Ingress resolves a **tenant ID** (GUID) from every incoming request and stores it in the request
-context. Downstream services receive the resolved tenant ID via the `X-Tenant-ID` header.
+AuthProxy resolves a **tenant ID** string from each incoming request and stores it in the request context.
+Downstream services receive the resolved tenant ID via the `Tenant-ID` header.
 
 ---
 
 ## Tenant resolution strategies
 
-Resolution strategies are evaluated **in order** until one succeeds.
+Resolution strategies run **in order** until one strategy resolves a tenant.
 Configure them under `Cratis:AuthProxy:TenantResolutions`:
 
 ```json
 {
   "Cratis": {
     "AuthProxy": {
-    "TenantResolutions": [
-      { "Strategy": "Host" },
-      { "Strategy": "Claim", "Options": { "ClaimType": "tid" } }
-    ]
+      "TenantResolutions": [
+        { "Strategy": "Host" },
+        { "Strategy": "Claim", "Options": { "ClaimType": "tid" } }
+      ]
+    }
   }
 }
 ```
@@ -26,10 +27,12 @@ Configure them under `Cratis:AuthProxy:TenantResolutions`:
 
 | Strategy | Description |
 |----------|-------------|
-| `Host` | Extracts the hostname from the `Host` header and looks it up in `Cratis:AuthProxy:Tenants`. |
-| `Claim` | Reads a claim value from the authenticated user's `ClaimsPrincipal`. |
-| `Route` | Matches a regex pattern against the request path to extract a tenant identifier. |
-| `Specified` | Uses a fixed, statically configured tenant ID for all requests. |
+| `Host` | Uses the request host and matches it against configured tenant `Domains` / `SourceIdentifiers`. |
+| `Claim` | Reads a claim value from the authenticated user and matches it against configured tenant `SourceIdentifiers`. |
+| `Route` | Extracts a source identifier from the request path by regex and matches it against configured tenant `SourceIdentifiers`. |
+| `Specified` | Resolves directly to a fixed tenant ID string from configuration. |
+| `Default` | Resolves directly to a fallback tenant ID string from configuration. |
+| `SubHost` | Resolves directly from subhost convention, for example `acme.example.com` -> `acme`. |
 
 ---
 
@@ -44,8 +47,7 @@ Configure them under `Cratis:AuthProxy:TenantResolutions`:
 }
 ```
 
-If `ClaimType` is omitted, the strategy falls back to reading the `X-MS-CLIENT-PRINCIPAL` header
-(Azure App Service format).
+If `ClaimType` is omitted, AuthProxy falls back to reading `X-MS-CLIENT-PRINCIPAL`.
 
 ---
 
@@ -55,13 +57,12 @@ If `ClaimType` is omitted, the strategy falls back to reading the `X-MS-CLIENT-P
 {
   "Strategy": "Route",
   "Options": {
-    "Pattern": "^/tenant/(?<tenant>[^/]+)"
+    "Pattern": "^/tenant/(?<sourceIdentifier>[^/]+)"
   }
 }
 ```
 
-The named group `tenant` is used as the tenant identifier, which is then matched against
-`Cratis:AuthProxy:Tenants`.
+The regex must expose a named group called `sourceIdentifier`.
 
 ---
 
@@ -71,28 +72,65 @@ The named group `tenant` is used as the tenant identifier, which is then matched
 {
   "Strategy": "Specified",
   "Options": {
-    "TenantId": "00000000-0000-0000-0000-000000000001"
+    "TenantId": "acme"
   }
 }
 ```
 
 ---
 
+## Default strategy options
+
+```json
+{
+  "Strategy": "Default",
+  "Options": {
+    "TenantId": "lobby"
+  }
+}
+```
+
+---
+
+## SubHost strategy options
+
+```json
+{
+  "Strategy": "SubHost",
+  "Options": {
+    "ParentHost": "example.com",
+    "VerificationUrlTemplate": "https://platform.example.com/internal/tenants/{tenantId}"
+  }
+}
+```
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `ParentHost` | `string` | Parent host suffix used to extract the tenant ID from request host. |
+| `VerificationUrlTemplate` | `string` | Optional strategy-specific verification URL template. Overrides global `TenantVerification.UrlTemplate` for this strategy. |
+
+`SubHost` resolves directly to the subhost tenant ID and does not require a `Tenants` dictionary lookup.
+Use `VerificationUrlTemplate` to validate that the resolved tenant exists before forwarding requests.
+
+---
+
 ## Tenant registry
 
-Each strategy (except `Specified`) resolves a **source identifier** string that is matched
-against the `Cratis:AuthProxy:Tenants` dictionary to obtain the final tenant GUID.
+For `Host`, `Claim`, and `Route`, AuthProxy resolves a source identifier and then looks up the tenant ID in `Cratis:AuthProxy:Tenants`.
 
 ```json
 {
   "Cratis": {
     "AuthProxy": {
-    "Tenants": {
-      "00000000-0000-0000-0000-000000000001": {
-        "SourceIdentifiers": [ "myapp.example.com" ]
-      },
-      "00000000-0000-0000-0000-000000000002": {
-        "SourceIdentifiers": [ "otherapp.example.com" ]
+      "Tenants": {
+        "acme": {
+          "Domains": ["acme.example.com"],
+          "SourceIdentifiers": ["acme", "tenant-acme"]
+        },
+        "contoso": {
+          "Domains": ["contoso.example.com"],
+          "SourceIdentifiers": ["contoso", "tenant-contoso"]
+        }
       }
     }
   }
@@ -103,37 +141,27 @@ against the `Cratis:AuthProxy:Tenants` dictionary to obtain the final tenant GUI
 
 ## Lobby fallback
 
-When no tenant can be resolved and the [invite lobby](invites.md) is configured, the user is
-redirected to the lobby frontend instead of receiving a `401 Unauthorized` response.
-See [Invites & Lobby](invites.md) for details.
+When no tenant can be resolved and the [invite lobby](invites.md) is configured, AuthProxy redirects the user to the lobby frontend instead of returning `401 Unauthorized`.
 
-If no lobby is configured and `TenantResolutions` is non-empty, Ingress returns `401 Unauthorized`.
-When `TenantResolutions` is empty (not configured), the request proceeds without a tenant.
+If no lobby is configured and `TenantResolutions` is non-empty, AuthProxy returns `401 Unauthorized`.
+When `TenantResolutions` is empty, the request proceeds without a tenant.
 
 ---
 
 ## Tenant verification
 
-After a tenant has been resolved Ingress can verify that it actually **exists** in your platform
-before forwarding the request. This is an opt-in feature — when not configured all resolved
-tenants are accepted without a remote check.
+After tenant resolution, AuthProxy can verify that the tenant exists before forwarding the request.
+This is optional.
 
-### How it works
-
-Ingress issues an HTTP GET to a configurable URL. The remote service must return:
-
-- **200** – tenant exists, request proceeds.
-- **404** – tenant does not exist; Ingress serves `tenant-not-found.html` with HTTP 404.
-- Any other status or network error – Ingress treats the tenant as not found and serves the same page.
-
-### Configuration
+### Global verification configuration
 
 ```json
 {
   "Cratis": {
     "AuthProxy": {
-    "TenantVerification": {
-      "UrlTemplate": "https://platform.example.com/api/tenants/{tenantId}"
+      "TenantVerification": {
+        "UrlTemplate": "https://platform.example.com/api/tenants/{tenantId}"
+      }
     }
   }
 }
@@ -141,11 +169,17 @@ Ingress issues an HTTP GET to a configurable URL. The remote service must return
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `UrlTemplate` | `string` | URL to call for verification. Use `{tenantId}` as a placeholder for the resolved tenant GUID. |
+| `UrlTemplate` | `string` | URL template for tenant verification. Use `{tenantId}` placeholder. |
 
-The `{tenantId}` placeholder is replaced at runtime with the resolved tenant ID.
+### Response handling
+
+- `200`: tenant exists, request proceeds.
+- `404`: tenant does not exist; AuthProxy serves `tenant-not-found.html` with `404`.
+- Any other status or network error: treated as tenant verification failure, and `tenant-not-found.html` is served.
+
+If a strategy provides a strategy-specific verification URL template (for example `SubHost.Options.VerificationUrlTemplate`), that template is used instead of the global `TenantVerification.UrlTemplate`.
 
 ### Tenant not found page
 
-When verification fails, the `tenant-not-found.html` page is served.
-See [Error pages](error-pages.md) for how to override this page with your own custom version.
+When verification fails, AuthProxy serves `tenant-not-found.html`.
+See [Error pages](error-pages.md) to override this page.

--- a/Documentation/index.md
+++ b/Documentation/index.md
@@ -5,7 +5,7 @@ Welcome to the Cratis Ingress documentation.
 Ingress is a lightweight ASP.NET Core gateway service that sits in front of your microservices and handles:
 
 - **Authentication** – OpenID Connect (single or multi-provider) and JWT Bearer support.
-- **Tenancy** – flexible per-request tenant resolution from host, claim, route, or a fixed value; optional remote tenant verification.
+- **Tenancy** – flexible per-request tenant resolution from host, subhost, claim, route, or a fixed value; optional remote tenant verification.
 - **Identity enrichment** – calls a `/.cratis/me` endpoint on your microservices to enrich the identity cookie with application-specific details.
 - **Invite / Lobby flow** – invite-based onboarding using signed JWT tokens, with an optional lobby microservice for users who have not yet been assigned a tenant.
 - **Custom error pages** – user-friendly HTML pages for error conditions (404, 403, tenant not found, invitation expired/invalid), overridable by mounting a custom pages directory.

--- a/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_identity_cookie_is_already_present.cs
+++ b/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_identity_cookie_is_already_present.cs
@@ -34,7 +34,7 @@ public class when_identity_cookie_is_already_present : Specification
         _context.Request.Headers.Cookie = $"{Cookies.Identity}=existing-value";
     }
 
-    async Task Because() => _result = await _resolver.Resolve(_context, new ClientPrincipal { UserId = "user-1" }, Guid.NewGuid());
+    async Task Because() => _result = await _resolver.Resolve(_context, new ClientPrincipal { UserId = "user-1" }, Guid.NewGuid().ToString());
 
     [Fact] void should_be_authorized() => Assert.True(_result.IsAuthorized);
     [Fact] void should_not_call_the_http_client() => _httpClientFactory.DidNotReceive().CreateClient(Arg.Any<string>());

--- a/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_identity_cookie_is_present_and_invite_cookie_exists.cs
+++ b/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_identity_cookie_is_present_and_invite_cookie_exists.cs
@@ -44,7 +44,7 @@ public class when_identity_cookie_is_present_and_invite_cookie_exists : Specific
         _context.Request.Headers.Cookie = $"{Cookies.Identity}=existing-value; {Cookies.InviteToken}=invite-token";
     }
 
-    async Task Because() => _result = await _resolver.Resolve(_context, new ClientPrincipal { UserId = "user-1" }, Guid.NewGuid());
+    async Task Because() => _result = await _resolver.Resolve(_context, new ClientPrincipal { UserId = "user-1" }, Guid.NewGuid().ToString());
 
     [Fact] void should_be_authorized() => _result.IsAuthorized.ShouldBeTrue();
     [Fact] void should_call_the_http_client_to_refresh_details() => _httpClientFactory.Received(1).CreateClient(Arg.Any<string>());

--- a/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_invite_claim_forwarding_is_configured.cs
+++ b/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_invite_claim_forwarding_is_configured.cs
@@ -82,7 +82,7 @@ public class when_invite_claim_forwarding_is_configured : Specification
                     new ClientPrincipalClaim { Type = "given_name", Value = "Alice" }
                 ]
             },
-            Guid.NewGuid());
+            Guid.NewGuid().ToString());
 
     [Fact] void should_preserve_user_id() => _handler.Principal?.UserId.ShouldEqual("identity-user-id");
 

--- a/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_microservice_returns_forbidden.cs
+++ b/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_microservice_returns_forbidden.cs
@@ -34,7 +34,7 @@ public class when_microservice_returns_forbidden : Specification
         _context = new DefaultHttpContext();
     }
 
-    async Task Because() => _result = await _resolver.Resolve(_context, new ClientPrincipal { UserId = "user-1" }, Guid.NewGuid());
+    async Task Because() => _result = await _resolver.Resolve(_context, new ClientPrincipal { UserId = "user-1" }, Guid.NewGuid().ToString());
 
     [Fact] void should_not_be_authorized() => Assert.False(_result.IsAuthorized);
     [Fact] void should_set_403_on_response() => Assert.Equal(StatusCodes.Status403Forbidden, _context.Response.StatusCode);

--- a/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_microservice_returns_identity_details.cs
+++ b/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_microservice_returns_identity_details.cs
@@ -34,7 +34,7 @@ public class when_microservice_returns_identity_details : Specification
         _context = new DefaultHttpContext();
     }
 
-    async Task Because() => _result = await _resolver.Resolve(_context, new ClientPrincipal { UserId = "user-1" }, Guid.NewGuid());
+    async Task Because() => _result = await _resolver.Resolve(_context, new ClientPrincipal { UserId = "user-1" }, Guid.NewGuid().ToString());
 
     [Fact] void should_be_authorized() => Assert.True(_result.IsAuthorized);
     [Fact] void should_write_identity_cookie_to_response() => Assert.NotEmpty(_context.Response.Headers.SetCookie.ToString());

--- a/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_microservice_returns_invalid_json.cs
+++ b/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_microservice_returns_invalid_json.cs
@@ -34,7 +34,7 @@ public class when_microservice_returns_invalid_json : Specification
         _context = new DefaultHttpContext();
     }
 
-    async Task Because() => _result = await _resolver.Resolve(_context, new ClientPrincipal { UserId = "user-1" }, Guid.NewGuid());
+    async Task Because() => _result = await _resolver.Resolve(_context, new ClientPrincipal { UserId = "user-1" }, Guid.NewGuid().ToString());
 
     [Fact] void should_still_be_authorized() => _result.IsAuthorized.ShouldBeTrue();
     [Fact] void should_write_identity_cookie_to_response() => _context.Response.Headers.SetCookie.ToString().ShouldContain(Cookies.Identity);

--- a/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_microservice_returns_non_success_status_code.cs
+++ b/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_microservice_returns_non_success_status_code.cs
@@ -34,7 +34,7 @@ public class when_microservice_returns_non_success_status_code : Specification
         _context = new DefaultHttpContext();
     }
 
-    async Task Because() => _result = await _resolver.Resolve(_context, new ClientPrincipal { UserId = "user-1" }, Guid.NewGuid());
+    async Task Because() => _result = await _resolver.Resolve(_context, new ClientPrincipal { UserId = "user-1" }, Guid.NewGuid().ToString());
 
     [Fact] void should_still_be_authorized() => _result.IsAuthorized.ShouldBeTrue();
     [Fact] void should_write_identity_cookie_to_response() => _context.Response.Headers.SetCookie.ToString().ShouldContain(Cookies.Identity);

--- a/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_multiple_microservices_return_details.cs
+++ b/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_multiple_microservices_return_details.cs
@@ -35,7 +35,7 @@ public class when_multiple_microservices_return_details : Specification
         _context = new DefaultHttpContext();
     }
 
-    async Task Because() => _result = await _resolver.Resolve(_context, new ClientPrincipal { UserId = "user-1" }, Guid.NewGuid());
+    async Task Because() => _result = await _resolver.Resolve(_context, new ClientPrincipal { UserId = "user-1" }, Guid.NewGuid().ToString());
 
     [Fact] void should_be_authorized() => Assert.True(_result.IsAuthorized);
     [Fact] void should_write_the_merged_identity_cookie() => Assert.NotEmpty(_context.Response.Headers.SetCookie.ToString());

--- a/Source/AuthProxy.Specs/Identity/for_InjectIdentityHeadersTransform/when_user_is_authenticated_and_tenant_is_resolved.cs
+++ b/Source/AuthProxy.Specs/Identity/for_InjectIdentityHeadersTransform/when_user_is_authenticated_and_tenant_is_resolved.cs
@@ -7,7 +7,7 @@ namespace Cratis.AuthProxy.Identity.for_InjectIdentityHeadersTransform;
 
 public class when_user_is_authenticated_and_tenant_is_resolved : Specification
 {
-    static readonly Guid _tenantId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    const string TenantId = "22222222-2222-2222-2222-222222222222";
 
     InjectIdentityHeadersTransform _transform;
     RequestTransformContext _transformContext;
@@ -24,7 +24,7 @@ public class when_user_is_authenticated_and_tenant_is_resolved : Specification
         ],
         "aad");
         httpContext.User = new ClaimsPrincipal(identity);
-        httpContext.Items[TenancyMiddleware.TenantIdItemKey] = _tenantId;
+        httpContext.Items[TenancyMiddleware.TenantIdItemKey] = TenantId;
 
         _transformContext = new RequestTransformContext
         {
@@ -45,5 +45,5 @@ public class when_user_is_authenticated_and_tenant_is_resolved : Specification
         _transformContext.ProxyRequest.Headers.GetValues(Headers.PrincipalName).Single().ShouldEqual("user@example.com");
 
     [Fact] void should_set_tenant_id_header() =>
-        _transformContext.ProxyRequest.Headers.GetValues(Headers.TenantId).Single().ShouldEqual(_tenantId.ToString());
+        _transformContext.ProxyRequest.Headers.GetValues(Headers.TenantId).Single().ShouldEqual(TenantId);
 }

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_tenant_invite_and_tenant_does_not_match.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_tenant_invite_and_tenant_does_not_match.cs
@@ -9,8 +9,8 @@ public class when_authenticated_user_has_pending_tenant_invite_and_tenant_does_n
 {
     const string LobbyUrl = "http://lobby-service/";
     const string TenantClaimType = "tenant_id";
-    static readonly Guid _tokenTenantId = Guid.NewGuid();
-    static readonly Guid _resolvedTenantId = Guid.NewGuid();
+    const string TokenTenantId = "tenant-a";
+    const string ResolvedTenantId = "tenant-b";
 
     InviteMiddleware _middleware;
     DefaultHttpContext _context;
@@ -22,7 +22,7 @@ public class when_authenticated_user_has_pending_tenant_invite_and_tenant_does_n
         tokenValidator.TryGetClaim(Arg.Any<string>(), TenantClaimType, out Arg.Any<string>())
             .Returns(x =>
             {
-                x[2] = _tokenTenantId.ToString();
+                x[2] = TokenTenantId;
                 return true;
             });
 
@@ -66,7 +66,7 @@ public class when_authenticated_user_has_pending_tenant_invite_and_tenant_does_n
         _context.User = new ClaimsPrincipal(identity);
 
         _context.Request.Headers.Cookie = $"{Cookies.InviteToken}=pending-invite-token";
-        _context.Items[TenancyMiddleware.TenantIdItemKey] = _resolvedTenantId;
+        _context.Items[TenancyMiddleware.TenantIdItemKey] = ResolvedTenantId;
     }
 
     async Task Because() => await _middleware.InvokeAsync(_context);

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_tenant_invite_and_tenant_matches.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_tenant_invite_and_tenant_matches.cs
@@ -9,7 +9,7 @@ public class when_authenticated_user_has_pending_tenant_invite_and_tenant_matche
 {
     const string LobbyUrl = "http://lobby-service/";
     const string TenantClaimType = "tenant_id";
-    static readonly Guid _tenantId = Guid.NewGuid();
+    const string TenantId = "tenant-matched";
 
     InviteMiddleware _middleware;
     DefaultHttpContext _context;
@@ -21,7 +21,7 @@ public class when_authenticated_user_has_pending_tenant_invite_and_tenant_matche
         tokenValidator.TryGetClaim(Arg.Any<string>(), TenantClaimType, out Arg.Any<string>())
             .Returns(x =>
             {
-                x[2] = _tenantId.ToString();
+                x[2] = TenantId;
                 return true;
             });
 
@@ -65,7 +65,7 @@ public class when_authenticated_user_has_pending_tenant_invite_and_tenant_matche
         _context.User = new ClaimsPrincipal(identity);
 
         _context.Request.Headers.Cookie = $"{Cookies.InviteToken}=pending-invite-token";
-        _context.Items[TenancyMiddleware.TenantIdItemKey] = _tenantId;
+        _context.Items[TenancyMiddleware.TenantIdItemKey] = TenantId;
     }
 
     async Task Because() => await _middleware.InvokeAsync(_context);

--- a/Source/AuthProxy.Specs/Tenancy/for_SubHostSourceIdentifierStrategy/when_parent_host_is_not_configured.cs
+++ b/Source/AuthProxy.Specs/Tenancy/for_SubHostSourceIdentifierStrategy/when_parent_host_is_not_configured.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Tenancy.for_SubHostSourceIdentifierStrategy;
+
+public class when_parent_host_is_not_configured : Specification
+{
+    SubHostSourceIdentifierStrategy _strategy;
+    DefaultHttpContext _context;
+    SubHostOptions _options;
+    bool _succeeded;
+    string _sourceIdentifier;
+
+    void Establish()
+    {
+        _strategy = new SubHostSourceIdentifierStrategy();
+        _context = new DefaultHttpContext();
+        _context.Request.Host = new HostString("acme.example.com");
+        _options = new SubHostOptions { ParentHost = "" };
+    }
+
+    void Because() => _succeeded = _strategy.TryResolveSourceIdentifier(_context, _options, out _sourceIdentifier);
+
+    [Fact] void should_fail() => _succeeded.ShouldBeFalse();
+    [Fact] void should_return_empty_source_identifier() => _sourceIdentifier.ShouldEqual(string.Empty);
+}

--- a/Source/AuthProxy.Specs/Tenancy/for_SubHostSourceIdentifierStrategy/when_subhost_matches_parent_host.cs
+++ b/Source/AuthProxy.Specs/Tenancy/for_SubHostSourceIdentifierStrategy/when_subhost_matches_parent_host.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Tenancy.for_SubHostSourceIdentifierStrategy;
+
+public class when_subhost_matches_parent_host : Specification
+{
+    SubHostSourceIdentifierStrategy _strategy;
+    DefaultHttpContext _context;
+    SubHostOptions _options;
+    bool _succeeded;
+    string _sourceIdentifier;
+
+    void Establish()
+    {
+        _strategy = new SubHostSourceIdentifierStrategy();
+        _context = new DefaultHttpContext();
+        _context.Request.Host = new HostString("acme.example.com");
+        _options = new SubHostOptions { ParentHost = "example.com" };
+    }
+
+    void Because() => _succeeded = _strategy.TryResolveSourceIdentifier(_context, _options, out _sourceIdentifier);
+
+    [Fact] void should_succeed() => _succeeded.ShouldBeTrue();
+    [Fact] void should_resolve_the_subhost_as_tenant_id() => _sourceIdentifier.ShouldEqual("acme");
+}

--- a/Source/AuthProxy.Specs/Tenancy/for_TenantVerifier/when_verification_call_throws.cs
+++ b/Source/AuthProxy.Specs/Tenancy/for_TenantVerifier/when_verification_call_throws.cs
@@ -31,7 +31,7 @@ public class when_verification_call_throws : Specification
             Substitute.For<ILogger<TenantVerifier>>());
     }
 
-    async Task Because() => _result = await _verifier.VerifyAsync(Guid.NewGuid());
+    async Task Because() => _result = await _verifier.VerifyAsync(Guid.NewGuid().ToString());
 
     [Fact] void should_not_be_verified() => _result.ShouldBeFalse();
 

--- a/Source/AuthProxy.Specs/Tenancy/for_TenantVerifier/when_verification_endpoint_returns_not_found.cs
+++ b/Source/AuthProxy.Specs/Tenancy/for_TenantVerifier/when_verification_endpoint_returns_not_found.cs
@@ -33,7 +33,7 @@ public class when_verification_endpoint_returns_not_found : Specification
             Substitute.For<ILogger<TenantVerifier>>());
     }
 
-    async Task Because() => _result = await _verifier.VerifyAsync(Guid.NewGuid());
+    async Task Because() => _result = await _verifier.VerifyAsync(Guid.NewGuid().ToString());
 
     [Fact] void should_not_be_verified() => _result.ShouldBeFalse();
 }

--- a/Source/AuthProxy.Specs/Tenancy/for_TenantVerifier/when_verification_endpoint_returns_success.cs
+++ b/Source/AuthProxy.Specs/Tenancy/for_TenantVerifier/when_verification_endpoint_returns_success.cs
@@ -7,7 +7,7 @@ namespace Cratis.AuthProxy.Tenancy.for_TenantVerifier;
 
 public class when_verification_endpoint_returns_success : Specification
 {
-    static readonly Guid _tenantId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    const string TenantId = "11111111-1111-1111-1111-111111111111";
 
     TenantVerifier _verifier;
     bool _result;
@@ -35,10 +35,10 @@ public class when_verification_endpoint_returns_success : Specification
             Substitute.For<ILogger<TenantVerifier>>());
     }
 
-    async Task Because() => _result = await _verifier.VerifyAsync(_tenantId);
+    async Task Because() => _result = await _verifier.VerifyAsync(TenantId);
 
     [Fact] void should_be_verified() => _result.ShouldBeTrue();
-    [Fact] void should_replace_tenant_id_in_url() => _calledUrl.ShouldContain(_tenantId.ToString());
+    [Fact] void should_replace_tenant_id_in_url() => _calledUrl.ShouldContain(TenantId);
 
     class RecordingHttpMessageHandler(Action<string> onRequest, HttpStatusCode statusCode) : HttpMessageHandler
     {

--- a/Source/AuthProxy.Specs/Tenancy/for_TenantVerifier/when_verification_url_is_not_configured.cs
+++ b/Source/AuthProxy.Specs/Tenancy/for_TenantVerifier/when_verification_url_is_not_configured.cs
@@ -23,7 +23,7 @@ public class when_verification_url_is_not_configured : Specification
             Substitute.For<ILogger<TenantVerifier>>());
     }
 
-    async Task Because() => _result = await _verifier.VerifyAsync(Guid.NewGuid());
+    async Task Because() => _result = await _verifier.VerifyAsync(Guid.NewGuid().ToString());
 
     [Fact] void should_be_verified() => _result.ShouldBeTrue();
     [Fact] void should_not_call_http_client() => _httpClientFactory.DidNotReceive().CreateClient(Arg.Any<string>());

--- a/Source/AuthProxy.Specs/for_TenancyMiddleware/when_everything_succeeds.cs
+++ b/Source/AuthProxy.Specs/for_TenancyMiddleware/when_everything_succeeds.cs
@@ -7,7 +7,7 @@ namespace Cratis.AuthProxy.for_TenancyMiddleware;
 
 public class when_everything_succeeds : Specification
 {
-    static readonly Guid _tenantId = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
+    const string TenantId = "dddddddd-dddd-dddd-dddd-dddddddddddd";
 
     TenancyMiddleware _middleware;
     DefaultHttpContext _context;
@@ -21,20 +21,20 @@ public class when_everything_succeeds : Specification
 
         var tenantResolver = Substitute.For<ITenantResolver>();
         tenantResolver
-            .TryResolve(Arg.Any<HttpContext>(), out Arg.Any<Guid>())
+            .TryResolve(Arg.Any<HttpContext>(), out Arg.Any<string>())
             .Returns(call =>
             {
-                call[1] = _tenantId;
+                call[1] = TenantId;
                 return true;
             });
 
         var identityResolver = Substitute.For<IIdentityDetailsResolver>();
         identityResolver
-            .Resolve(Arg.Any<HttpContext>(), Arg.Any<Identity.ClientPrincipal>(), Arg.Any<Guid>())
+            .Resolve(Arg.Any<HttpContext>(), Arg.Any<Identity.ClientPrincipal>(), Arg.Any<string>())
             .Returns(Task.FromResult(new IdentityProviderResult("user-id", "user-name", true, true, [], null!)));
 
         var tenantVerifier = Substitute.For<ITenantVerifier>();
-        tenantVerifier.VerifyAsync(Arg.Any<Guid>()).Returns(Task.FromResult(true));
+        tenantVerifier.VerifyAsync(Arg.Any<string>()).Returns(Task.FromResult(true));
 
         _middleware = new TenancyMiddleware(
             _ =>
@@ -57,5 +57,5 @@ public class when_everything_succeeds : Specification
     async Task Because() => await _middleware.InvokeAsync(_context);
 
     [Fact] void should_call_next() => Assert.True(_nextCalled);
-    [Fact] void should_store_tenant_id_in_context_items() => Assert.Equal(_tenantId, _context.Items[TenancyMiddleware.TenantIdItemKey]);
+    [Fact] void should_store_tenant_id_in_context_items() => Assert.Equal(TenantId, _context.Items[TenancyMiddleware.TenantIdItemKey]);
 }

--- a/Source/AuthProxy.Specs/for_TenancyMiddleware/when_identity_resolver_denies_access.cs
+++ b/Source/AuthProxy.Specs/for_TenancyMiddleware/when_identity_resolver_denies_access.cs
@@ -13,7 +13,7 @@ public class when_identity_resolver_denies_access : Specification
 
     void Establish()
     {
-        var tenantId = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+        const string tenantId = "cccccccc-cccc-cccc-cccc-cccccccccccc";
 
         var config = new C.AuthProxy();
         var optionsMonitor = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
@@ -21,7 +21,7 @@ public class when_identity_resolver_denies_access : Specification
 
         var tenantResolver = Substitute.For<ITenantResolver>();
         tenantResolver
-            .TryResolve(Arg.Any<HttpContext>(), out Arg.Any<Guid>())
+            .TryResolve(Arg.Any<HttpContext>(), out Arg.Any<string>())
             .Returns(call =>
             {
                 call[1] = tenantId;
@@ -30,11 +30,11 @@ public class when_identity_resolver_denies_access : Specification
 
         var identityResolver = Substitute.For<IIdentityDetailsResolver>();
         identityResolver
-            .Resolve(Arg.Any<HttpContext>(), Arg.Any<Identity.ClientPrincipal>(), Arg.Any<Guid>())
+            .Resolve(Arg.Any<HttpContext>(), Arg.Any<Identity.ClientPrincipal>(), Arg.Any<string>())
             .Returns(Task.FromResult(IdentityProviderResult.Unauthorized));
 
         var tenantVerifier = Substitute.For<ITenantVerifier>();
-        tenantVerifier.VerifyAsync(Arg.Any<Guid>()).Returns(Task.FromResult(true));
+        tenantVerifier.VerifyAsync(Arg.Any<string>()).Returns(Task.FromResult(true));
 
         _middleware = new TenancyMiddleware(
             _ =>

--- a/Source/AuthProxy.Specs/for_TenancyMiddleware/when_request_has_spoofed_identity_headers.cs
+++ b/Source/AuthProxy.Specs/for_TenancyMiddleware/when_request_has_spoofed_identity_headers.cs
@@ -17,10 +17,10 @@ public class when_request_has_spoofed_identity_headers : Specification
         optionsMonitor.CurrentValue.Returns(config);
 
         var tenantResolver = Substitute.For<ITenantResolver>();
-        tenantResolver.TryResolve(Arg.Any<HttpContext>(), out Arg.Any<Guid>()).Returns(true);
+        tenantResolver.TryResolve(Arg.Any<HttpContext>(), out Arg.Any<string>()).Returns(true);
 
         var identityResolver = Substitute.For<IIdentityDetailsResolver>();
-        identityResolver.Resolve(Arg.Any<HttpContext>(), Arg.Any<Identity.ClientPrincipal>(), Arg.Any<Guid>()).Returns(Task.FromResult(new IdentityProviderResult("user-id", "user-name", true, true, [], null!)));
+        identityResolver.Resolve(Arg.Any<HttpContext>(), Arg.Any<Identity.ClientPrincipal>(), Arg.Any<string>()).Returns(Task.FromResult(new IdentityProviderResult("user-id", "user-name", true, true, [], null!)));
 
         _middleware = new TenancyMiddleware(
             _ => Task.CompletedTask,

--- a/Source/AuthProxy.Specs/for_TenancyMiddleware/when_strategy_sets_verification_url_template_override.cs
+++ b/Source/AuthProxy.Specs/for_TenancyMiddleware/when_strategy_sets_verification_url_template_override.cs
@@ -3,14 +3,11 @@
 
 namespace Cratis.AuthProxy.for_TenancyMiddleware;
 
-public class when_tenant_does_not_exist : Specification
+public class when_strategy_sets_verification_url_template_override : Specification
 {
-    const string TenantId = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee";
-
     TenancyMiddleware _middleware;
     DefaultHttpContext _context;
-    IErrorPageProvider _errorPageProvider;
-    bool _nextCalled;
+    ITenantVerifier _tenantVerifier;
 
     void Establish()
     {
@@ -23,38 +20,30 @@ public class when_tenant_does_not_exist : Specification
             .TryResolve(Arg.Any<HttpContext>(), out Arg.Any<string>())
             .Returns(call =>
             {
-                call[1] = TenantId;
+                var context = (HttpContext)call[0];
+                context.Items[TenancyMiddleware.TenantVerificationUrlTemplateItemKey] = "https://tenant-registry.local/{tenantId}";
+                call[1] = "acme";
                 return true;
             });
 
-        var tenantVerifier = Substitute.For<ITenantVerifier>();
-        tenantVerifier.VerifyAsync(TenantId).Returns(Task.FromResult(false));
-
-        _errorPageProvider = Substitute.For<IErrorPageProvider>();
+        _tenantVerifier = Substitute.For<ITenantVerifier>();
+        _tenantVerifier.VerifyAsync(Arg.Any<string>(), Arg.Any<string?>()).Returns(Task.FromResult(true));
 
         _middleware = new TenancyMiddleware(
-            _ =>
-            {
-                _nextCalled = true;
-                return Task.CompletedTask;
-            },
+            _ => Task.CompletedTask,
             optionsMonitor,
             tenantResolver,
-            tenantVerifier,
+            _tenantVerifier,
             Substitute.For<IIdentityDetailsResolver>(),
-            _errorPageProvider,
+            Substitute.For<IErrorPageProvider>(),
             Substitute.For<ILogger<TenancyMiddleware>>());
 
         _context = new DefaultHttpContext();
     }
 
-    async Task Because() => await _middleware.InvokeAsync(_context);
+    Task Because() => _middleware.InvokeAsync(_context);
 
-    [Fact] void should_not_call_next() => _nextCalled.ShouldBeFalse();
     [Fact]
-    void should_serve_tenant_not_found_page() =>
-        _errorPageProvider.Received(1).WriteErrorPageAsync(
-            _context,
-            WellKnownPageNames.TenantNotFound,
-            StatusCodes.Status404NotFound);
+    void should_forward_strategy_override_to_verifier() =>
+        _tenantVerifier.Received(1).VerifyAsync("acme", "https://tenant-registry.local/{tenantId}");
 }

--- a/Source/AuthProxy.Specs/for_TenancyMiddleware/when_tenant_resolution_fails_and_auth_path_is_requested_with_lobby_and_resolutions_configured.cs
+++ b/Source/AuthProxy.Specs/for_TenancyMiddleware/when_tenant_resolution_fails_and_auth_path_is_requested_with_lobby_and_resolutions_configured.cs
@@ -31,7 +31,7 @@ public class when_tenant_resolution_fails_and_auth_path_is_requested_with_lobby_
         optionsMonitor.CurrentValue.Returns(config);
 
         var tenantResolver = Substitute.For<ITenantResolver>();
-        tenantResolver.TryResolve(Arg.Any<HttpContext>(), out Arg.Any<Guid>()).Returns(false);
+        tenantResolver.TryResolve(Arg.Any<HttpContext>(), out Arg.Any<string>()).Returns(false);
 
         _middleware = new TenancyMiddleware(
             _ =>

--- a/Source/AuthProxy.Specs/for_TenancyMiddleware/when_tenant_resolution_fails_and_invite_cookie_is_present_with_lobby_configured.cs
+++ b/Source/AuthProxy.Specs/for_TenancyMiddleware/when_tenant_resolution_fails_and_invite_cookie_is_present_with_lobby_configured.cs
@@ -27,7 +27,7 @@ public class when_tenant_resolution_fails_and_invite_cookie_is_present_with_lobb
         optionsMonitor.CurrentValue.Returns(config);
 
         var tenantResolver = Substitute.For<ITenantResolver>();
-        tenantResolver.TryResolve(Arg.Any<HttpContext>(), out Arg.Any<Guid>()).Returns(false);
+        tenantResolver.TryResolve(Arg.Any<HttpContext>(), out Arg.Any<string>()).Returns(false);
 
         _middleware = new TenancyMiddleware(
             _ =>

--- a/Source/AuthProxy.Specs/for_TenancyMiddleware/when_tenant_resolution_fails_and_invite_path_is_requested_with_lobby_configured.cs
+++ b/Source/AuthProxy.Specs/for_TenancyMiddleware/when_tenant_resolution_fails_and_invite_path_is_requested_with_lobby_configured.cs
@@ -27,7 +27,7 @@ public class when_tenant_resolution_fails_and_invite_path_is_requested_with_lobb
         optionsMonitor.CurrentValue.Returns(config);
 
         var tenantResolver = Substitute.For<ITenantResolver>();
-        tenantResolver.TryResolve(Arg.Any<HttpContext>(), out Arg.Any<Guid>()).Returns(false);
+        tenantResolver.TryResolve(Arg.Any<HttpContext>(), out Arg.Any<string>()).Returns(false);
 
         _middleware = new TenancyMiddleware(
             _ =>

--- a/Source/AuthProxy.Specs/for_TenancyMiddleware/when_tenant_resolution_fails_and_lobby_is_configured.cs
+++ b/Source/AuthProxy.Specs/for_TenancyMiddleware/when_tenant_resolution_fails_and_lobby_is_configured.cs
@@ -31,7 +31,7 @@ public class when_tenant_resolution_fails_and_lobby_is_configured : Specificatio
         optionsMonitor.CurrentValue.Returns(config);
 
         var tenantResolver = Substitute.For<ITenantResolver>();
-        tenantResolver.TryResolve(Arg.Any<HttpContext>(), out Arg.Any<Guid>()).Returns(false);
+        tenantResolver.TryResolve(Arg.Any<HttpContext>(), out Arg.Any<string>()).Returns(false);
 
         _middleware = new TenancyMiddleware(
             _ =>

--- a/Source/AuthProxy.Specs/for_TenancyMiddleware/when_tenant_resolution_fails_and_resolutions_are_configured.cs
+++ b/Source/AuthProxy.Specs/for_TenancyMiddleware/when_tenant_resolution_fails_and_resolutions_are_configured.cs
@@ -22,7 +22,7 @@ public class when_tenant_resolution_fails_and_resolutions_are_configured : Speci
         optionsMonitor.CurrentValue.Returns(config);
 
         var tenantResolver = Substitute.For<ITenantResolver>();
-        tenantResolver.TryResolve(Arg.Any<HttpContext>(), out Arg.Any<Guid>()).Returns(false);
+        tenantResolver.TryResolve(Arg.Any<HttpContext>(), out Arg.Any<string>()).Returns(false);
 
         _middleware = new TenancyMiddleware(
             _ =>

--- a/Source/AuthProxy.Specs/for_TenantResolver/when_claim_strategy_resolves_from_claim_and_tenant_is_matched.cs
+++ b/Source/AuthProxy.Specs/for_TenantResolver/when_claim_strategy_resolves_from_claim_and_tenant_is_matched.cs
@@ -5,12 +5,12 @@ namespace Cratis.AuthProxy.for_TenantResolver;
 
 public class when_claim_strategy_resolves_from_claim_and_tenant_is_matched : Specification
 {
-    static readonly Guid _expectedTenantId = Guid.Parse("55555555-5555-5555-5555-555555555555");
+    const string ExpectedTenantId = "55555555-5555-5555-5555-555555555555";
 
     TenantResolver _resolver;
     DefaultHttpContext _context;
     bool _succeeded;
-    Guid _tenantId;
+    string _tenantId = string.Empty;
 
     void Establish()
     {
@@ -18,7 +18,7 @@ public class when_claim_strategy_resolves_from_claim_and_tenant_is_matched : Spe
         {
             Tenants = new C.Tenants
             {
-                [_expectedTenantId] = new C.Tenant { Name = "Acme", SourceIdentifiers = ["tenant-from-claim"] }
+                [ExpectedTenantId] = new C.Tenant { Name = "Acme", SourceIdentifiers = ["tenant-from-claim"] }
             },
             TenantResolutions =
             [
@@ -49,5 +49,5 @@ public class when_claim_strategy_resolves_from_claim_and_tenant_is_matched : Spe
     void Because() => _succeeded = _resolver.TryResolve(_context, out _tenantId);
 
     [Fact] void should_succeed() => _succeeded.ShouldBeTrue();
-    [Fact] void should_return_the_matched_tenant_id() => _tenantId.ShouldEqual(_expectedTenantId);
+    [Fact] void should_return_the_matched_tenant_id() => _tenantId.ShouldEqual(ExpectedTenantId);
 }

--- a/Source/AuthProxy.Specs/for_TenantResolver/when_no_resolutions_are_configured.cs
+++ b/Source/AuthProxy.Specs/for_TenantResolver/when_no_resolutions_are_configured.cs
@@ -8,7 +8,7 @@ public class when_no_resolutions_are_configured : Specification
     TenantResolver _resolver;
     DefaultHttpContext _context;
     bool _succeeded;
-    Guid _tenantId;
+    string _tenantId = string.Empty;
 
     void Establish()
     {
@@ -23,5 +23,5 @@ public class when_no_resolutions_are_configured : Specification
     void Because() => _succeeded = _resolver.TryResolve(_context, out _tenantId);
 
     [Fact] void should_succeed() => Assert.True(_succeeded);
-    [Fact] void should_return_empty_tenant_id() => Assert.Equal(Guid.Empty, _tenantId);
+    [Fact] void should_return_empty_tenant_id() => Assert.Equal(string.Empty, _tenantId);
 }

--- a/Source/AuthProxy.Specs/for_TenantResolver/when_route_strategy_resolves_and_tenant_source_identifier_is_matched.cs
+++ b/Source/AuthProxy.Specs/for_TenantResolver/when_route_strategy_resolves_and_tenant_source_identifier_is_matched.cs
@@ -5,12 +5,12 @@ namespace Cratis.AuthProxy.for_TenantResolver;
 
 public class when_route_strategy_resolves_and_tenant_source_identifier_is_matched : Specification
 {
-    static readonly Guid _expectedTenantId = Guid.Parse("44444444-4444-4444-4444-444444444444");
+    const string ExpectedTenantId = "44444444-4444-4444-4444-444444444444";
 
     TenantResolver _resolver;
     DefaultHttpContext _context;
     bool _succeeded;
-    Guid _tenantId;
+    string _tenantId = string.Empty;
 
     void Establish()
     {
@@ -18,7 +18,7 @@ public class when_route_strategy_resolves_and_tenant_source_identifier_is_matche
         {
             Tenants = new C.Tenants
             {
-                [_expectedTenantId] = new C.Tenant { Name = "Acme", SourceIdentifiers = ["tenant-abc"] }
+                [ExpectedTenantId] = new C.Tenant { Name = "Acme", SourceIdentifiers = ["tenant-abc"] }
             },
             TenantResolutions =
             [
@@ -42,5 +42,5 @@ public class when_route_strategy_resolves_and_tenant_source_identifier_is_matche
     void Because() => _succeeded = _resolver.TryResolve(_context, out _tenantId);
 
     [Fact] void should_succeed() => _succeeded.ShouldBeTrue();
-    [Fact] void should_return_the_matched_tenant_id() => _tenantId.ShouldEqual(_expectedTenantId);
+    [Fact] void should_return_the_matched_tenant_id() => _tenantId.ShouldEqual(ExpectedTenantId);
 }

--- a/Source/AuthProxy.Specs/for_TenantResolver/when_strategy_resolves_and_tenant_is_matched.cs
+++ b/Source/AuthProxy.Specs/for_TenantResolver/when_strategy_resolves_and_tenant_is_matched.cs
@@ -5,12 +5,12 @@ namespace Cratis.AuthProxy.for_TenantResolver;
 
 public class when_strategy_resolves_and_tenant_is_matched : Specification
 {
-    static readonly Guid _expectedTenantId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    const string ExpectedTenantId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
 
     TenantResolver _resolver;
     DefaultHttpContext _context;
     bool _succeeded;
-    Guid _tenantId;
+    string _tenantId = string.Empty;
 
     void Establish()
     {
@@ -18,7 +18,7 @@ public class when_strategy_resolves_and_tenant_is_matched : Specification
         {
             Tenants = new C.Tenants
             {
-                [_expectedTenantId] = new C.Tenant { Name = "Acme", Domains = ["acme.example.com"] }
+                [ExpectedTenantId] = new C.Tenant { Name = "Acme", Domains = ["acme.example.com"] }
             },
             TenantResolutions =
             [
@@ -38,5 +38,5 @@ public class when_strategy_resolves_and_tenant_is_matched : Specification
     void Because() => _succeeded = _resolver.TryResolve(_context, out _tenantId);
 
     [Fact] void should_succeed() => Assert.True(_succeeded);
-    [Fact] void should_return_the_matched_tenant_id() => Assert.Equal(_expectedTenantId, _tenantId);
+    [Fact] void should_return_the_matched_tenant_id() => Assert.Equal(ExpectedTenantId, _tenantId);
 }

--- a/Source/AuthProxy.Specs/for_TenantResolver/when_strategy_resolves_but_no_tenant_is_matched.cs
+++ b/Source/AuthProxy.Specs/for_TenantResolver/when_strategy_resolves_but_no_tenant_is_matched.cs
@@ -8,7 +8,7 @@ public class when_strategy_resolves_but_no_tenant_is_matched : Specification
     TenantResolver _resolver;
     DefaultHttpContext _context;
     bool _succeeded;
-    Guid _tenantId;
+    string _tenantId = string.Empty;
 
     void Establish()
     {
@@ -16,7 +16,7 @@ public class when_strategy_resolves_but_no_tenant_is_matched : Specification
         {
             Tenants = new C.Tenants
             {
-                [Guid.NewGuid()] = new C.Tenant { Name = "Acme", Domains = ["acme.example.com"] }
+                [Guid.NewGuid().ToString()] = new C.Tenant { Name = "Acme", Domains = ["acme.example.com"] }
             },
             TenantResolutions =
             [
@@ -36,5 +36,5 @@ public class when_strategy_resolves_but_no_tenant_is_matched : Specification
     void Because() => _succeeded = _resolver.TryResolve(_context, out _tenantId);
 
     [Fact] void should_not_succeed() => Assert.False(_succeeded);
-    [Fact] void should_return_empty_tenant_id() => Assert.Equal(Guid.Empty, _tenantId);
+    [Fact] void should_return_empty_tenant_id() => Assert.Equal(string.Empty, _tenantId);
 }

--- a/Source/AuthProxy.Specs/for_TenantResolver/when_subhost_strategy_resolves_and_verification_template_is_configured.cs
+++ b/Source/AuthProxy.Specs/for_TenantResolver/when_subhost_strategy_resolves_and_verification_template_is_configured.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.for_TenantResolver;
+
+public class when_subhost_strategy_resolves_and_verification_template_is_configured : Specification
+{
+    TenantResolver _resolver;
+    DefaultHttpContext _context;
+    bool _succeeded;
+    string _tenantId = string.Empty;
+
+    void Establish()
+    {
+        var config = new C.AuthProxy
+        {
+            TenantResolutions =
+            [
+                new C.TenantResolution
+                {
+                    Strategy = C.TenantSourceIdentifierResolverType.SubHost,
+                    Options = new SubHostOptions
+                    {
+                        ParentHost = "example.com",
+                        VerificationUrlTemplate = "https://tenant-registry.local/tenants/{tenantId}"
+                    }
+                }
+            ]
+        };
+
+        var optionsMonitor = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        optionsMonitor.CurrentValue.Returns(config);
+
+        _context = new DefaultHttpContext();
+        _context.Request.Host = new HostString("acme.example.com");
+
+        _resolver = new TenantResolver(optionsMonitor, [new SubHostSourceIdentifierStrategy()], Substitute.For<ILogger<TenantResolver>>());
+    }
+
+    void Because() => _succeeded = _resolver.TryResolve(_context, out _tenantId);
+
+    [Fact] void should_succeed() => _succeeded.ShouldBeTrue();
+    [Fact] void should_resolve_subhost_as_tenant_id() => _tenantId.ShouldEqual("acme");
+
+    [Fact]
+    void should_store_verification_template_in_http_context_items() =>
+        _context.Items[TenancyMiddleware.TenantVerificationUrlTemplateItemKey]
+            .ShouldEqual("https://tenant-registry.local/tenants/{tenantId}");
+}

--- a/Source/AuthProxy.Specs/for_TenantResolver/when_subhost_strategy_resolves_directly_to_tenant_id.cs
+++ b/Source/AuthProxy.Specs/for_TenantResolver/when_subhost_strategy_resolves_directly_to_tenant_id.cs
@@ -3,10 +3,8 @@
 
 namespace Cratis.AuthProxy.for_TenantResolver;
 
-public class when_specified_strategy_resolves_directly_to_tenant_id : Specification
+public class when_subhost_strategy_resolves_directly_to_tenant_id : Specification
 {
-    const string ExpectedTenantId = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
-
     TenantResolver _resolver;
     DefaultHttpContext _context;
     bool _succeeded;
@@ -20,8 +18,8 @@ public class when_specified_strategy_resolves_directly_to_tenant_id : Specificat
             [
                 new C.TenantResolution
                 {
-                    Strategy = C.TenantSourceIdentifierResolverType.Specified,
-                    Options = new SpecifiedOptions { TenantId = ExpectedTenantId }
+                    Strategy = C.TenantSourceIdentifierResolverType.SubHost,
+                    Options = new SubHostOptions { ParentHost = "example.com" }
                 }
             ]
         };
@@ -30,12 +28,13 @@ public class when_specified_strategy_resolves_directly_to_tenant_id : Specificat
         optionsMonitor.CurrentValue.Returns(config);
 
         _context = new DefaultHttpContext();
+        _context.Request.Host = new HostString("acme.example.com");
 
-        _resolver = new TenantResolver(optionsMonitor, [new SpecifiedSourceIdentifierStrategy()], Substitute.For<ILogger<TenantResolver>>());
+        _resolver = new TenantResolver(optionsMonitor, [new SubHostSourceIdentifierStrategy()], Substitute.For<ILogger<TenantResolver>>());
     }
 
     void Because() => _succeeded = _resolver.TryResolve(_context, out _tenantId);
 
-    [Fact] void should_succeed() => Assert.True(_succeeded);
-    [Fact] void should_return_the_specified_tenant_id() => Assert.Equal(ExpectedTenantId, _tenantId);
+    [Fact] void should_succeed() => _succeeded.ShouldBeTrue();
+    [Fact] void should_return_the_subhost_as_tenant_id() => _tenantId.ShouldEqual("acme");
 }

--- a/Source/AuthProxy/Configuration/AuthProxy.cs
+++ b/Source/AuthProxy/Configuration/AuthProxy.cs
@@ -43,7 +43,7 @@ public class AuthProxy
 
     /// <summary>
     /// Gets or sets the <see cref="Tenants"/>.
-    /// Tenants are keyed by tenant ID (GUID).
+    /// Tenants are keyed by tenant ID string.
     /// </summary>
     public Tenants Tenants { get; set; } = new();
 

--- a/Source/AuthProxy/Configuration/TenantSourceIdentifierResolverType.cs
+++ b/Source/AuthProxy/Configuration/TenantSourceIdentifierResolverType.cs
@@ -25,4 +25,7 @@ public enum TenantSourceIdentifierResolverType
 
     /// <summary>Always resolve to the configured default tenant ID when no other strategy matches.</summary>
     Default = 5,
+
+    /// <summary>Resolve the tenant ID from the request subhost by convention (for example, tenant.example.com -> tenant).</summary>
+    SubHost = 6,
 }

--- a/Source/AuthProxy/Configuration/Tenants.cs
+++ b/Source/AuthProxy/Configuration/Tenants.cs
@@ -6,4 +6,4 @@ namespace Cratis.AuthProxy.Configuration;
 /// <summary>
 /// Represents the configuration for all tenants, keyed by tenant ID.
 /// </summary>
-public class Tenants : Dictionary<Guid, Tenant>;
+public class Tenants : Dictionary<string, Tenant>;

--- a/Source/AuthProxy/ITenantResolver.cs
+++ b/Source/AuthProxy/ITenantResolver.cs
@@ -12,7 +12,7 @@ public interface ITenantResolver
     /// Tries to resolve the tenant ID from the current request.
     /// </summary>
     /// <param name="context">The current <see cref="HttpContext"/>.</param>
-    /// <param name="tenantId">The resolved tenant ID, or <see cref="Guid.Empty"/> when unresolved.</param>
+    /// <param name="tenantId">The resolved tenant ID, or an empty string when unresolved.</param>
     /// <returns><see langword="true"/> if a tenant was resolved; otherwise <see langword="false"/>.</returns>
-    bool TryResolve(HttpContext context, out Guid tenantId);
+    bool TryResolve(HttpContext context, out string tenantId);
 }

--- a/Source/AuthProxy/Identity/IIdentityDetailsResolver.cs
+++ b/Source/AuthProxy/Identity/IIdentityDetailsResolver.cs
@@ -23,5 +23,5 @@ public interface IIdentityDetailsResolver
     /// A <see cref="Task{TResult}"/> resolving to the merged <see cref="IdentityProviderResult"/>,
     /// or an unauthorized result when any microservice reports HTTP 403.
     /// </returns>
-    Task<IdentityProviderResult> Resolve(HttpContext context, ClientPrincipal principal, Guid tenantId);
+    Task<IdentityProviderResult> Resolve(HttpContext context, ClientPrincipal principal, string tenantId);
 }

--- a/Source/AuthProxy/Identity/IdentityDetailsResolver.cs
+++ b/Source/AuthProxy/Identity/IdentityDetailsResolver.cs
@@ -37,7 +37,7 @@ public class IdentityDetailsResolver(
     };
 
     /// <inheritdoc/>
-    public async Task<IdentityProviderResult> Resolve(HttpContext context, ClientPrincipal principal, Guid tenantId)
+    public async Task<IdentityProviderResult> Resolve(HttpContext context, ClientPrincipal principal, string tenantId)
     {
         var hasPendingInviteToken = context.Request.Cookies.ContainsKey(Cookies.InviteToken);
 
@@ -144,7 +144,7 @@ public class IdentityDetailsResolver(
         string serviceName,
         string baseUrl,
         ClientPrincipal principal,
-        Guid tenantId,
+        string tenantId,
         HttpResponse response)
     {
         var url = baseUrl.TrimEnd('/') + WellKnownPaths.IdentityDetails;
@@ -153,7 +153,7 @@ public class IdentityDetailsResolver(
         using var client = httpClientFactory.CreateClient();
         using var request = new HttpRequestMessage(HttpMethod.Get, url);
         request.SetMicrosoftIdentityHeaders(principal);
-        request.Headers.Add(Headers.TenantId, tenantId.ToString());
+        request.Headers.Add(Headers.TenantId, tenantId);
 
         HttpResponseMessage httpResponse;
         try

--- a/Source/AuthProxy/Identity/InjectIdentityHeadersTransform.cs
+++ b/Source/AuthProxy/Identity/InjectIdentityHeadersTransform.cs
@@ -31,10 +31,10 @@ public class InjectIdentityHeadersTransform : RequestTransform
 
         // Forward the resolved Tenant-ID if it was set by the tenancy middleware.
         if (httpContext.Items.TryGetValue(TenancyMiddleware.TenantIdItemKey, out var tenantId)
-            && tenantId is Guid tid && tid != Guid.Empty)
+            && tenantId is string tid && !string.IsNullOrWhiteSpace(tid))
         {
             context.ProxyRequest.Headers.Remove(Headers.TenantId);
-            context.ProxyRequest.Headers.Add(Headers.TenantId, tid.ToString());
+            context.ProxyRequest.Headers.Add(Headers.TenantId, tid);
         }
 
         return ValueTask.CompletedTask;

--- a/Source/AuthProxy/Invites/InviteMiddleware.cs
+++ b/Source/AuthProxy/Invites/InviteMiddleware.cs
@@ -237,18 +237,19 @@ public class InviteMiddleware(
             return false;
         }
 
-        if (!Guid.TryParse(tokenTenantIdStr, out var tokenTenantId))
+        if (string.IsNullOrWhiteSpace(tokenTenantIdStr))
         {
             return false;
         }
 
         if (!context.Items.TryGetValue(TenancyMiddleware.TenantIdItemKey, out var resolvedTenantObj)
-            || resolvedTenantObj is not Guid resolvedTenantId)
+            || resolvedTenantObj is not string resolvedTenantId
+            || string.IsNullOrWhiteSpace(resolvedTenantId))
         {
             return false;
         }
 
-        return tokenTenantId != Guid.Empty && tokenTenantId == resolvedTenantId;
+        return string.Equals(tokenTenantIdStr, resolvedTenantId, StringComparison.OrdinalIgnoreCase);
     }
 
     string BuildLobbyRedirectUrlWithInvitationId(string lobbyUrl, string inviteToken)

--- a/Source/AuthProxy/Tenancy/ITenantVerifier.cs
+++ b/Source/AuthProxy/Tenancy/ITenantVerifier.cs
@@ -15,9 +15,13 @@ public interface ITenantVerifier
     /// as not found (HTTP 404) or cannot be reached.
     /// </summary>
     /// <param name="tenantId">The tenant identifier to verify.</param>
+    /// <param name="urlTemplateOverride">
+    /// Optional strategy-specific URL template to use instead of the global
+    /// <see cref="Configuration.TenantVerification.UrlTemplate"/>.
+    /// </param>
     /// <returns>
     /// A <see cref="Task{TResult}"/> that resolves to <see langword="true"/> if the tenant exists;
     /// otherwise <see langword="false"/>.
     /// </returns>
-    Task<bool> VerifyAsync(Guid tenantId);
+    Task<bool> VerifyAsync(string tenantId, string? urlTemplateOverride = null);
 }

--- a/Source/AuthProxy/Tenancy/SubHostOptions.cs
+++ b/Source/AuthProxy/Tenancy/SubHostOptions.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Tenancy;
+
+/// <summary>
+/// Options for the <see cref="SubHostSourceIdentifierStrategy"/>.
+/// </summary>
+public record SubHostOptions
+{
+    /// <summary>
+    /// Gets the parent host used to extract the tenant from the request host.
+    /// For example, with <c>ParentHost</c> set to <c>example.com</c>,
+    /// a host of <c>acme.example.com</c> resolves the tenant ID <c>acme</c>.
+    /// </summary>
+    public string? ParentHost { get; init; }
+
+    /// <summary>
+    /// Gets an optional URL template used to verify resolved subhost tenant IDs.
+    /// Use <c>{tenantId}</c> as a placeholder.
+    /// </summary>
+    public string? VerificationUrlTemplate { get; init; }
+}

--- a/Source/AuthProxy/Tenancy/SubHostSourceIdentifierStrategy.cs
+++ b/Source/AuthProxy/Tenancy/SubHostSourceIdentifierStrategy.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using C = Cratis.AuthProxy.Configuration;
+
+namespace Cratis.AuthProxy.Tenancy;
+
+/// <summary>
+/// Resolves the tenant ID from the request subhost by convention.
+/// </summary>
+public class SubHostSourceIdentifierStrategy : ISourceIdentifierStrategyTyped<SubHostOptions>
+{
+    /// <inheritdoc/>
+    public C.TenantSourceIdentifierResolverType Type => C.TenantSourceIdentifierResolverType.SubHost;
+
+    /// <inheritdoc/>
+    public bool TryResolveSourceIdentifier(HttpContext context, SubHostOptions typedOptions, out string sourceIdentifier)
+    {
+        sourceIdentifier = string.Empty;
+
+        var parentHost = typedOptions.ParentHost?.Trim().TrimStart('.');
+        if (string.IsNullOrWhiteSpace(parentHost))
+        {
+            return false;
+        }
+
+        var host = context.Request.Host.Host;
+        if (string.IsNullOrWhiteSpace(host))
+        {
+            return false;
+        }
+
+        var suffix = $".{parentHost}";
+        if (!host.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var subHost = host[..^suffix.Length];
+        if (string.IsNullOrWhiteSpace(subHost) || subHost.Contains('.'))
+        {
+            return false;
+        }
+
+        sourceIdentifier = subHost;
+        return true;
+    }
+}

--- a/Source/AuthProxy/Tenancy/TenancyServiceCollectionExtensions.cs
+++ b/Source/AuthProxy/Tenancy/TenancyServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ public static class TenancyServiceCollectionExtensions
         builder.Services.AddSingleton<ISourceIdentifierStrategy, RouteSourceIdentifierStrategy>();
         builder.Services.AddSingleton<ISourceIdentifierStrategy, SpecifiedSourceIdentifierStrategy>();
         builder.Services.AddSingleton<ISourceIdentifierStrategy, DefaultSourceIdentifierStrategy>();
+        builder.Services.AddSingleton<ISourceIdentifierStrategy, SubHostSourceIdentifierStrategy>();
         builder.Services.AddSingleton<ITenantResolver, TenantResolver>();
         builder.Services.AddSingleton<IPostConfigureOptions<Configuration.AuthProxy>, TenantResolutionOptionsConfigurer>();
 

--- a/Source/AuthProxy/Tenancy/TenantResolutionOptionsConfigurer.cs
+++ b/Source/AuthProxy/Tenancy/TenantResolutionOptionsConfigurer.cs
@@ -35,6 +35,7 @@ public class TenantResolutionOptionsConfigurer(IConfiguration configuration) : I
                 C.TenantSourceIdentifierResolverType.Route => optionsSection.Get<RouteOptions>() ?? new RouteOptions(),
                 C.TenantSourceIdentifierResolverType.Specified => optionsSection.Get<SpecifiedOptions>() ?? new SpecifiedOptions(),
                 C.TenantSourceIdentifierResolverType.Default => optionsSection.Get<DefaultOptions>() ?? new DefaultOptions(),
+                C.TenantSourceIdentifierResolverType.SubHost => optionsSection.Get<SubHostOptions>() ?? new SubHostOptions(),
                 _ => null
             };
         }

--- a/Source/AuthProxy/Tenancy/TenantVerifier.cs
+++ b/Source/AuthProxy/Tenancy/TenantVerifier.cs
@@ -23,15 +23,18 @@ public class TenantVerifier(
     ILogger<TenantVerifier> logger) : ITenantVerifier
 {
     /// <inheritdoc/>
-    public async Task<bool> VerifyAsync(Guid tenantId)
+    public async Task<bool> VerifyAsync(string tenantId, string? urlTemplateOverride = null)
     {
-        var urlTemplate = config.CurrentValue.TenantVerification?.UrlTemplate;
+        var urlTemplate = string.IsNullOrWhiteSpace(urlTemplateOverride)
+            ? config.CurrentValue.TenantVerification?.UrlTemplate
+            : urlTemplateOverride;
+
         if (string.IsNullOrWhiteSpace(urlTemplate))
         {
             return true;
         }
 
-        var url = urlTemplate.Replace("{tenantId}", tenantId.ToString());
+        var url = urlTemplate.Replace("{tenantId}", tenantId, StringComparison.Ordinal);
         using var client = httpClientFactory.CreateClient();
 
         try

--- a/Source/AuthProxy/Tenancy/TenantVerifierLogging.cs
+++ b/Source/AuthProxy/Tenancy/TenantVerifierLogging.cs
@@ -14,7 +14,7 @@ internal static partial class TenantVerifierLogging
     /// <param name="logger">The logger to write to.</param>
     /// <param name="tenantId">The tenant identifier that was not found.</param>
     [LoggerMessage(LogLevel.Warning, "Tenant '{TenantId}' was not found by the verification service.")]
-    internal static partial void TenantNotFound(this ILogger<TenantVerifier> logger, Guid tenantId);
+    internal static partial void TenantNotFound(this ILogger<TenantVerifier> logger, string tenantId);
 
     /// <summary>
     /// Logs a non-success, non-404 HTTP status code returned by the tenant verification service.
@@ -23,7 +23,7 @@ internal static partial class TenantVerifierLogging
     /// <param name="tenantId">The tenant identifier being verified.</param>
     /// <param name="statusCode">The unexpected HTTP status code.</param>
     [LoggerMessage(LogLevel.Warning, "Tenant verification for '{TenantId}' returned unexpected status {StatusCode}.")]
-    internal static partial void TenantVerificationFailed(this ILogger<TenantVerifier> logger, Guid tenantId, int statusCode);
+    internal static partial void TenantVerificationFailed(this ILogger<TenantVerifier> logger, string tenantId, int statusCode);
 
     /// <summary>
     /// Logs an exception thrown while contacting the tenant verification service.
@@ -33,5 +33,5 @@ internal static partial class TenantVerifierLogging
     /// <param name="tenantId">The tenant identifier being verified.</param>
     /// <param name="url">The URL that was contacted.</param>
     [LoggerMessage(LogLevel.Error, "Error contacting tenant verification service for '{TenantId}' at '{Url}'.")]
-    internal static partial void TenantVerificationError(this ILogger<TenantVerifier> logger, Exception exception, Guid tenantId, string url);
+    internal static partial void TenantVerificationError(this ILogger<TenantVerifier> logger, Exception exception, string tenantId, string url);
 }

--- a/Source/AuthProxy/TenancyMiddleware.cs
+++ b/Source/AuthProxy/TenancyMiddleware.cs
@@ -38,6 +38,12 @@ public class TenancyMiddleware(
     public const string TenantIdItemKey = "Cratis.TenantId";
 
     /// <summary>
+    /// Key used to store an optional strategy-specific verification URL template in
+    /// <see cref="HttpContext.Items"/>.
+    /// </summary>
+    public const string TenantVerificationUrlTemplateItemKey = "Cratis.TenantVerificationUrlTemplate";
+
+    /// <summary>
     /// Executes the tenancy middleware for the given <paramref name="context"/>.
     /// </summary>
     /// <param name="context">The current <see cref="HttpContext"/>.</param>
@@ -84,7 +90,11 @@ public class TenancyMiddleware(
         }
 
         // 3. Verify the resolved tenant exists (when verification is configured).
-        if (tenantId != Guid.Empty && !await tenantVerifier.VerifyAsync(tenantId))
+        var verificationUrlTemplate = context.Items.TryGetValue(TenantVerificationUrlTemplateItemKey, out var verificationTemplate)
+            ? verificationTemplate as string
+            : null;
+
+        if (!string.IsNullOrWhiteSpace(tenantId) && !await tenantVerifier.VerifyAsync(tenantId, verificationUrlTemplate))
         {
             logger.TenantDoesNotExist(tenantId, SanitizePath(context.Request.Path));
             await errorPageProvider.WriteErrorPageAsync(
@@ -98,7 +108,7 @@ public class TenancyMiddleware(
 
         // 4. If the user is authenticated, resolve identity details (call /.cratis/me).
         var principal = context.BuildClientPrincipal();
-        if (principal is not null && tenantId != Guid.Empty)
+        if (principal is not null && !string.IsNullOrWhiteSpace(tenantId))
         {
             var result = await identityDetailsResolver.Resolve(context, principal, tenantId);
             if (!result.IsAuthorized)

--- a/Source/AuthProxy/TenancyMiddlewareLogging.cs
+++ b/Source/AuthProxy/TenancyMiddlewareLogging.cs
@@ -12,5 +12,5 @@ internal static partial class TenancyMiddlewareLogging
     internal static partial void CouldNotResolveTenant(this ILogger logger, string path);
 
     [LoggerMessage(LogLevel.Warning, "Resolved tenant '{TenantId}' does not exist for request {Path}. Returning tenant-not-found page.")]
-    internal static partial void TenantDoesNotExist(this ILogger logger, Guid tenantId, string path);
+    internal static partial void TenantDoesNotExist(this ILogger logger, string tenantId, string path);
 }

--- a/Source/AuthProxy/TenantResolver.cs
+++ b/Source/AuthProxy/TenantResolver.cs
@@ -23,9 +23,10 @@ public class TenantResolver(
     ILogger<TenantResolver> logger) : ITenantResolver
 {
     /// <inheritdoc/>
-    public bool TryResolve(HttpContext context, out Guid tenantId)
+    public bool TryResolve(HttpContext context, out string tenantId)
     {
-        tenantId = Guid.Empty;
+        tenantId = string.Empty;
+        context.Items.Remove(TenancyMiddleware.TenantVerificationUrlTemplateItemKey);
         var resolutions = config.CurrentValue.TenantResolutions;
 
         if (resolutions.Count == 0)
@@ -103,6 +104,25 @@ public class TenantResolver(
                     return true;
                 }
             }
+            else if (strategy is T.ISourceIdentifierStrategyTyped<T.SubHostOptions> subHostStrategy)
+            {
+                var subHostOptions = resolution.Options as T.SubHostOptions ?? new T.SubHostOptions();
+
+                if (!subHostStrategy.TryResolveSourceIdentifier(context, subHostOptions, out var sourceIdentifier))
+                {
+                    continue;
+                }
+
+                if (HandleResolvedSourceIdentifier(resolution.Strategy, sourceIdentifier, out tenantId, config.CurrentValue))
+                {
+                    if (!string.IsNullOrWhiteSpace(subHostOptions.VerificationUrlTemplate))
+                    {
+                        context.Items[TenancyMiddleware.TenantVerificationUrlTemplateItemKey] = subHostOptions.VerificationUrlTemplate;
+                    }
+
+                    return true;
+                }
+            }
             else if (strategy is T.ISourceIdentifierStrategyTyped<object>)
             {
                 var sourceIdentifier = context.Request.Host.Host;
@@ -125,17 +145,21 @@ public class TenantResolver(
     private static bool HandleResolvedSourceIdentifier(
           Type strategyType,
           string sourceIdentifier,
-          out Guid tenantId,
+          out string tenantId,
           C.AuthProxy config)
     {
-        tenantId = Guid.Empty;
+        tenantId = string.Empty;
 
-        // Specified and Default strategies return a fixed Guid directly.
-        if ((strategyType == Type.Specified || strategyType == Type.Default)
-                 && Guid.TryParse(sourceIdentifier, out var specifiedId))
+        // Specified, Default, and SubHost strategies return a fixed tenant ID directly.
+        if (strategyType == Type.Specified || strategyType == Type.Default || strategyType == Type.SubHost)
         {
-            tenantId = specifiedId;
-            return true;
+            if (!string.IsNullOrWhiteSpace(sourceIdentifier))
+            {
+                tenantId = sourceIdentifier;
+                return true;
+            }
+
+            return false;
         }
 
         // For all other strategies, look up the source identifier in the tenant map.

--- a/Source/AuthProxy/TenantResolverLogging.cs
+++ b/Source/AuthProxy/TenantResolverLogging.cs
@@ -8,10 +8,10 @@ namespace Cratis.AuthProxy;
 internal static partial class TenantResolverLogging
 {
     [LoggerMessage(LogLevel.Debug, "Tenant resolved via Specified strategy to {TenantId}")]
-    internal static partial void TenantResolvedViaSpecifiedStrategy(this ILogger logger, Guid tenantId);
+    internal static partial void TenantResolvedViaSpecifiedStrategy(this ILogger logger, string tenantId);
 
     [LoggerMessage(LogLevel.Debug, "Tenant resolved via {Strategy} strategy using source identifier '{SourceIdentifier}' to {TenantId}")]
-    internal static partial void TenantResolved(this ILogger logger, C.TenantSourceIdentifierResolverType strategy, string sourceIdentifier, Guid tenantId);
+    internal static partial void TenantResolved(this ILogger logger, C.TenantSourceIdentifierResolverType strategy, string sourceIdentifier, string tenantId);
 
     [LoggerMessage(LogLevel.Warning, "Source identifier '{SourceIdentifier}' resolved by {Strategy} strategy but matched no configured tenant")]
     internal static partial void SourceIdentifierMatchedNoTenant(this ILogger logger, string sourceIdentifier, C.TenantSourceIdentifierResolverType strategy);


### PR DESCRIPTION
## Changed
- Tenant resolution now uses tenant ID strings end-to-end instead of requiring GUID parsing.
- Added `SubHost` tenant resolution strategy with typed `ParentHost` options.
- Added optional strategy-level verification URL override support for tenant verification back-channel calls.
- Updated tenancy, middleware, invite, identity propagation, and verifier contracts to use string tenant IDs consistently.

## Fixed
- Tenant-issued invite matching now compares tenant IDs as strings instead of requiring GUID format.
- Updated and expanded specs to cover SubHost resolution, strategy verification override flow, and string tenant ID behavior.
- Updated tenancy and configuration documentation to describe string tenant IDs and SubHost verification options.