### PR TITLE
Fix frontend build output path (Ingress → AuthProxy)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,6 +81,7 @@ jobs:
           path: ./Source/AuthProxy/wwwroot
           retention-days: 1
           include-hidden-files: true
+          if-no-files-found: error
 
   dotnet-publish:
     if: needs.release.outputs.publish == 'true'

--- a/Source/Web/vite.config.ts
+++ b/Source/Web/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
         tailwindcss(),
     ],
     build: {
-        outDir: '../Ingress/wwwroot',
+        outDir: '../AuthProxy/wwwroot',
         emptyOutDir: true,
     },
     server: {


### PR DESCRIPTION
# Summary

The Vite build still pointed at `../Ingress/wwwroot` — a project that no longer exists after the rename to AuthProxy — so `npm run build` never populated `Source/AuthProxy/wwwroot`. The frontend was absent from the published container image, and the publish pipeline's frontend artifact was silently empty (`upload-artifact` defaults to `if-no-files-found: warn`), which then broke the `dotnet-publish` step that downloads it.

## Fixed

- The React frontend is now built into the AuthProxy web root and bundled into the published image, instead of being written to a stale `Ingress` path and dropped.

## Changed

- The publish pipeline now fails loudly if the frontend build output is empty, instead of silently shipping an image without the frontend.
