### PR TITLE
Fix static page asset resolution and request classification

### DIFF
--- a/Source/AuthProxy.Specs/ErrorPages/for_ErrorPageProvider/when_page_has_relative_assets.cs
+++ b/Source/AuthProxy.Specs/ErrorPages/for_ErrorPageProvider/when_page_has_relative_assets.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Hosting;
+
+namespace Cratis.AuthProxy.ErrorPages.for_ErrorPageProvider;
+
+public class when_page_has_relative_assets : Specification
+{
+    ErrorPageProvider _provider;
+    DefaultHttpContext _context;
+    string _rootDirectory;
+
+    void Establish()
+    {
+        _rootDirectory = Path.Combine(Path.GetTempPath(), $"authproxy-pages-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_rootDirectory);
+        File.WriteAllText(
+            Path.Combine(_rootDirectory, "access-denied.html"),
+            "<html><head><link rel=\"stylesheet\" href=\"styles.css\" /></head><body><img src=\"logo.svg\" /></body></html>");
+
+        var config = new C.AuthProxy { PagesPath = _rootDirectory };
+        var optionsMonitor = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        optionsMonitor.CurrentValue.Returns(config);
+
+        var environment = Substitute.For<IWebHostEnvironment>();
+        environment.ContentRootPath.Returns("/tmp/not-used");
+
+        _provider = new ErrorPageProvider(environment, optionsMonitor);
+
+        _context = new DefaultHttpContext();
+        _context.Response.Body = new MemoryStream();
+    }
+
+    async Task Because() => await _provider.WriteErrorPageAsync(_context, "access-denied.html", StatusCodes.Status403Forbidden);
+
+    [Fact]
+    void should_insert_base_href_before_relative_assets_are_declared()
+    {
+        _context.Response.Body.Position = 0;
+        using var reader = new StreamReader(_context.Response.Body);
+        var body = reader.ReadToEnd();
+
+        var baseIndex = body.IndexOf("<base href=\"/_pages/\">", StringComparison.Ordinal);
+        var linkIndex = body.IndexOf("<link rel=\"stylesheet\" href=\"styles.css\" />", StringComparison.Ordinal);
+
+        baseIndex.ShouldBeGreaterThan(-1);
+        linkIndex.ShouldBeGreaterThan(-1);
+        (baseIndex < linkIndex).ShouldBeTrue();
+    }
+}

--- a/Source/AuthProxy.Specs/Scenarios/when_static_page_asset_is_requested/AuthProxyFactory.cs
+++ b/Source/AuthProxy.Specs/Scenarios/when_static_page_asset_is_requested/AuthProxyFactory.cs
@@ -1,0 +1,112 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.AuthProxy.Scenarios.when_static_page_asset_is_requested;
+
+public class AuthProxyFactory : WebApplicationFactory<Program>
+{
+    public const string IdentityBackendBaseUrl = "http://identity.test/";
+    public const string TenantId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+
+    readonly string _pagesPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+    public AuthProxyFactory()
+    {
+        Directory.CreateDirectory(_pagesPath);
+        File.WriteAllText(Path.Combine(_pagesPath, "403.html"), "<html><head><link rel=\"stylesheet\" href=\"styles.css\" /></head><body><img src=\"logo.svg\" /></body></html>");
+        File.WriteAllText(Path.Combine(_pagesPath, "styles.css"), "body { color: red; }");
+        File.WriteAllText(Path.Combine(_pagesPath, "logo.svg"), "<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>");
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        if (disposing && Directory.Exists(_pagesPath))
+        {
+            Directory.Delete(_pagesPath, recursive: true);
+        }
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureAppConfiguration((_, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"{C.AuthProxy.SectionKey}:Services:test:Backend:BaseUrl"] = IdentityBackendBaseUrl,
+                [$"{C.AuthProxy.SectionKey}:TenantResolutions:0:Strategy"] = nameof(C.TenantSourceIdentifierResolverType.Specified),
+                [$"{C.AuthProxy.SectionKey}:TenantResolutions:0:Options:TenantId"] = TenantId,
+                [$"{C.AuthProxy.SectionKey}:PagesPath"] = _pagesPath,
+            });
+        });
+
+        builder.ConfigureTestServices(services =>
+        {
+            services.AddAuthentication(TestAuthHandler.Scheme)
+                .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(TestAuthHandler.Scheme, _ => { });
+
+            services.AddSingleton<IHttpClientFactory>(new TestHttpClientFactory(
+                _ => new HttpResponseMessage(HttpStatusCode.Forbidden)));
+        });
+    }
+
+    public HttpClient CreateTestClient(bool authenticated = false)
+    {
+        var client = CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+        if (authenticated)
+        {
+            client.DefaultRequestHeaders.Add(TestAuthHandler.AuthHeader, "true");
+        }
+
+        return client;
+    }
+
+    public class TestAuthHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        System.Text.Encodings.Web.UrlEncoder encoder)
+        : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+    {
+        public const string Scheme = "TestScheme";
+        public const string AuthHeader = "X-Test-Auth";
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            if (!Request.Headers.ContainsKey(AuthHeader))
+            {
+                return Task.FromResult(AuthenticateResult.NoResult());
+            }
+
+            var claims =
+                new[]
+                {
+                    new Claim(ClaimTypes.Name, "test-user"),
+                    new Claim("sub", "test-user-id"),
+                    new Claim("oid", "test-user-id"),
+                };
+            var identity = new ClaimsIdentity(claims, Scheme);
+            return Task.FromResult(AuthenticateResult.Success(
+                new AuthenticationTicket(new ClaimsPrincipal(identity), Scheme)));
+        }
+    }
+
+    sealed class TestHttpClientFactory(Func<string, HttpResponseMessage> handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) =>
+            new(new DispatchingHandler(handler)) { Timeout = TimeSpan.FromSeconds(10) };
+
+        sealed class DispatchingHandler(Func<string, HttpResponseMessage> handler) : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+                Task.FromResult(handler(request.RequestUri?.ToString() ?? string.Empty));
+        }
+    }
+}

--- a/Source/AuthProxy.Specs/Scenarios/when_static_page_asset_is_requested/and_authenticated_request_is_made.cs
+++ b/Source/AuthProxy.Specs/Scenarios/when_static_page_asset_is_requested/and_authenticated_request_is_made.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Scenarios.when_static_page_asset_is_requested;
+
+public class and_authenticated_request_is_made(AuthProxyFactory factory) : IClassFixture<AuthProxyFactory>, IAsyncLifetime
+{
+    HttpResponseMessage? _response;
+    string? _responseBody;
+
+    public async Task InitializeAsync()
+    {
+        using var client = factory.CreateTestClient(authenticated: true);
+        _response = await client.GetAsync("/_pages/logo.svg");
+        _responseBody = await _response.Content.ReadAsStringAsync();
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact] public void should_return_200() => Assert.Equal(System.Net.HttpStatusCode.OK, _response.StatusCode);
+    [Fact] public void should_return_the_static_asset() => Assert.Contains("<svg", _responseBody);
+}

--- a/Source/AuthProxy.Specs/for_HttpContextExtensions/when_request_is_authentication_bootstrap_path.cs
+++ b/Source/AuthProxy.Specs/for_HttpContextExtensions/when_request_is_authentication_bootstrap_path.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.for_HttpContextExtensions;
+
+public class when_request_is_authentication_bootstrap_path : Specification
+{
+    DefaultHttpContext _context;
+    bool _isAuthenticationBootstrap;
+
+    void Establish()
+    {
+        _context = new DefaultHttpContext();
+        _context.Request.Path = "/signin-github";
+    }
+
+    void Because() => _isAuthenticationBootstrap = _context.IsAuthenticationBootstrap();
+
+    [Fact] void should_identify_the_request_as_authentication_bootstrap() => _isAuthenticationBootstrap.ShouldBeTrue();
+}

--- a/Source/AuthProxy.Specs/for_HttpContextExtensions/when_request_is_invitation.cs
+++ b/Source/AuthProxy.Specs/for_HttpContextExtensions/when_request_is_invitation.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.for_HttpContextExtensions;
+
+public class when_request_is_invitation : Specification
+{
+    DefaultHttpContext _context;
+    bool _isInvitation;
+    bool _hasToken;
+    string _token;
+
+    void Establish()
+    {
+        _context = new DefaultHttpContext();
+        _context.Request.Path = "/invite/some-token";
+        _token = string.Empty;
+    }
+
+    void Because()
+    {
+        _isInvitation = _context.IsInvitation();
+        _hasToken = _context.TryGetInvitationToken(out _token);
+    }
+
+    [Fact] void should_identify_the_request_as_invitation() => _isInvitation.ShouldBeTrue();
+    [Fact] void should_extract_the_invitation_token() => _token.ShouldEqual("some-token");
+    [Fact] void should_report_that_an_invitation_token_exists() => _hasToken.ShouldBeTrue();
+}

--- a/Source/AuthProxy/Authentication/AuthenticationServiceCollectionExtensions.cs
+++ b/Source/AuthProxy/Authentication/AuthenticationServiceCollectionExtensions.cs
@@ -64,15 +64,9 @@ public static class AuthenticationServiceCollectionExtensions
                 .GetRequiredService<IOptionsMonitor<C.Authentication>>()
                 .CurrentValue;
 
-            var requestPath = ctx.Request.Path;
-            var isAuthBootstrapPath = requestPath.StartsWithSegments(WellKnownPaths.LoginPrefix)
-                || requestPath.StartsWithSegments(WellKnownPaths.LoginPage)
-                || requestPath.StartsWithSegments(WellKnownPaths.Providers)
-                || requestPath.StartsWithSegments("/signin-");
-
-            var returnUrl = isAuthBootstrapPath
+            var returnUrl = ctx.HttpContext.IsAuthenticationBootstrap()
                 ? "/"
-                : ctx.Request.Path + ctx.Request.QueryString;
+                : ctx.HttpContext.GetPathAndQuery();
 
             if (authConfig.TotalProviderCount > 1)
             {

--- a/Source/AuthProxy/Authentication/SelectProviderMiddleware.cs
+++ b/Source/AuthProxy/Authentication/SelectProviderMiddleware.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.AuthProxy.ErrorPages;
-using Cratis.AuthProxy.Invites;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Options;
 using C = Cratis.AuthProxy.Configuration;
@@ -33,11 +32,9 @@ public class SelectProviderMiddleware(
     public async Task InvokeAsync(HttpContext context)
     {
         if (context.User.Identity?.IsAuthenticated == true
-            || context.Request.Path.StartsWithSegments(InviteMiddleware.InvitePathPrefix)
-            || context.Request.Path.StartsWithSegments(WellKnownPaths.LoginPrefix)
-            || context.Request.Path.StartsWithSegments(WellKnownPaths.LoginPage)
-            || context.Request.Path.StartsWithSegments(WellKnownPaths.Providers)
-            || context.Request.Cookies.ContainsKey(Cookies.InviteToken))
+            || context.IsInvitation()
+            || context.IsAuthenticationUI()
+            || context.HasPendingInvitation())
         {
             await next(context);
             return;
@@ -69,7 +66,7 @@ public class SelectProviderMiddleware(
         if (providers.Count == 1)
         {
             var scheme = OidcProviderScheme.FromName(providers[0].Name);
-            var returnUrl = $"{context.Request.Path}{context.Request.QueryString}";
+            var returnUrl = context.GetPathAndQuery();
             var properties = new AuthenticationProperties { RedirectUri = returnUrl };
             await context.ChallengeAsync(scheme, properties);
             return;

--- a/Source/AuthProxy/ErrorPages/ErrorPageProvider.cs
+++ b/Source/AuthProxy/ErrorPages/ErrorPageProvider.cs
@@ -51,10 +51,17 @@ public class ErrorPageProvider(IWebHostEnvironment environment, IOptionsMonitor<
         }
 
         var tag = $"<base href=\"{baseHref}\">";
-        var headEnd = html.IndexOf("</head>", StringComparison.OrdinalIgnoreCase);
-        return headEnd >= 0
-            ? html.Insert(headEnd, tag)
-            : tag + html;
+        var headStart = html.IndexOf("<head", StringComparison.OrdinalIgnoreCase);
+        if (headStart >= 0)
+        {
+            var headTagEnd = html.IndexOf('>', headStart);
+            if (headTagEnd >= 0)
+            {
+                return html.Insert(headTagEnd + 1, tag);
+            }
+        }
+
+        return tag + html;
     }
 
     string? ResolvePage(string pageName)

--- a/Source/AuthProxy/HttpContextExtensions.cs
+++ b/Source/AuthProxy/HttpContextExtensions.cs
@@ -1,0 +1,105 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy;
+
+/// <summary>
+/// Provides helper methods for classifying well-known AuthProxy HTTP requests.
+/// </summary>
+public static class HttpContextExtensions
+{
+    const string SignInPathPrefix = "/signin-";
+
+    /// <summary>
+    /// Gets the current request path and query string as a single relative URL.
+    /// </summary>
+    /// <param name="context">The <see cref="HttpContext"/> to evaluate.</param>
+    /// <returns>The current request path and query string.</returns>
+    public static string GetPathAndQuery(this HttpContext context) => $"{context.Request.Path}{context.Request.QueryString}";
+
+    /// <summary>
+    /// Determines whether the request has a pending invitation cookie.
+    /// </summary>
+    /// <param name="context">The <see cref="HttpContext"/> to evaluate.</param>
+    /// <returns><see langword="true"/> if a pending invitation cookie exists; otherwise <see langword="false"/>.</returns>
+    public static bool HasPendingInvitation(this HttpContext context) => context.Request.Cookies.ContainsKey(Cookies.InviteToken);
+
+    /// <summary>
+    /// Determines whether the request targets an invitation URL.
+    /// </summary>
+    /// <param name="context">The <see cref="HttpContext"/> to evaluate.</param>
+    /// <returns><see langword="true"/> if the request is an invitation URL; otherwise <see langword="false"/>.</returns>
+    public static bool IsInvitation(this HttpContext context) => context.Request.Path.StartsWithSegments(WellKnownPaths.InvitePathPrefix);
+
+    /// <summary>
+    /// Determines whether the request targets one of the login endpoints.
+    /// </summary>
+    /// <param name="context">The <see cref="HttpContext"/> to evaluate.</param>
+    /// <returns><see langword="true"/> if the request is a login endpoint; otherwise <see langword="false"/>.</returns>
+    public static bool IsLogin(this HttpContext context) =>
+        context.Request.Path.StartsWithSegments(WellKnownPaths.LoginPrefix)
+        || context.Request.Path.StartsWithSegments(WellKnownPaths.LoginPage);
+
+    /// <summary>
+    /// Determines whether the request targets the well-known providers endpoint.
+    /// </summary>
+    /// <param name="context">The <see cref="HttpContext"/> to evaluate.</param>
+    /// <returns><see langword="true"/> if the request targets the providers endpoint; otherwise <see langword="false"/>.</returns>
+    public static bool IsProviders(this HttpContext context) => context.Request.Path.StartsWithSegments(WellKnownPaths.Providers);
+
+    /// <summary>
+    /// Determines whether the request targets the AuthProxy authentication user interface.
+    /// </summary>
+    /// <param name="context">The <see cref="HttpContext"/> to evaluate.</param>
+    /// <returns><see langword="true"/> if the request is part of the authentication UI; otherwise <see langword="false"/>.</returns>
+    public static bool IsAuthenticationUI(this HttpContext context) => context.IsLogin() || context.IsProviders();
+
+    /// <summary>
+    /// Determines whether the request targets any authentication bootstrap endpoint.
+    /// </summary>
+    /// <param name="context">The <see cref="HttpContext"/> to evaluate.</param>
+    /// <returns><see langword="true"/> if the request is part of authentication bootstrap; otherwise <see langword="false"/>.</returns>
+    public static bool IsAuthenticationBootstrap(this HttpContext context) =>
+        context.IsAuthenticationUI() || (context.Request.Path.Value?.StartsWith(SignInPathPrefix, StringComparison.OrdinalIgnoreCase) ?? false);
+
+    /// <summary>
+    /// Attempts to extract the invitation token from the current invitation request path.
+    /// </summary>
+    /// <param name="context">The <see cref="HttpContext"/> to evaluate.</param>
+    /// <param name="invitationToken">The extracted invitation token when present.</param>
+    /// <returns><see langword="true"/> if an invitation token was extracted; otherwise <see langword="false"/>.</returns>
+    public static bool TryGetInvitationToken(this HttpContext context, out string invitationToken)
+    {
+        invitationToken = string.Empty;
+
+        if (!context.Request.Path.StartsWithSegments(WellKnownPaths.InvitePathPrefix, out var remaining))
+        {
+            return false;
+        }
+
+        invitationToken = remaining.Value?.TrimStart('/') ?? string.Empty;
+
+        return true;
+    }
+
+    /// <summary>
+    /// Attempts to get the pending invitation token from the request cookies.
+    /// </summary>
+    /// <param name="context">The <see cref="HttpContext"/> to evaluate.</param>
+    /// <param name="invitationToken">The pending invitation token when present.</param>
+    /// <returns><see langword="true"/> if a pending invitation token exists; otherwise <see langword="false"/>.</returns>
+    public static bool TryGetPendingInvitationToken(this HttpContext context, out string invitationToken)
+    {
+        invitationToken = string.Empty;
+
+        if (!context.Request.Cookies.TryGetValue(Cookies.InviteToken, out var token)
+            || string.IsNullOrWhiteSpace(token))
+        {
+            return false;
+        }
+
+        invitationToken = token;
+
+        return true;
+    }
+}

--- a/Source/AuthProxy/IngressExtensions.cs
+++ b/Source/AuthProxy/IngressExtensions.cs
@@ -8,9 +8,8 @@ using Cratis.AuthProxy.ReverseProxy;
 using Cratis.AuthProxy.Tenancy;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.HttpOverrides;
-using Microsoft.Extensions.FileProviders;
+using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.Options;
-using Microsoft.Extensions.Primitives;
 using C = Cratis.AuthProxy.Configuration;
 
 namespace Cratis.AuthProxy;
@@ -65,8 +64,8 @@ public static class IngressExtensions
     public static WebApplication UseIngress(this WebApplication app)
     {
         app.UseForwardedHeaders();
+        app.Map(WellKnownPaths.Pages, pagesApp => ConfigurePagesPipeline(pagesApp, app.Environment, app.Services.GetRequiredService<IOptionsMonitor<C.AuthProxy>>()));
         app.UseStaticFiles();
-        UsePagesStaticFiles(app);
         app.UseAuthentication();
         app.UseMiddleware<Authentication.SelectProviderMiddleware>();
         app.UseAuthorization();
@@ -81,25 +80,8 @@ public static class IngressExtensions
         return app;
     }
 
-    static void UsePagesStaticFiles(WebApplication app)
-    {
-        var config = app.Services.GetRequiredService<IOptionsMonitor<C.AuthProxy>>();
-
-        app.UseStaticFiles(new StaticFileOptions
-        {
-            FileProvider = new PagesFileProvider(app.Environment, config),
-            RequestPath = WellKnownPaths.Pages,
-        });
-    }
-
     static void MapIngressEndpoints(this WebApplication app)
     {
-        // All requests under /_pages are served as static files (anonymous by design).
-        // Any path not matched by the static file middleware is returned as 404 without
-        // requiring authentication, so the pages are never subject to auth challenges.
-        app.Map($"{WellKnownPaths.Pages}/{{**path}}", () => Results.NotFound())
-            .AllowAnonymous();
-
         // Returns a JSON array of all configured providers (OIDC + OAuth) used by the login page.
         app.MapGet(WellKnownPaths.Providers, (IOptionsMonitor<C.AuthProxy> config) =>
         {
@@ -164,79 +146,89 @@ public static class IngressExtensions
         .AllowAnonymous();
     }
 
-    sealed class PagesFileProvider(IWebHostEnvironment environment, IOptionsMonitor<C.AuthProxy> config) : IFileProvider
+    static void ConfigurePagesPipeline(IApplicationBuilder app, IWebHostEnvironment environment, IOptionsMonitor<C.AuthProxy> config)
     {
-        public IDirectoryContents GetDirectoryContents(string subpath) => NotFoundDirectoryContents.Singleton;
+        var pagesContentTypeProvider = new FileExtensionContentTypeProvider();
 
-        public IFileInfo GetFileInfo(string subpath)
+        app.Run(async context =>
         {
-            var relativePath = subpath.TrimStart('/');
+            if (!HttpMethods.IsGet(context.Request.Method) && !HttpMethods.IsHead(context.Request.Method))
+            {
+                context.Response.StatusCode = StatusCodes.Status404NotFound;
+                return;
+            }
+
+            var relativePath = context.Request.Path.Value?.TrimStart('/');
             if (string.IsNullOrWhiteSpace(relativePath))
             {
-                return new NotFoundFileInfo(subpath);
+                context.Response.StatusCode = StatusCodes.Status404NotFound;
+                return;
             }
 
-            foreach (var directory in GetCandidateDirectories())
+            var assetPath = ResolvePageAssetPath(environment, config, relativePath);
+            if (assetPath is null)
             {
-                var directoryFullPath = Path.GetFullPath(directory);
-                var candidateFullPath = Path.GetFullPath(Path.Combine(directoryFullPath, relativePath));
-                var startsWithDirectory = candidateFullPath.StartsWith($"{directoryFullPath}{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase)
-                    || string.Equals(candidateFullPath, directoryFullPath, StringComparison.OrdinalIgnoreCase);
-
-                if (!startsWithDirectory || !File.Exists(candidateFullPath))
-                {
-                    continue;
-                }
-
-                return new PhysicalPathFileInfo(candidateFullPath);
+                context.Response.StatusCode = StatusCodes.Status404NotFound;
+                return;
             }
 
-            return new NotFoundFileInfo(subpath);
-        }
+            if (!pagesContentTypeProvider.TryGetContentType(assetPath, out var contentType))
+            {
+                contentType = "application/octet-stream";
+            }
 
-        public IChangeToken Watch(string filter) => NullChangeToken.Singleton;
+            context.Response.ContentType = contentType;
 
-        IEnumerable<string> GetCandidateDirectories()
+            if (HttpMethods.IsHead(context.Request.Method))
+            {
+                var fileInfo = new FileInfo(assetPath);
+                context.Response.ContentLength = fileInfo.Length;
+                return;
+            }
+
+            await context.Response.SendFileAsync(assetPath);
+        });
+    }
+
+    static string? ResolvePageAssetPath(IWebHostEnvironment environment, IOptionsMonitor<C.AuthProxy> config, string relativePath)
+    {
+        foreach (var directory in GetCandidateDirectories(environment, config))
         {
-            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var directoryFullPath = Path.GetFullPath(directory);
+            var candidateFullPath = Path.GetFullPath(Path.Combine(directoryFullPath, relativePath));
+            var isWithinDirectory = candidateFullPath.StartsWith($"{directoryFullPath}{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(candidateFullPath, directoryFullPath, StringComparison.OrdinalIgnoreCase);
 
-            var configuredPath = config.CurrentValue.PagesPath;
-            if (!string.IsNullOrWhiteSpace(configuredPath))
+            if (isWithinDirectory && File.Exists(candidateFullPath))
             {
-                var resolvedConfiguredPath = Path.IsPathRooted(configuredPath)
-                    ? configuredPath
-                    : Path.Combine(environment.ContentRootPath, configuredPath);
-
-                if (Directory.Exists(resolvedConfiguredPath) && seen.Add(resolvedConfiguredPath))
-                {
-                    yield return resolvedConfiguredPath;
-                }
-            }
-
-            var defaultPagesPath = Path.Combine(environment.ContentRootPath, "Pages");
-            if (Directory.Exists(defaultPagesPath) && seen.Add(defaultPagesPath))
-            {
-                yield return defaultPagesPath;
+                return candidateFullPath;
             }
         }
 
-        sealed class PhysicalPathFileInfo(string fullPath) : IFileInfo
+        return null;
+    }
+
+    static IEnumerable<string> GetCandidateDirectories(IWebHostEnvironment environment, IOptionsMonitor<C.AuthProxy> config)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        var configuredPath = config.CurrentValue.PagesPath;
+        if (!string.IsNullOrWhiteSpace(configuredPath))
         {
-            readonly FileInfo _fileInfo = new(fullPath);
+            var resolvedConfiguredPath = Path.IsPathRooted(configuredPath)
+                ? configuredPath
+                : Path.Combine(environment.ContentRootPath, configuredPath);
 
-            public bool Exists => _fileInfo.Exists;
+            if (Directory.Exists(resolvedConfiguredPath) && seen.Add(resolvedConfiguredPath))
+            {
+                yield return resolvedConfiguredPath;
+            }
+        }
 
-            public long Length => _fileInfo.Length;
-
-            public string PhysicalPath => _fileInfo.FullName;
-
-            public string Name => _fileInfo.Name;
-
-            public DateTimeOffset LastModified => new(_fileInfo.LastWriteTimeUtc, TimeSpan.Zero);
-
-            public bool IsDirectory => false;
-
-            public Stream CreateReadStream() => _fileInfo.OpenRead();
+        var defaultPagesPath = Path.Combine(environment.ContentRootPath, "Pages");
+        if (Directory.Exists(defaultPagesPath) && seen.Add(defaultPagesPath))
+        {
+            yield return defaultPagesPath;
         }
     }
 }

--- a/Source/AuthProxy/Invites/InviteMiddleware.cs
+++ b/Source/AuthProxy/Invites/InviteMiddleware.cs
@@ -70,7 +70,7 @@ public class InviteMiddleware(
         // Run this first so authenticated callbacks that return to /invite/{token}
         // do not get re-challenged and end up in a redirect loop.
         if (context.User.Identity?.IsAuthenticated == true
-            && context.Request.Cookies.TryGetValue(Cookies.InviteToken, out var inviteToken))
+            && context.TryGetPendingInvitationToken(out var inviteToken))
         {
             var exchangeSucceeded = await ExchangeInvite(context, inviteToken);
             context.Response.Cookies.Delete(Cookies.InviteToken);
@@ -89,9 +89,8 @@ public class InviteMiddleware(
         }
 
         // ── Phase 1: incoming invite URL ──────────────────────────────────────
-        if (context.Request.Path.StartsWithSegments(InvitePathPrefix, out var remaining))
+        if (context.TryGetInvitationToken(out var token))
         {
-            var token = remaining.Value?.TrimStart('/');
             if (string.IsNullOrEmpty(token))
             {
                 context.Response.StatusCode = StatusCodes.Status400BadRequest;
@@ -150,7 +149,7 @@ public class InviteMiddleware(
             if (providers.Count == 1)
             {
                 var scheme = OidcProviderScheme.FromName(providers[0].Name);
-                var returnUrl = $"{context.Request.Path}{context.Request.QueryString}";
+                var returnUrl = context.GetPathAndQuery();
                 var properties = new AuthenticationProperties { RedirectUri = returnUrl };
                 await context.ChallengeAsync(scheme, properties);
                 return;

--- a/Source/AuthProxy/TenancyMiddleware.cs
+++ b/Source/AuthProxy/TenancyMiddleware.cs
@@ -59,11 +59,9 @@ public class TenancyMiddleware(
             // frontend – unless this is an invite path (handled by InviteMiddleware) or the
             // user already has a pending invite cookie (so the Phase 2 exchange can proceed).
             var lobbyUrl = config.CurrentValue.Invite?.Lobby?.Frontend?.BaseUrl;
-            var isInvitePath = context.Request.Path.StartsWithSegments(WellKnownPaths.InvitePathPrefix);
-            var hasPendingInviteCookie = context.Request.Cookies.ContainsKey(Cookies.InviteToken);
-            var isAuthPath = context.Request.Path.StartsWithSegments(WellKnownPaths.LoginPrefix)
-                || context.Request.Path.StartsWithSegments(WellKnownPaths.LoginPage)
-                || context.Request.Path.StartsWithSegments(WellKnownPaths.Providers);
+            var isInvitePath = context.IsInvitation();
+            var hasPendingInviteCookie = context.HasPendingInvitation();
+            var isAuthPath = context.IsAuthenticationUI();
             if (!string.IsNullOrWhiteSpace(lobbyUrl)
                 && !isInvitePath
                 && !isAuthPath


### PR DESCRIPTION
## Changed
- Centralize AuthProxy invitation and authentication request classification so middleware shares one consistent set of path helpers

## Fixed
- Serve custom page assets from `/_pages` without routing them through the authenticated middleware pipeline
- Inject the page base href before relative assets are declared so custom error pages resolve their CSS and images correctly