### PR TITLE
Add SubHost tenant authentication state and configurable lobby redirect on unresolved tenant

### DIFF
--- a/Documentation/configuration/authentication.md
+++ b/Documentation/configuration/authentication.md
@@ -69,6 +69,27 @@ Each provider generates a dedicated login endpoint at `/.cratis/login/{scheme}`.
 The scheme name is derived from the provider `Name` by lowercasing and replacing spaces with hyphens
 (e.g. `"My Provider"` → `/.cratis/login/my-provider`).
 
+### Tenant-aware authentication state
+
+When authentication starts from a tenant-scoped request, AuthProxy stores tenant resolution metadata in the protected authentication `state` value:
+
+- Tenant ID
+- Tenant resolution strategy
+- Strategy-specific metadata (for `SubHost`, the configured `ParentHost`)
+
+On callback (`/signin-{scheme}`), AuthProxy reads this state and re-applies strategy behavior before finishing sign-in. For `SubHost`, AuthProxy reconstructs the tenant URL and redirects back to that tenant host.
+
+Example flow:
+
+1. Request arrives at `https://some-tenant.cratis.studio/`
+2. AuthProxy resolves tenant `some-tenant` via `SubHost`
+3. Challenge is sent with protected state containing tenant metadata
+4. Provider redirects back to `https://auth.cratis.studio/signin-github?...&state=...`
+5. AuthProxy restores tenant metadata from state
+6. AuthProxy redirects to `https://some-tenant.cratis.studio/` (original return URL preserved)
+
+This allows a common callback endpoint while still restoring tenant-specific behavior after sign-in.
+
 ### OidcProviderConfig properties
 
 | Property | Type | Description |

--- a/Documentation/configuration/tenancy.md
+++ b/Documentation/configuration/tenancy.md
@@ -127,6 +127,12 @@ The resolved subhost string becomes the tenant ID directly.
 **No `Tenants` dictionary lookup is performed** — unlike `Host`, `Claim`, and `Route` strategies, SubHost does not match a source identifier against a pre-configured list.
 This is intentional: SubHost is designed for environments where tenants are provisioned dynamically (for example SaaS platforms where each customer gets their own subdomain).
 
+### SubHost and authentication callbacks
+
+For interactive authentication flows, AuthProxy stores SubHost strategy metadata in protected authentication `state` when it issues the provider challenge. On callback, AuthProxy restores this metadata and redirects to the tenant subhost.
+
+This enables a shared callback endpoint (for example `auth.cratis.studio`) while returning the user to the original tenant host (for example `nova.cratis.studio`).
+
 Because there is no registry lookup to prove the tenant exists, you should configure `VerificationUrlTemplate` to have AuthProxy call your back-end to confirm the tenant is valid before forwarding the request:
 
 ```json

--- a/Source/AuthProxy.Specs/Authentication/for_AuthenticationServiceCollectionExtensions/when_registering_oauth_provider_options.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_AuthenticationServiceCollectionExtensions/when_registering_oauth_provider_options.cs
@@ -39,4 +39,5 @@ public class when_registering_oauth_provider_options : Specification
     [Fact] void should_set_callback_path() => _options.CallbackPath.ToString().ShouldEqual("/signin-github");
     [Fact] void should_include_configured_scope() => _options.Scope.Contains("read:user").ShouldBeTrue();
     [Fact] void should_register_ticket_creation_event() => _options.Events.OnCreatingTicket.ShouldNotBeNull();
+    [Fact] void should_register_ticket_received_event() => _options.Events.OnTicketReceived.ShouldNotBeNull();
 }

--- a/Source/AuthProxy.Specs/Authentication/for_AuthenticationServiceCollectionExtensions/when_registering_oidc_provider_options.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_AuthenticationServiceCollectionExtensions/when_registering_oidc_provider_options.cs
@@ -36,4 +36,5 @@ public class when_registering_oidc_provider_options : Specification
     [Fact] void should_set_callback_path() => _options.CallbackPath.ToString().ShouldEqual("/signin-microsoft");
     [Fact] void should_include_standard_scopes() => _options.Scope.Contains("openid").ShouldBeTrue();
     [Fact] void should_include_custom_scopes() => _options.Scope.Contains("offline_access").ShouldBeTrue();
+    [Fact] void should_configure_ticket_received_event() => _options.Events.OnTicketReceived.ShouldNotBeNull();
 }

--- a/Source/AuthProxy.Specs/Authentication/for_SelectProviderMiddleware/when_invite_cookie_is_present.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_SelectProviderMiddleware/when_invite_cookie_is_present.cs
@@ -28,7 +28,8 @@ public class when_invite_cookie_is_present : Specification
                 return Task.CompletedTask;
             },
             authConfig,
-            Substitute.For<IErrorPageProvider>());
+            Substitute.For<IErrorPageProvider>(),
+            Substitute.For<ITenantResolver>());
 
         _context = new DefaultHttpContext();
         _context.Request.Path = "/";

--- a/Source/AuthProxy.Specs/Authentication/for_SelectProviderMiddleware/when_multiple_providers_are_configured/when_multiple_providers_are_configured.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_SelectProviderMiddleware/when_multiple_providers_are_configured/when_multiple_providers_are_configured.cs
@@ -34,7 +34,8 @@ public class when_multiple_providers_are_configured : Specification
                 return Task.CompletedTask;
             },
             authConfig,
-            _errorPageProvider);
+            _errorPageProvider,
+            Substitute.For<ITenantResolver>());
 
         _context = new DefaultHttpContext();
         _context.Request.Path = "/";

--- a/Source/AuthProxy.Specs/Authentication/for_SelectProviderMiddleware/when_no_providers_are_configured.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_SelectProviderMiddleware/when_no_providers_are_configured.cs
@@ -21,7 +21,8 @@ public class when_no_providers_are_configured : Specification
                 return Task.CompletedTask;
             },
             authConfig,
-            Substitute.For<IErrorPageProvider>());
+            Substitute.For<IErrorPageProvider>(),
+            Substitute.For<ITenantResolver>());
 
         _context = new DefaultHttpContext();
         _context.Request.Path = "/";

--- a/Source/AuthProxy.Specs/Authentication/for_SelectProviderMiddleware/when_path_is_invite_path.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_SelectProviderMiddleware/when_path_is_invite_path.cs
@@ -28,7 +28,8 @@ public class when_path_is_invite_path : Specification
                 return Task.CompletedTask;
             },
             authConfig,
-            Substitute.For<IErrorPageProvider>());
+            Substitute.For<IErrorPageProvider>(),
+            Substitute.For<ITenantResolver>());
 
         _context = new DefaultHttpContext();
         _context.Request.Path = "/invite/some-token";

--- a/Source/AuthProxy.Specs/Authentication/for_SelectProviderMiddleware/when_single_provider_is_configured.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_SelectProviderMiddleware/when_single_provider_is_configured.cs
@@ -27,7 +27,8 @@ public class when_single_provider_is_configured : Specification
                 return Task.CompletedTask;
             },
             authConfig,
-            Substitute.For<IErrorPageProvider>());
+            Substitute.For<IErrorPageProvider>(),
+            Substitute.For<ITenantResolver>());
 
         _context = new DefaultHttpContext();
         _context.Request.Path = "/protected";

--- a/Source/AuthProxy.Specs/Authentication/for_SelectProviderMiddleware/when_user_is_authenticated.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_SelectProviderMiddleware/when_user_is_authenticated.cs
@@ -24,7 +24,8 @@ public class when_user_is_authenticated : Specification
                 return Task.CompletedTask;
             },
             authConfig,
-            Substitute.For<IErrorPageProvider>());
+            Substitute.For<IErrorPageProvider>(),
+            Substitute.For<ITenantResolver>());
 
         _context = new DefaultHttpContext();
         _context.Request.Path = "/";

--- a/Source/AuthProxy.Specs/Authentication/for_TenantAuthenticationState/when_creating_challenge_properties_for_subhost_tenant.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_TenantAuthenticationState/when_creating_challenge_properties_for_subhost_tenant.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.Authentication.for_TenantAuthenticationState;
+
+public class when_creating_challenge_properties_for_subhost_tenant : Specification
+{
+    AuthenticationProperties _properties = default!;
+
+    void Establish()
+    {
+        var context = new DefaultHttpContext();
+        var resolver = new StubTenantResolver(new TenantResolutionResult("nova", C.TenantSourceIdentifierResolverType.SubHost, "cratis.studio"));
+
+        _properties = TenantAuthenticationState.CreateChallengeProperties(context, resolver, "/dashboard");
+    }
+
+    [Fact] void should_set_redirect_uri() => _properties.RedirectUri.ShouldEqual("/dashboard");
+    [Fact] void should_include_tenant_id() => _properties.Items[TenantAuthenticationState.TenantIdStateKey].ShouldEqual("nova");
+    [Fact] void should_include_strategy() => _properties.Items[TenantAuthenticationState.StrategyStateKey].ShouldEqual(nameof(C.TenantSourceIdentifierResolverType.SubHost));
+    [Fact] void should_include_subhost_parent_host() => _properties.Items[TenantAuthenticationState.SubHostParentHostStateKey].ShouldEqual("cratis.studio");
+
+    sealed class StubTenantResolver(TenantResolutionResult resolvedResult) : ITenantResolver
+    {
+        public bool TryResolve(HttpContext context, out string tenantId)
+        {
+            tenantId = resolvedResult.TenantId;
+            return true;
+        }
+
+        public bool TryResolve(HttpContext context, out TenantResolutionResult result)
+        {
+            result = resolvedResult;
+            return true;
+        }
+    }
+}

--- a/Source/AuthProxy.Specs/Authentication/for_TenantAuthenticationState/when_resolving_post_authentication_redirect_for_subhost_tenant.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_TenantAuthenticationState/when_resolving_post_authentication_redirect_for_subhost_tenant.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.Authentication.for_TenantAuthenticationState;
+
+public class when_resolving_post_authentication_redirect_for_subhost_tenant : Specification
+{
+    bool _succeeded;
+    string _redirectUri = string.Empty;
+
+    void Establish()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Scheme = "https";
+        context.Request.Host = new HostString("auth.cratis.studio");
+
+        var properties = new AuthenticationProperties { RedirectUri = "/" };
+        properties.Items[TenantAuthenticationState.TenantIdStateKey] = "nova";
+        properties.Items[TenantAuthenticationState.StrategyStateKey] = nameof(C.TenantSourceIdentifierResolverType.SubHost);
+        properties.Items[TenantAuthenticationState.SubHostParentHostStateKey] = "cratis.studio";
+
+        _succeeded = TenantAuthenticationState.TryResolvePostAuthenticationRedirectUri(
+            context,
+            properties,
+            "/dashboard?tab=home",
+            out _redirectUri);
+    }
+
+    [Fact] void should_succeed() => _succeeded.ShouldBeTrue();
+    [Fact] void should_build_subhost_redirect_uri() => _redirectUri.ShouldEqual("https://nova.cratis.studio/dashboard?tab=home");
+}

--- a/Source/AuthProxy.Specs/Authentication/for_TenantAuthenticationState/when_resolving_post_authentication_redirect_without_tenant_state.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_TenantAuthenticationState/when_resolving_post_authentication_redirect_without_tenant_state.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.Authentication.for_TenantAuthenticationState;
+
+public class when_resolving_post_authentication_redirect_without_tenant_state : Specification
+{
+    bool _succeeded;
+    string _redirectUri = string.Empty;
+
+    void Establish()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Scheme = "https";
+
+        var properties = new AuthenticationProperties { RedirectUri = "/" };
+
+        _succeeded = TenantAuthenticationState.TryResolvePostAuthenticationRedirectUri(
+            context,
+            properties,
+            "/",
+            out _redirectUri);
+    }
+
+    [Fact] void should_not_succeed() => _succeeded.ShouldBeFalse();
+    [Fact] void should_return_empty_redirect_uri() => _redirectUri.ShouldEqual(string.Empty);
+}

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite/and_exchange_call_throws.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite/and_exchange_call_throws.cs
@@ -39,6 +39,7 @@ public class and_exchange_call_throws : Specification
             tokenValidator,
             optionsMonitor,
             CreateEmptyAuthConfig(),
+            Substitute.For<ITenantResolver>(),
             httpClientFactory,
             Substitute.For<IErrorPageProvider>(),
             Substitute.For<ILogger<InviteMiddleware>>());

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite/and_exchange_returns_non_success_status.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite/and_exchange_returns_non_success_status.cs
@@ -42,6 +42,7 @@ public class and_exchange_returns_non_success_status : Specification
             tokenValidator,
             optionsMonitor,
             CreateEmptyAuthConfig(),
+            Substitute.For<ITenantResolver>(),
             httpClientFactory,
             Substitute.For<IErrorPageProvider>(),
             Substitute.For<ILogger<InviteMiddleware>>());

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite/and_exchange_url_is_missing.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite/and_exchange_url_is_missing.cs
@@ -32,6 +32,7 @@ public class and_exchange_url_is_missing : Specification
             tokenValidator,
             optionsMonitor,
             CreateEmptyAuthConfig(),
+            Substitute.For<ITenantResolver>(),
             _httpClientFactory,
             Substitute.For<IErrorPageProvider>(),
             Substitute.For<ILogger<InviteMiddleware>>());

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite/and_lobby_is_configured.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite/and_lobby_is_configured.cs
@@ -44,6 +44,7 @@ public class and_lobby_is_configured : Specification
             tokenValidator,
             optionsMonitor,
             CreateEmptyAuthConfig(),
+            Substitute.For<ITenantResolver>(),
             httpClientFactory,
             Substitute.For<IErrorPageProvider>(),
             Substitute.For<ILogger<InviteMiddleware>>());

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite/and_lobby_query_append_is_enabled.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite/and_lobby_query_append_is_enabled.cs
@@ -49,6 +49,7 @@ public class and_lobby_query_append_is_enabled : Specification
             tokenValidator,
             optionsMonitor,
             CreateEmptyAuthConfig(),
+            Substitute.For<ITenantResolver>(),
             httpClientFactory,
             Substitute.For<IErrorPageProvider>(),
             Substitute.For<ILogger<InviteMiddleware>>());

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite/and_lobby_url_already_has_query.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite/and_lobby_url_already_has_query.cs
@@ -49,6 +49,7 @@ public class and_lobby_url_already_has_query : Specification
             tokenValidator,
             optionsMonitor,
             CreateEmptyAuthConfig(),
+            Substitute.For<ITenantResolver>(),
             httpClientFactory,
             Substitute.For<IErrorPageProvider>(),
             Substitute.For<ILogger<InviteMiddleware>>());

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite/when_authenticated_user_has_pending_invite.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite/when_authenticated_user_has_pending_invite.cs
@@ -35,6 +35,7 @@ public class when_authenticated_user_has_pending_invite : Specification
             tokenValidator,
             optionsMonitor,
             CreateEmptyAuthConfig(),
+            Substitute.For<ITenantResolver>(),
             httpClientFactory,
             Substitute.For<IErrorPageProvider>(),
             Substitute.For<ILogger<InviteMiddleware>>());

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite_with_fallback_claims.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite_with_fallback_claims.cs
@@ -37,6 +37,7 @@ public class when_authenticated_user_has_pending_invite_with_fallback_claims : S
             tokenValidator,
             optionsMonitor,
             CreateEmptyAuthConfig(),
+            Substitute.For<ITenantResolver>(),
             httpClientFactory,
             Substitute.For<IErrorPageProvider>(),
             Substitute.For<ILogger<InviteMiddleware>>());

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_tenant_invite/and_tenant_does_not_match.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_tenant_invite/and_tenant_does_not_match.cs
@@ -54,6 +54,7 @@ public class and_tenant_does_not_match : Specification
             tokenValidator,
             optionsMonitor,
             CreateEmptyAuthConfig(),
+            Substitute.For<ITenantResolver>(),
             httpClientFactory,
             Substitute.For<IErrorPageProvider>(),
             Substitute.For<ILogger<InviteMiddleware>>());

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_tenant_invite/and_tenant_matches.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_tenant_invite/and_tenant_matches.cs
@@ -53,6 +53,7 @@ public class and_tenant_matches : Specification
             tokenValidator,
             optionsMonitor,
             CreateEmptyAuthConfig(),
+            Substitute.For<ITenantResolver>(),
             httpClientFactory,
             Substitute.For<IErrorPageProvider>(),
             Substitute.For<ILogger<InviteMiddleware>>());

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_returns_to_invite_path_with_pending_invite.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_returns_to_invite_path_with_pending_invite.cs
@@ -38,6 +38,7 @@ public class when_authenticated_user_returns_to_invite_path_with_pending_invite 
             tokenValidator,
             optionsMonitor,
             authConfig,
+            Substitute.For<ITenantResolver>(),
             httpClientFactory,
             Substitute.For<IErrorPageProvider>(),
             Substitute.For<ILogger<InviteMiddleware>>());

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_expired_invite_token_is_presented.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_expired_invite_token_is_presented.cs
@@ -30,6 +30,7 @@ public class when_expired_invite_token_is_presented : Specification
             tokenValidator,
             optionsMonitor,
             CreateEmptyAuthConfig(),
+            Substitute.For<ITenantResolver>(),
             Substitute.For<IHttpClientFactory>(),
             _errorPageProvider,
             Substitute.For<ILogger<InviteMiddleware>>());

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_invalid_invite_token_is_presented.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_invalid_invite_token_is_presented.cs
@@ -30,6 +30,7 @@ public class when_invalid_invite_token_is_presented : Specification
             tokenValidator,
             optionsMonitor,
             CreateEmptyAuthConfig(),
+            Substitute.For<ITenantResolver>(),
             Substitute.For<IHttpClientFactory>(),
             _errorPageProvider,
             Substitute.For<ILogger<InviteMiddleware>>());

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_invite_path_is_missing_token.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_invite_path_is_missing_token.cs
@@ -15,6 +15,7 @@ public class when_invite_path_is_missing_token : Specification
             Substitute.For<IInviteTokenValidator>(),
             CreateAuthProxyConfig(),
             CreateAuthConfig(),
+            Substitute.For<ITenantResolver>(),
             Substitute.For<IHttpClientFactory>(),
             Substitute.For<IErrorPageProvider>(),
             Substitute.For<ILogger<InviteMiddleware>>());

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_valid_invite_token_is_presented/and_no_providers_are_configured.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_valid_invite_token_is_presented/and_no_providers_are_configured.cs
@@ -35,6 +35,7 @@ public class and_no_providers_are_configured : Specification
             tokenValidator,
             optionsMonitor,
             authConfigMonitor,
+            Substitute.For<ITenantResolver>(),
             Substitute.For<IHttpClientFactory>(),
             Substitute.For<IErrorPageProvider>(),
             Substitute.For<ILogger<InviteMiddleware>>());

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_valid_invite_token_is_presented/when_valid_invite_token_is_presented.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_valid_invite_token_is_presented/when_valid_invite_token_is_presented.cs
@@ -31,6 +31,7 @@ public class when_valid_invite_token_is_presented : Specification
             tokenValidator,
             optionsMonitor,
             CreateSingleProviderAuthConfig(),
+            Substitute.For<ITenantResolver>(),
             Substitute.For<IHttpClientFactory>(),
             Substitute.For<IErrorPageProvider>(),
             Substitute.For<ILogger<InviteMiddleware>>());

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_valid_invite_token_is_presented_with_multiple_providers.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_valid_invite_token_is_presented_with_multiple_providers.cs
@@ -44,6 +44,7 @@ public class when_valid_invite_token_is_presented_with_multiple_providers : Spec
             tokenValidator,
             optionsMonitor,
             authConfigMonitor,
+            Substitute.For<ITenantResolver>(),
             Substitute.For<IHttpClientFactory>(),
             _errorPageProvider,
             Substitute.For<ILogger<InviteMiddleware>>());

--- a/Source/AuthProxy.Specs/Scenarios/when_subhost_login_is_challenged/AuthProxyFactory.cs
+++ b/Source/AuthProxy.Specs/Scenarios/when_subhost_login_is_challenged/AuthProxyFactory.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.AuthProxy.Scenarios.when_subhost_login_is_challenged;
+
+/// <summary>
+/// WebApplicationFactory that configures a single OAuth provider and SubHost tenant resolution
+/// so the challenge state can be validated end-to-end.
+/// </summary>
+public class AuthProxyFactory : WebApplicationFactory<Program>
+{
+    /// <summary>The parent host configured for SubHost tenant resolution.</summary>
+    public const string ParentHost = "cratis.studio";
+
+    /// <summary>The provider scheme derived from configured provider name.</summary>
+    public const string ProviderScheme = "github";
+
+    /// <summary>Gets the last scheme used in a captured challenge call.</summary>
+    public string? CapturedScheme => _captureService.CapturedScheme;
+
+    /// <summary>Gets the last authentication properties used in a captured challenge call.</summary>
+    public AuthenticationProperties? CapturedProperties => _captureService.CapturedProperties;
+
+    readonly ChallengeCaptureAuthenticationService _captureService = new();
+
+    /// <inheritdoc/>
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureAppConfiguration((_, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"{C.AuthProxy.SectionKey}:TenantResolutions:0:Strategy"] = nameof(C.TenantSourceIdentifierResolverType.SubHost),
+                [$"{C.AuthProxy.SectionKey}:TenantResolutions:0:Options:ParentHost"] = ParentHost,
+
+                [$"{C.Authentication.SectionKey}:OAuthProviders:0:Name"] = "GitHub",
+                [$"{C.Authentication.SectionKey}:OAuthProviders:0:AuthorizationEndpoint"] = "https://github.com/login/oauth/authorize",
+                [$"{C.Authentication.SectionKey}:OAuthProviders:0:TokenEndpoint"] = "https://github.com/login/oauth/access_token",
+                [$"{C.Authentication.SectionKey}:OAuthProviders:0:UserInformationEndpoint"] = "https://api.github.com/user",
+                [$"{C.Authentication.SectionKey}:OAuthProviders:0:ClientId"] = "client-id",
+                [$"{C.Authentication.SectionKey}:OAuthProviders:0:ClientSecret"] = "client-secret",
+                [$"{C.Authentication.SectionKey}:OAuthProviders:0:Scopes:0"] = "read:user",
+            });
+        });
+
+        builder.ConfigureTestServices(services => services.AddSingleton<IAuthenticationService>(_captureService));
+    }
+
+    /// <summary>Creates a test HTTP client that does not follow redirects.</summary>
+    /// <returns>A configured <see cref="HttpClient"/> that does not follow redirects.</returns>
+    public HttpClient CreateTestClient() =>
+        CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+    sealed class ChallengeCaptureAuthenticationService : IAuthenticationService
+    {
+        public string? CapturedScheme { get; private set; }
+
+        public AuthenticationProperties? CapturedProperties { get; private set; }
+
+        public Task<AuthenticateResult> AuthenticateAsync(HttpContext context, string? scheme) =>
+            Task.FromResult(AuthenticateResult.NoResult());
+
+        public Task ChallengeAsync(HttpContext context, string? scheme, AuthenticationProperties? properties)
+        {
+            CapturedScheme = scheme;
+            CapturedProperties = properties;
+            context.Response.StatusCode = StatusCodes.Status302Found;
+            context.Response.Headers.Location = "https://example.test/oauth/authorize";
+            return Task.CompletedTask;
+        }
+
+        public Task ForbidAsync(HttpContext context, string? scheme, AuthenticationProperties? properties)
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            return Task.CompletedTask;
+        }
+
+        public Task SignInAsync(HttpContext context, string? scheme, ClaimsPrincipal principal, AuthenticationProperties? properties) =>
+            Task.CompletedTask;
+
+        public Task SignOutAsync(HttpContext context, string? scheme, AuthenticationProperties? properties) =>
+            Task.CompletedTask;
+    }
+}

--- a/Source/AuthProxy.Specs/Scenarios/when_subhost_login_is_challenged/and_login_endpoint_is_requested.cs
+++ b/Source/AuthProxy.Specs/Scenarios/when_subhost_login_is_challenged/and_login_endpoint_is_requested.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Authentication;
+
+namespace Cratis.AuthProxy.Scenarios.when_subhost_login_is_challenged;
+
+/// <summary>
+/// End-to-end scenario: when login is initiated from a subhost tenant request, the emitted
+/// OAuth state contains tenant and strategy metadata.
+/// </summary>
+/// <param name="factory">The shared application factory.</param>
+public class and_login_endpoint_is_requested(AuthProxyFactory factory) : IClassFixture<AuthProxyFactory>, IAsyncLifetime
+{
+    HttpResponseMessage? _response;
+
+    public async Task InitializeAsync()
+    {
+        using var client = factory.CreateTestClient();
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"/.cratis/login/{AuthProxyFactory.ProviderScheme}?returnUrl=%2Fdashboard");
+        request.Headers.Host = "nova.cratis.studio";
+
+        _response = await client.SendAsync(request);
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact] public void should_redirect_to_authorization_endpoint() => Assert.Equal(System.Net.HttpStatusCode.Redirect, _response!.StatusCode);
+
+    [Fact] public void should_challenge_with_provider_scheme() => Assert.Equal(AuthProxyFactory.ProviderScheme, factory.CapturedScheme);
+
+    [Fact]
+    public void should_capture_return_url_as_redirect_uri() =>
+        Assert.Equal("/dashboard", factory.CapturedProperties!.RedirectUri);
+
+    [Fact]
+    public void should_include_tenant_id_in_state() =>
+        Assert.Equal("nova", factory.CapturedProperties!.Items[TenantAuthenticationState.TenantIdStateKey]);
+
+    [Fact]
+    public void should_include_subhost_strategy_in_state() =>
+        Assert.Equal(nameof(C.TenantSourceIdentifierResolverType.SubHost), factory.CapturedProperties!.Items[TenantAuthenticationState.StrategyStateKey]);
+
+    [Fact]
+    public void should_include_subhost_parent_host_in_state() =>
+        Assert.Equal(AuthProxyFactory.ParentHost, factory.CapturedProperties!.Items[TenantAuthenticationState.SubHostParentHostStateKey]);
+}

--- a/Source/AuthProxy.Specs/for_TenancyMiddleware/when_tenant_resolution_fails/and_lobby_redirect_on_unresolved_tenant_is_enabled.cs
+++ b/Source/AuthProxy.Specs/for_TenancyMiddleware/when_tenant_resolution_fails/and_lobby_redirect_on_unresolved_tenant_is_enabled.cs
@@ -3,7 +3,7 @@
 
 namespace Cratis.AuthProxy.for_TenancyMiddleware.when_tenant_resolution_fails;
 
-public class and_lobby_is_configured : Specification
+public class and_lobby_redirect_on_unresolved_tenant_is_enabled : Specification
 {
     const string LobbyUrl = "http://lobby-service/";
 
@@ -21,6 +21,7 @@ public class and_lobby_is_configured : Specification
             ],
             Invite = new C.Invite
             {
+                RedirectToLobbyWhenTenantUnresolved = true,
                 Lobby = new C.Service
                 {
                     Frontend = new C.ServiceEndpoint { BaseUrl = LobbyUrl }
@@ -52,6 +53,5 @@ public class and_lobby_is_configured : Specification
     async Task Because() => await _middleware.InvokeAsync(_context);
 
     [Fact] void should_not_call_next() => _nextCalled.ShouldBeFalse();
-    [Fact] void should_not_redirect_to_lobby() => _context.Response.Headers.Location.ToString().ShouldEqual(string.Empty);
-    [Fact] void should_return_401() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status401Unauthorized);
+    [Fact] void should_redirect_to_lobby() => _context.Response.Headers.Location.ToString().ShouldEqual(LobbyUrl);
 }

--- a/Source/AuthProxy/Authentication/AuthenticationServiceCollectionExtensions.cs
+++ b/Source/AuthProxy/Authentication/AuthenticationServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authentication.OAuth;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.Options;
 using C = Cratis.AuthProxy.Configuration;
 
@@ -126,6 +127,24 @@ public static class AuthenticationServiceCollectionExtensions
                 options.CorrelationCookie.SecurePolicy = CookieSecurePolicy.None;
                 options.NonceCookie.SameSite = SameSiteMode.Lax;
                 options.NonceCookie.SecurePolicy = CookieSecurePolicy.None;
+
+                options.Events = new OpenIdConnectEvents
+                {
+                    OnTicketReceived = context =>
+                    {
+                        if (context.Properties is not null
+                            && TenantAuthenticationState.TryResolvePostAuthenticationRedirectUri(
+                                context.HttpContext,
+                                context.Properties,
+                                context.ReturnUri,
+                                out var redirectUri))
+                        {
+                            context.ReturnUri = redirectUri;
+                        }
+
+                        return Task.CompletedTask;
+                    }
+                };
             });
         }
     }
@@ -176,6 +195,20 @@ public static class AuthenticationServiceCollectionExtensions
                         using var user = JsonDocument.Parse(
                             await response.Content.ReadAsStringAsync(ctx.HttpContext.RequestAborted));
                         ctx.RunClaimActions(user.RootElement);
+                    },
+                    OnTicketReceived = context =>
+                    {
+                        if (context.Properties is not null
+                            && TenantAuthenticationState.TryResolvePostAuthenticationRedirectUri(
+                                context.HttpContext,
+                                context.Properties,
+                                context.ReturnUri,
+                                out var redirectUri))
+                        {
+                            context.ReturnUri = redirectUri;
+                        }
+
+                        return Task.CompletedTask;
                     }
                 };
             });

--- a/Source/AuthProxy/Authentication/SelectProviderMiddleware.cs
+++ b/Source/AuthProxy/Authentication/SelectProviderMiddleware.cs
@@ -17,10 +17,12 @@ namespace Cratis.AuthProxy.Authentication;
 /// <param name="next">The next middleware in the pipeline.</param>
 /// <param name="authConfig">The authentication configuration monitor.</param>
 /// <param name="errorPageProvider">The error page provider used to serve the selection page.</param>
+/// <param name="tenantResolver">The tenant resolver used to capture tenant metadata in authentication state.</param>
 public class SelectProviderMiddleware(
     RequestDelegate next,
     IOptionsMonitor<C.Authentication> authConfig,
-    IErrorPageProvider errorPageProvider)
+    IErrorPageProvider errorPageProvider,
+    ITenantResolver tenantResolver)
 {
     static readonly JsonSerializerOptions _serializerOptions = new()
     {
@@ -67,7 +69,7 @@ public class SelectProviderMiddleware(
         {
             var scheme = OidcProviderScheme.FromName(providers[0].Name);
             var returnUrl = context.GetPathAndQuery();
-            var properties = new AuthenticationProperties { RedirectUri = returnUrl };
+            var properties = TenantAuthenticationState.CreateChallengeProperties(context, tenantResolver, returnUrl);
             await context.ChallengeAsync(scheme, properties);
             return;
         }

--- a/Source/AuthProxy/Authentication/TenantAuthenticationState.cs
+++ b/Source/AuthProxy/Authentication/TenantAuthenticationState.cs
@@ -1,0 +1,160 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+using C = Cratis.AuthProxy.Configuration;
+
+namespace Cratis.AuthProxy.Authentication;
+
+/// <summary>
+/// Encapsulates tenant resolution metadata that is round-tripped through authentication state.
+/// </summary>
+public static class TenantAuthenticationState
+{
+    /// <summary>Authentication state key for the tenant ID.</summary>
+    public const string TenantIdStateKey = "Cratis.AuthProxy.TenantId";
+
+    /// <summary>Authentication state key for the tenant resolution strategy.</summary>
+    public const string StrategyStateKey = "Cratis.AuthProxy.TenantStrategy";
+
+    /// <summary>Authentication state key for the SubHost parent host.</summary>
+    public const string SubHostParentHostStateKey = "Cratis.AuthProxy.SubHostParentHost";
+
+    /// <summary>
+    /// Creates challenge properties and, when a tenant can be resolved, stores tenant metadata in state.
+    /// </summary>
+    /// <param name="context">The current HTTP context.</param>
+    /// <param name="tenantResolver">The tenant resolver used to capture tenant metadata.</param>
+    /// <param name="returnUrl">The return URL to use after successful authentication.</param>
+    /// <returns>An <see cref="AuthenticationProperties"/> initialized for the challenge.</returns>
+    public static AuthenticationProperties CreateChallengeProperties(HttpContext context, ITenantResolver tenantResolver, string returnUrl)
+    {
+        var properties = new AuthenticationProperties
+        {
+            RedirectUri = NormalizeReturnUrl(returnUrl)
+        };
+
+        if (!tenantResolver.TryResolve(context, out TenantResolutionResult result)
+            || string.IsNullOrWhiteSpace(result.TenantId))
+        {
+            return properties;
+        }
+
+        properties.Items[TenantIdStateKey] = result.TenantId;
+        properties.Items[StrategyStateKey] = result.Strategy.ToString();
+
+        if (result.Strategy == C.TenantSourceIdentifierResolverType.SubHost
+            && !string.IsNullOrWhiteSpace(result.SubHostParentHost))
+        {
+            properties.Items[SubHostParentHostStateKey] = result.SubHostParentHost.Trim().TrimStart('.');
+        }
+
+        return properties;
+    }
+
+    /// <summary>
+    /// Tries to resolve a post-authentication redirect URI from tenant metadata in state.
+    /// </summary>
+    /// <param name="context">The current HTTP context.</param>
+    /// <param name="properties">The round-tripped authentication properties.</param>
+    /// <param name="currentReturnUri">The current handler return URI.</param>
+    /// <param name="redirectUri">The resolved redirect URI when successful.</param>
+    /// <returns><see langword="true"/> if a redirect URI was resolved; otherwise <see langword="false"/>.</returns>
+    public static bool TryResolvePostAuthenticationRedirectUri(
+        HttpContext context,
+        AuthenticationProperties properties,
+        string? currentReturnUri,
+        out string redirectUri)
+    {
+        redirectUri = string.Empty;
+
+        if (!properties.Items.TryGetValue(TenantIdStateKey, out var tenantId)
+            || string.IsNullOrWhiteSpace(tenantId)
+            || !properties.Items.TryGetValue(StrategyStateKey, out var strategyText)
+            || !Enum.TryParse<C.TenantSourceIdentifierResolverType>(strategyText, true, out var strategy))
+        {
+            return false;
+        }
+
+        var returnUrl = NormalizeReturnUrl(currentReturnUri ?? properties.RedirectUri ?? "/");
+
+        if (strategy == C.TenantSourceIdentifierResolverType.SubHost)
+        {
+            if (!properties.Items.TryGetValue(SubHostParentHostStateKey, out var parentHost)
+                || string.IsNullOrWhiteSpace(parentHost))
+            {
+                return false;
+            }
+
+            var normalizedParentHost = parentHost.Trim().TrimStart('.');
+            if (!IsValidHostLabel(tenantId) || string.IsNullOrWhiteSpace(normalizedParentHost))
+            {
+                return false;
+            }
+
+            var targetHost = $"{tenantId}.{normalizedParentHost}";
+            redirectUri = BuildAbsoluteRedirectUri(context.Request.Scheme, targetHost, returnUrl);
+            return true;
+        }
+
+        return false;
+    }
+
+    static string NormalizeReturnUrl(string? returnUrl)
+    {
+        if (string.IsNullOrWhiteSpace(returnUrl))
+        {
+            return "/";
+        }
+
+        if (returnUrl.StartsWith('/'))
+        {
+            return returnUrl;
+        }
+
+        if (Uri.TryCreate(returnUrl, UriKind.Absolute, out var absoluteUri))
+        {
+            return $"{absoluteUri.AbsolutePath}{absoluteUri.Query}";
+        }
+
+        return $"/{returnUrl}";
+    }
+
+    static string BuildAbsoluteRedirectUri(string scheme, string host, string returnUrl)
+    {
+        var queryStart = returnUrl.IndexOf('?');
+        var path = queryStart >= 0 ? returnUrl[..queryStart] : returnUrl;
+        var query = queryStart >= 0 ? returnUrl[(queryStart + 1)..] : string.Empty;
+
+        var builder = new UriBuilder(scheme, host)
+        {
+            Path = string.IsNullOrWhiteSpace(path) ? "/" : path,
+            Query = query,
+        };
+
+        return builder.Uri.ToString();
+    }
+
+    static bool IsValidHostLabel(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        if (value.StartsWith('-') || value.EndsWith('-'))
+        {
+            return false;
+        }
+
+        foreach (var character in value)
+        {
+            if (!char.IsLetterOrDigit(character) && character != '-')
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/Source/AuthProxy/Configuration/Invite.cs
+++ b/Source/AuthProxy/Configuration/Invite.cs
@@ -54,6 +54,13 @@ public class Invite
     public string InvitationIdQueryStringKey { get; set; } = "invitationId";
 
     /// <summary>
+    /// Gets or sets a value indicating whether unresolved-tenant requests should redirect to the lobby frontend.
+    /// Defaults to <see langword="false"/> so unresolved tenants stay in the current proxy and receive
+    /// the proxy's local response behavior.
+    /// </summary>
+    public bool RedirectToLobbyWhenTenantUnresolved { get; set; }
+
+    /// <summary>
     /// Gets or sets claim mappings to forward values from the invite token into
     /// the principal sent to the identity details provider.
     /// This allows invite claims and identity-provider claims to be combined in a configurable way.

--- a/Source/AuthProxy/ITenantResolver.cs
+++ b/Source/AuthProxy/ITenantResolver.cs
@@ -15,4 +15,12 @@ public interface ITenantResolver
     /// <param name="tenantId">The resolved tenant ID, or an empty string when unresolved.</param>
     /// <returns><see langword="true"/> if a tenant was resolved; otherwise <see langword="false"/>.</returns>
     bool TryResolve(HttpContext context, out string tenantId);
+
+    /// <summary>
+    /// Tries to resolve tenant metadata from the current request.
+    /// </summary>
+    /// <param name="context">The current <see cref="HttpContext"/>.</param>
+    /// <param name="result">The full tenant resolution result when a tenant was resolved.</param>
+    /// <returns><see langword="true"/> if a tenant was resolved; otherwise <see langword="false"/>.</returns>
+    bool TryResolve(HttpContext context, out TenantResolutionResult result);
 }

--- a/Source/AuthProxy/IngressExtensions.cs
+++ b/Source/AuthProxy/IngressExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.AuthProxy.Authentication;
 using Cratis.AuthProxy.ErrorPages;
 using Cratis.AuthProxy.Identity;
 using Cratis.AuthProxy.Invites;
@@ -98,7 +99,7 @@ public static class IngressExtensions
             .AllowAnonymous();
 
         // Initiates the challenge for the requested provider scheme.
-        app.MapGet($"{WellKnownPaths.LoginPrefix}/{{scheme}}", async (string scheme, HttpContext context, IOptionsMonitor<C.Authentication> authConfig) =>
+        app.MapGet($"{WellKnownPaths.LoginPrefix}/{{scheme}}", async (string scheme, HttpContext context, IOptionsMonitor<C.Authentication> authConfig, ITenantResolver tenantResolver) =>
         {
             var config = authConfig.CurrentValue;
             var providerExists = config.OidcProviders.Any(p => OidcProviderScheme.FromName(p.Name) == scheme)
@@ -112,12 +113,12 @@ public static class IngressExtensions
             }
 
             var returnUrl = context.Request.Query["returnUrl"].FirstOrDefault() ?? "/";
-            var properties = new AuthenticationProperties { RedirectUri = returnUrl };
+            var properties = TenantAuthenticationState.CreateChallengeProperties(context, tenantResolver, returnUrl);
             await context.ChallengeAsync(scheme, properties);
         })
         .AllowAnonymous();
 
-        app.MapMethods($"{WellKnownPaths.LoginPrefix}/{{scheme}}", [HttpMethods.Head], async (string scheme, HttpContext context, IOptionsMonitor<C.Authentication> authConfig) =>
+        app.MapMethods($"{WellKnownPaths.LoginPrefix}/{{scheme}}", [HttpMethods.Head], async (string scheme, HttpContext context, IOptionsMonitor<C.Authentication> authConfig, ITenantResolver tenantResolver) =>
         {
             var config = authConfig.CurrentValue;
             var providerExists = config.OidcProviders.Any(p => OidcProviderScheme.FromName(p.Name) == scheme)
@@ -130,7 +131,7 @@ public static class IngressExtensions
             }
 
             var returnUrl = context.Request.Query["returnUrl"].FirstOrDefault() ?? "/";
-            var properties = new AuthenticationProperties { RedirectUri = returnUrl };
+            var properties = TenantAuthenticationState.CreateChallengeProperties(context, tenantResolver, returnUrl);
             await context.ChallengeAsync(scheme, properties);
         })
         .AllowAnonymous();

--- a/Source/AuthProxy/Invites/InviteMiddleware.cs
+++ b/Source/AuthProxy/Invites/InviteMiddleware.cs
@@ -3,6 +3,7 @@
 
 using System.Net.Http.Headers;
 using System.Security.Claims;
+using Cratis.AuthProxy.Authentication;
 using Cratis.AuthProxy.ErrorPages;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Options;
@@ -35,6 +36,7 @@ namespace Cratis.AuthProxy.Invites;
 /// <param name="tokenValidator">The validator for invite JWT tokens.</param>
 /// <param name="config">The auth proxy configuration monitor.</param>
 /// <param name="authConfig">The authentication configuration monitor, used to determine how many providers are available.</param>
+/// <param name="tenantResolver">The tenant resolver used to capture tenant metadata in authentication state.</param>
 /// <param name="httpClientFactory">The HTTP client factory used for the exchange call.</param>
 /// <param name="errorPageProvider">The error page provider used to serve custom error pages.</param>
 /// <param name="logger">The logger.</param>
@@ -43,6 +45,7 @@ public class InviteMiddleware(
     IInviteTokenValidator tokenValidator,
     IOptionsMonitor<C.AuthProxy> config,
     IOptionsMonitor<C.Authentication> authConfig,
+    ITenantResolver tenantResolver,
     IHttpClientFactory httpClientFactory,
     IErrorPageProvider errorPageProvider,
     ILogger<InviteMiddleware> logger)
@@ -150,7 +153,7 @@ public class InviteMiddleware(
             {
                 var scheme = OidcProviderScheme.FromName(providers[0].Name);
                 var returnUrl = context.GetPathAndQuery();
-                var properties = new AuthenticationProperties { RedirectUri = returnUrl };
+                var properties = TenantAuthenticationState.CreateChallengeProperties(context, tenantResolver, returnUrl);
                 await context.ChallengeAsync(scheme, properties);
                 return;
             }

--- a/Source/AuthProxy/TenancyMiddleware.cs
+++ b/Source/AuthProxy/TenancyMiddleware.cs
@@ -53,16 +53,18 @@ public class TenancyMiddleware(
         context.Request.Headers.Remove(Headers.TenantId);
 
         // 2. Resolve tenant.
-        if (!tenantResolver.TryResolve(context, out var tenantId))
+        if (!tenantResolver.TryResolve(context, out string tenantId))
         {
             // If a lobby is configured, redirect users without a resolved tenant to the lobby
             // frontend – unless this is an invite path (handled by InviteMiddleware) or the
             // user already has a pending invite cookie (so the Phase 2 exchange can proceed).
             var lobbyUrl = config.CurrentValue.Invite?.Lobby?.Frontend?.BaseUrl;
+            var shouldRedirectToLobby = config.CurrentValue.Invite?.RedirectToLobbyWhenTenantUnresolved == true;
             var isInvitePath = context.IsInvitation();
             var hasPendingInviteCookie = context.HasPendingInvitation();
             var isAuthPath = context.IsAuthenticationUI();
-            if (!string.IsNullOrWhiteSpace(lobbyUrl)
+            if (shouldRedirectToLobby
+                && !string.IsNullOrWhiteSpace(lobbyUrl)
                 && !isInvitePath
                 && !isAuthPath
                 && !hasPendingInviteCookie)

--- a/Source/AuthProxy/TenantResolutionResult.cs
+++ b/Source/AuthProxy/TenantResolutionResult.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using C = Cratis.AuthProxy.Configuration;
+
+namespace Cratis.AuthProxy;
+
+/// <summary>
+/// Represents the tenant resolution outcome for a request, including the strategy
+/// that produced the tenant and any strategy-specific metadata.
+/// </summary>
+/// <param name="TenantId">The resolved tenant ID.</param>
+/// <param name="Strategy">The strategy that resolved the tenant.</param>
+/// <param name="SubHostParentHost">The configured parent host when the SubHost strategy resolved the tenant.</param>
+public sealed record TenantResolutionResult(
+    string TenantId,
+    C.TenantSourceIdentifierResolverType Strategy,
+    string? SubHostParentHost = null);

--- a/Source/AuthProxy/TenantResolver.cs
+++ b/Source/AuthProxy/TenantResolver.cs
@@ -25,13 +25,23 @@ public class TenantResolver(
     /// <inheritdoc/>
     public bool TryResolve(HttpContext context, out string tenantId)
     {
-        tenantId = string.Empty;
+        var resolved = TryResolve(context, out TenantResolutionResult result);
+        tenantId = result.TenantId;
+        return resolved;
+    }
+
+    /// <inheritdoc/>
+    public bool TryResolve(HttpContext context, out TenantResolutionResult result)
+    {
+        var tenantId = string.Empty;
+        result = new TenantResolutionResult(string.Empty, Type.None);
         context.Items.Remove(TenancyMiddleware.TenantVerificationUrlTemplateItemKey);
         var resolutions = config.CurrentValue.TenantResolutions;
 
         if (resolutions.Count == 0)
         {
             // No resolution configured – treat as single-tenant with empty tenant ID.
+            result = new TenantResolutionResult(string.Empty, Type.None);
             return true;
         }
 
@@ -55,6 +65,7 @@ public class TenantResolver(
 
                 if (HandleResolvedSourceIdentifier(resolution.Strategy, sourceIdentifier, out tenantId, config.CurrentValue))
                 {
+                    result = new TenantResolutionResult(tenantId, resolution.Strategy);
                     return true;
                 }
             }
@@ -71,6 +82,7 @@ public class TenantResolver(
 
                 if (HandleResolvedSourceIdentifier(resolution.Strategy, sourceIdentifier, out tenantId, config.CurrentValue))
                 {
+                    result = new TenantResolutionResult(tenantId, resolution.Strategy);
                     return true;
                 }
             }
@@ -87,6 +99,7 @@ public class TenantResolver(
 
                 if (HandleResolvedSourceIdentifier(resolution.Strategy, sourceIdentifier, out tenantId, config.CurrentValue))
                 {
+                    result = new TenantResolutionResult(tenantId, resolution.Strategy);
                     return true;
                 }
             }
@@ -101,6 +114,7 @@ public class TenantResolver(
 
                 if (HandleResolvedSourceIdentifier(resolution.Strategy, sourceIdentifier, out tenantId, config.CurrentValue))
                 {
+                    result = new TenantResolutionResult(tenantId, resolution.Strategy);
                     return true;
                 }
             }
@@ -120,6 +134,7 @@ public class TenantResolver(
                         context.Items[TenancyMiddleware.TenantVerificationUrlTemplateItemKey] = subHostOptions.VerificationUrlTemplate;
                     }
 
+                    result = new TenantResolutionResult(tenantId, resolution.Strategy, subHostOptions.ParentHost);
                     return true;
                 }
             }
@@ -133,6 +148,7 @@ public class TenantResolver(
 
                 if (HandleResolvedSourceIdentifier(resolution.Strategy, sourceIdentifier, out tenantId, config.CurrentValue))
                 {
+                    result = new TenantResolutionResult(tenantId, resolution.Strategy);
                     return true;
                 }
             }


### PR DESCRIPTION
## Added

- `TenantResolutionResult` record to carry tenant identity, strategy, and SubHost parent host through the system without stringing values.
- `TenantAuthenticationState` helper that stamps tenant metadata into OAuth/OIDC `AuthenticationProperties` at challenge time and reconstructs the correct SubHost redirect URI in the `OnTicketReceived` callback.
- `RedirectToLobbyWhenTenantUnresolved` configuration option on `Invite` (defaults to `false`), making the lobby redirect opt-in rather than unconditional.
- Unit specs for `TenantAuthenticationState` covering challenge property creation and post-authentication redirect resolution.
- End-to-end scenario `when_subhost_login_is_challenged` asserting tenant metadata is correctly stamped into authentication state.
- Spec for `TenancyMiddleware` asserting the lobby redirect only fires when the flag is enabled.

## Changed

- `ITenantResolver` extended with a `TryResolve` overload returning the full `TenantResolutionResult`.
- All challenge paths (`IngressExtensions`, `SelectProviderMiddleware`, `InviteMiddleware`) now use `TenantAuthenticationState.CreateChallengeProperties` to stamp tenant state.
- `AuthenticationServiceCollectionExtensions` registers `OnTicketReceived` handlers for both OIDC and OAuth providers to reconstruct the SubHost return URL from state on callback.