### PR TITLE
Add /.cratis/logout and persist the tenant list for the post-login switcher

### DIFF
--- a/Documentation/configuration/logout.md
+++ b/Documentation/configuration/logout.md
@@ -1,0 +1,64 @@
+# Logout
+
+AuthProxy exposes a well-known logout endpoint that ends the current session and returns the user to a
+validated destination:
+
+```
+GET /.cratis/logout?redirect=<absolute-url>
+```
+
+The endpoint is anonymous — it works even when the session is already invalid — and is handled before
+the authentication challenge stages, so it never bounces the user to a login provider.
+
+---
+
+## What it clears
+
+A logout request:
+
+1. Signs the user out of the authentication cookie (`.Cratis.AuthProxy.Auth.v2`), including any chunked variants.
+2. Deletes every AuthProxy session cookie:
+   - `.cratis-identity`
+   - `.cratis-tenant`
+   - `.cratis-tenants`
+   - `.cratis-invite`
+   - `.cratis-registration`
+   - `.cratis-providers`
+3. Redirects (`302 Found`) to the validated `redirect` target.
+
+---
+
+## The `redirect` parameter
+
+The post-logout destination is supplied as an **absolute URL** in the `redirect` query-string parameter,
+for example:
+
+```
+/.cratis/logout?redirect=https://cratis.studio
+```
+
+Because the target is absolute, it cannot be validated with the relative-URL check used elsewhere.
+Instead it is matched against an **allow-list of origins** so the endpoint can never be turned into an
+open redirect. A target is allowed when its origin (scheme + host + port) matches any of:
+
+- The proxy's **own public origin** as seen by the browser (derived from the request, honoring
+  `X-Forwarded-Proto`). This covers redirecting back to the site the user is already on.
+- Any configured **service frontend** (`Cratis:AuthProxy:Services:<name>:Frontend:BaseUrl`).
+- The configured **lobby frontend** (`Cratis:AuthProxy:Invite:Lobby:Frontend:BaseUrl`).
+
+Same-site **relative** URLs (a single leading `/`, but not `//`) are always allowed.
+
+If `redirect` is missing, empty, or fails validation, AuthProxy falls back to the application root (`/`).
+
+---
+
+## Example
+
+A "Log out" control in the application simply navigates the browser to the endpoint:
+
+```html
+<a href="/.cratis/logout?redirect=https://cratis.studio">Log out</a>
+```
+
+After the redirect the user lands on the target unauthenticated; requesting a protected resource then
+triggers the normal login flow.

--- a/Documentation/configuration/logout.md
+++ b/Documentation/configuration/logout.md
@@ -45,10 +45,44 @@ open redirect. A target is allowed when its origin (scheme + host + port) matche
   `X-Forwarded-Proto`). This covers redirecting back to the site the user is already on.
 - Any configured **service frontend** (`Cratis:AuthProxy:Services:<name>:Frontend:BaseUrl`).
 - The configured **lobby frontend** (`Cratis:AuthProxy:Invite:Lobby:Frontend:BaseUrl`).
+- Any origin listed in **`Cratis:AuthProxy:Logout:AllowedRedirectOrigins`** (see below).
 
 Same-site **relative** URLs (a single leading `/`, but not `//`) are always allowed.
 
 If `redirect` is missing, empty, or fails validation, AuthProxy falls back to the application root (`/`).
+
+---
+
+## Allowing additional post-logout origins
+
+The implicit origins above cover redirecting back to the app itself, but a deployment often wants to send
+the user somewhere else after logout — for example a separate marketing or landing site that is neither
+the proxy's own origin nor a configured frontend. List those origins under
+`Cratis:AuthProxy:Logout:AllowedRedirectOrigins`. Each entry is an absolute origin (scheme + host,
+optionally a port) with no path; malformed or non-HTTP(S) entries are ignored.
+
+```json
+{
+  "Cratis": {
+    "AuthProxy": {
+      "Logout": {
+        "AllowedRedirectOrigins": [
+          "https://cratis.studio"
+        ]
+      }
+    }
+  }
+}
+```
+
+Equivalent environment variables (one indexed key per entry):
+
+```
+Cratis__AuthProxy__Logout__AllowedRedirectOrigins__0=https://cratis.studio
+```
+
+With the example above, `GET /.cratis/logout?redirect=https://cratis.studio` is permitted even when the
+app itself is served from a different host such as `https://app.cratis.studio`.
 
 ---
 

--- a/Documentation/configuration/tenant-selection.md
+++ b/Documentation/configuration/tenant-selection.md
@@ -11,12 +11,34 @@ The page receives tenant data through a cookie, not by calling your tenant endpo
 
 1. Authenticated request arrives without a `.cratis-tenant` cookie.
 2. AuthProxy calls the configured `Selection.Options.TenantsEndpoint`.
-3. If exactly one tenant is returned, AuthProxy sets `.cratis-tenant` immediately and redirects to the original URL (no selection page shown).
-4. If more than one tenant is returned, AuthProxy writes `.cratis-tenants` (URL-encoded JSON array) and serves `select-tenant.html`.
+3. If exactly one tenant is returned, AuthProxy sets `.cratis-tenant` immediately, removes any `.cratis-tenants` cookie, and redirects to the original URL (no selection page shown).
+4. If more than one tenant is returned, AuthProxy writes `.cratis-tenants` (URL-encoded JSON array) as a session cookie and serves `select-tenant.html`.
 5. User clicks a tenant option.
 6. Browser navigates to `/.cratis/select-tenant?tenantId=<id>&returnUrl=<path>`.
 7. AuthProxy validates the selected `tenantId` against `TenantsEndpoint` and sets `.cratis-tenant`.
-8. AuthProxy redirects back to `returnUrl`.
+8. AuthProxy redirects back to `returnUrl`. The `.cratis-tenants` cookie is **retained** so the application can offer an in-app tenant switcher.
+
+---
+
+## Switching tenants after selection
+
+For a user with **more than one** tenant, `.cratis-tenants` is written as a **session cookie** and is
+**not** deleted when a tenant is selected. It therefore remains available for the rest of the browser
+session, which lets the application's toolbar decide whether to show a "switch tenant" control (show it
+only when the cookie lists more than one tenant).
+
+To switch, the toolbar navigates to the same selection endpoint used by the selection page:
+
+```
+/.cratis/select-tenant?tenantId=<id>&returnUrl=<current path>
+```
+
+Every switch re-validates the requested `tenantId` against `TenantsEndpoint`, so a stale cookie can
+never grant access to a tenant the user is no longer a member of — an unknown `tenantId` is rejected
+with `400 Bad Request`.
+
+A user with exactly **one** tenant never receives `.cratis-tenants` (it is removed when the single
+tenant is auto-selected), so no switcher is shown for single-tenant users.
 
 ---
 

--- a/Documentation/configuration/toc.yml
+++ b/Documentation/configuration/toc.yml
@@ -6,6 +6,8 @@
   href: tenancy.md
 - name: Tenant Selection Page
   href: tenant-selection.md
+- name: Logout
+  href: logout.md
 - name: Services
   href: services.md
 - name: Lobby

--- a/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_redirecting_outside_the_configured_allow_list.cs
+++ b/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_redirecting_outside_the_configured_allow_list.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.for_LogoutMiddleware;
+
+public class when_logging_out_redirecting_outside_the_configured_allow_list : Specification
+{
+    LogoutMiddleware _middleware;
+    DefaultHttpContext _context;
+
+    void Establish()
+    {
+        var authProxyConfig = new C.AuthProxy
+        {
+            Logout = new C.Logout
+            {
+                AllowedRedirectOrigins = ["https://cratis.studio"]
+            }
+        };
+        var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        config.CurrentValue.Returns(authProxyConfig);
+
+        _middleware = new LogoutMiddleware(_ => Task.CompletedTask, config);
+
+        _context = new DefaultHttpContext();
+        _context.Request.Scheme = "https";
+        _context.Request.Host = new HostString("app.cratis.studio");
+        _context.Request.Path = WellKnownPaths.Logout;
+        _context.Request.QueryString = QueryString.Create("redirect", "https://evil.example.com/steal");
+        _context.Response.Body = new MemoryStream();
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IAuthenticationService)).Returns(Substitute.For<IAuthenticationService>());
+        _context.RequestServices = serviceProvider;
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_fall_back_to_the_application_root() => _context.Response.Headers.Location.ToString().ShouldEqual("/");
+    [Fact] void should_respond_with_found() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status302Found);
+}

--- a/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_redirecting_to_a_configured_allowed_origin.cs
+++ b/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_redirecting_to_a_configured_allowed_origin.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.for_LogoutMiddleware;
+
+public class when_logging_out_redirecting_to_a_configured_allowed_origin : Specification
+{
+    LogoutMiddleware _middleware;
+    DefaultHttpContext _context;
+
+    void Establish()
+    {
+        var authProxyConfig = new C.AuthProxy
+        {
+            Logout = new C.Logout
+            {
+                AllowedRedirectOrigins = ["https://cratis.studio"]
+            }
+        };
+        var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        config.CurrentValue.Returns(authProxyConfig);
+
+        _middleware = new LogoutMiddleware(_ => Task.CompletedTask, config);
+
+        _context = new DefaultHttpContext();
+        _context.Request.Scheme = "https";
+        _context.Request.Host = new HostString("app.cratis.studio");
+        _context.Request.Path = WellKnownPaths.Logout;
+        _context.Request.QueryString = QueryString.Create("redirect", "https://cratis.studio");
+        _context.Response.Body = new MemoryStream();
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IAuthenticationService)).Returns(Substitute.For<IAuthenticationService>());
+        _context.RequestServices = serviceProvider;
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_redirect_to_the_configured_origin() => _context.Response.Headers.Location.ToString().ShouldEqual("https://cratis.studio");
+    [Fact] void should_respond_with_found() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status302Found);
+}

--- a/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_redirecting_to_a_configured_frontend.cs
+++ b/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_redirecting_to_a_configured_frontend.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.for_LogoutMiddleware;
+
+public class when_logging_out_redirecting_to_a_configured_frontend : Specification
+{
+    LogoutMiddleware _middleware;
+    DefaultHttpContext _context;
+
+    void Establish()
+    {
+        var authProxyConfig = new C.AuthProxy
+        {
+            Services = new Dictionary<string, C.Service>
+            {
+                ["app"] = new C.Service
+                {
+                    Frontend = new C.ServiceEndpoint { BaseUrl = "https://app.example.com/" }
+                }
+            }
+        };
+        var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        config.CurrentValue.Returns(authProxyConfig);
+
+        _middleware = new LogoutMiddleware(_ => Task.CompletedTask, config);
+
+        _context = new DefaultHttpContext();
+        _context.Request.Scheme = "https";
+        _context.Request.Host = new HostString("internal-proxy");
+        _context.Request.Path = WellKnownPaths.Logout;
+        _context.Request.QueryString = QueryString.Create("redirect", "https://app.example.com/goodbye");
+        _context.Response.Body = new MemoryStream();
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IAuthenticationService)).Returns(Substitute.For<IAuthenticationService>());
+        _context.RequestServices = serviceProvider;
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_redirect_to_the_configured_frontend() => _context.Response.Headers.Location.ToString().ShouldEqual("https://app.example.com/goodbye");
+    [Fact] void should_respond_with_found() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status302Found);
+}

--- a/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_with_a_disallowed_redirect.cs
+++ b/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_with_a_disallowed_redirect.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.for_LogoutMiddleware;
+
+public class when_logging_out_with_a_disallowed_redirect : Specification
+{
+    LogoutMiddleware _middleware;
+    DefaultHttpContext _context;
+    IAuthenticationService _authenticationService;
+
+    void Establish()
+    {
+        var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        config.CurrentValue.Returns(new C.AuthProxy());
+
+        _middleware = new LogoutMiddleware(_ => Task.CompletedTask, config);
+
+        _context = new DefaultHttpContext();
+        _context.Request.Scheme = "https";
+        _context.Request.Host = new HostString("cratis.studio");
+        _context.Request.Path = WellKnownPaths.Logout;
+        _context.Request.QueryString = QueryString.Create("redirect", "https://evil.example.com/steal");
+        _context.Response.Body = new MemoryStream();
+
+        _authenticationService = Substitute.For<IAuthenticationService>();
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IAuthenticationService)).Returns(_authenticationService);
+        _context.RequestServices = serviceProvider;
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_still_sign_the_user_out() => _authenticationService.Received(1).SignOutAsync(_context, Arg.Any<string>(), Arg.Any<AuthenticationProperties>());
+    [Fact] void should_still_clear_the_session_cookies() => _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.Identity}=;");
+    [Fact] void should_fall_back_to_the_application_root() => _context.Response.Headers.Location.ToString().ShouldEqual("/");
+    [Fact] void should_respond_with_found() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status302Found);
+}

--- a/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_with_a_valid_redirect.cs
+++ b/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_with_a_valid_redirect.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+
+namespace Cratis.AuthProxy.for_LogoutMiddleware;
+
+public class when_logging_out_with_a_valid_redirect : Specification
+{
+    LogoutMiddleware _middleware;
+    DefaultHttpContext _context;
+    IAuthenticationService _authenticationService;
+    bool _nextCalled;
+
+    void Establish()
+    {
+        var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        config.CurrentValue.Returns(new C.AuthProxy());
+
+        _middleware = new LogoutMiddleware(
+            _ =>
+            {
+                _nextCalled = true;
+                return Task.CompletedTask;
+            },
+            config);
+
+        _context = new DefaultHttpContext();
+        _context.Request.Scheme = "https";
+        _context.Request.Host = new HostString("cratis.studio");
+        _context.Request.Path = WellKnownPaths.Logout;
+        _context.Request.QueryString = QueryString.Create("redirect", "https://cratis.studio");
+        _context.Response.Body = new MemoryStream();
+
+        _authenticationService = Substitute.For<IAuthenticationService>();
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IAuthenticationService)).Returns(_authenticationService);
+        _context.RequestServices = serviceProvider;
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_sign_out_of_the_authentication_cookie() => _authenticationService.Received(1).SignOutAsync(_context, CookieAuthenticationDefaults.AuthenticationScheme, Arg.Any<AuthenticationProperties>());
+    [Fact] void should_clear_the_identity_cookie() => _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.Identity}=;");
+    [Fact] void should_clear_the_selected_tenant_cookie() => _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.Tenant}=;");
+    [Fact] void should_clear_the_tenant_list_cookie() => _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.Tenants}=;");
+    [Fact] void should_clear_the_invite_cookie() => _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.InviteToken}=;");
+    [Fact] void should_clear_the_registration_cookie() => _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.Registration}=;");
+    [Fact] void should_clear_the_providers_cookie() => _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.Providers}=;");
+    [Fact] void should_redirect_to_the_requested_target() => _context.Response.Headers.Location.ToString().ShouldEqual("https://cratis.studio");
+    [Fact] void should_respond_with_found() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status302Found);
+    [Fact] void should_not_call_next() => _nextCalled.ShouldBeFalse();
+}

--- a/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_without_a_redirect.cs
+++ b/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_without_a_redirect.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.for_LogoutMiddleware;
+
+public class when_logging_out_without_a_redirect : Specification
+{
+    LogoutMiddleware _middleware;
+    DefaultHttpContext _context;
+
+    void Establish()
+    {
+        var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        config.CurrentValue.Returns(new C.AuthProxy());
+
+        _middleware = new LogoutMiddleware(_ => Task.CompletedTask, config);
+
+        _context = new DefaultHttpContext();
+        _context.Request.Scheme = "https";
+        _context.Request.Host = new HostString("cratis.studio");
+        _context.Request.Path = WellKnownPaths.Logout;
+        _context.Response.Body = new MemoryStream();
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IAuthenticationService)).Returns(Substitute.For<IAuthenticationService>());
+        _context.RequestServices = serviceProvider;
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_fall_back_to_the_application_root() => _context.Response.Headers.Location.ToString().ShouldEqual("/");
+    [Fact] void should_respond_with_found() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status302Found);
+    [Fact] void should_clear_the_session_cookies() => _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.Tenant}=;");
+}

--- a/Source/AuthProxy.Specs/for_LogoutMiddleware/when_request_is_not_a_logout.cs
+++ b/Source/AuthProxy.Specs/for_LogoutMiddleware/when_request_is_not_a_logout.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.for_LogoutMiddleware;
+
+public class when_request_is_not_a_logout : Specification
+{
+    LogoutMiddleware _middleware;
+    DefaultHttpContext _context;
+    IAuthenticationService _authenticationService;
+    bool _nextCalled;
+
+    void Establish()
+    {
+        var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        config.CurrentValue.Returns(new C.AuthProxy());
+
+        _middleware = new LogoutMiddleware(
+            _ =>
+            {
+                _nextCalled = true;
+                return Task.CompletedTask;
+            },
+            config);
+
+        _context = new DefaultHttpContext();
+        _context.Request.Path = "/products";
+        _context.Response.Body = new MemoryStream();
+
+        _authenticationService = Substitute.For<IAuthenticationService>();
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IAuthenticationService)).Returns(_authenticationService);
+        _context.RequestServices = serviceProvider;
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_call_next() => _nextCalled.ShouldBeTrue();
+    [Fact] void should_not_sign_out() => _authenticationService.DidNotReceive().SignOutAsync(Arg.Any<HttpContext>(), Arg.Any<string>(), Arg.Any<AuthenticationProperties>());
+    [Fact] void should_not_clear_any_cookies() => _context.Response.Headers.SetCookie.ToString().ShouldBeEmpty();
+}

--- a/Source/AuthProxy.Specs/for_TenantSelectionMiddleware/when_switching_tenant_retains_the_tenant_list.cs
+++ b/Source/AuthProxy.Specs/for_TenantSelectionMiddleware/when_switching_tenant_retains_the_tenant_list.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net;
+using System.Text;
+
+namespace Cratis.AuthProxy.for_TenantSelectionMiddleware;
+
+public class when_switching_tenant_retains_the_tenant_list : Specification
+{
+    TenantSelectionMiddleware _middleware;
+    DefaultHttpContext _context;
+
+    void Establish()
+    {
+        var authProxyConfig = new C.AuthProxy
+        {
+            TenantResolutions =
+            [
+                new C.TenantResolution
+                {
+                    Strategy = C.TenantSourceIdentifierResolverType.Selection,
+                    Options = new SelectionOptions
+                    {
+                        TenantsEndpoint = "https://platform.example.com/api/tenants/selectable"
+                    }
+                }
+            ]
+        };
+        var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        config.CurrentValue.Returns(authProxyConfig);
+
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        httpClientFactory.CreateClient(Arg.Any<string>())
+            .Returns(new HttpClient(new FakeTenantsHandler()));
+
+        _middleware = new TenantSelectionMiddleware(
+            _ => Task.CompletedTask,
+            config,
+            Substitute.For<ITenantResolver>(),
+            httpClientFactory,
+            Substitute.For<IErrorPageProvider>());
+
+        _context = new DefaultHttpContext();
+        _context.Request.Path = WellKnownPaths.SelectTenant;
+        _context.Request.QueryString = new QueryString("?tenantId=tenant-b&returnUrl=%2Fdashboard");
+        _context.Request.Headers.Cookie = $"{Cookies.Tenants}=%5B%7B%22id%22%3A%22tenant-a%22%7D%5D";
+        _context.Response.Body = new MemoryStream();
+        _context.User = new ClaimsPrincipal(new ClaimsIdentity([new Claim("oid", "user-id")], "aad"));
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_set_selected_tenant_cookie() => _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.Tenant}=tenant-b");
+    [Fact] void should_not_clear_the_tenant_list_cookie() => _context.Response.Headers.SetCookie.ToString().ShouldNotContain($"{Cookies.Tenants}=;");
+    [Fact] void should_redirect_to_return_url() => _context.Response.Headers.Location.ToString().ShouldEqual("/dashboard");
+
+    sealed class FakeTenantsHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """[{"id":"tenant-a","name":"Tenant A"},{"id":"tenant-b","name":"Tenant B"}]""",
+                    Encoding.UTF8,
+                    "application/json")
+            });
+    }
+}

--- a/Source/AuthProxy.Specs/for_TenantSelectionMiddleware/when_switching_to_a_tenant_that_is_not_a_member.cs
+++ b/Source/AuthProxy.Specs/for_TenantSelectionMiddleware/when_switching_to_a_tenant_that_is_not_a_member.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net;
+using System.Text;
+
+namespace Cratis.AuthProxy.for_TenantSelectionMiddleware;
+
+public class when_switching_to_a_tenant_that_is_not_a_member : Specification
+{
+    TenantSelectionMiddleware _middleware;
+    DefaultHttpContext _context;
+
+    void Establish()
+    {
+        var authProxyConfig = new C.AuthProxy
+        {
+            TenantResolutions =
+            [
+                new C.TenantResolution
+                {
+                    Strategy = C.TenantSourceIdentifierResolverType.Selection,
+                    Options = new SelectionOptions
+                    {
+                        TenantsEndpoint = "https://platform.example.com/api/tenants/selectable"
+                    }
+                }
+            ]
+        };
+        var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        config.CurrentValue.Returns(authProxyConfig);
+
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        httpClientFactory.CreateClient(Arg.Any<string>())
+            .Returns(new HttpClient(new FakeTenantsHandler()));
+
+        _middleware = new TenantSelectionMiddleware(
+            _ => Task.CompletedTask,
+            config,
+            Substitute.For<ITenantResolver>(),
+            httpClientFactory,
+            Substitute.For<IErrorPageProvider>());
+
+        _context = new DefaultHttpContext();
+        _context.Request.Path = WellKnownPaths.SelectTenant;
+        _context.Request.QueryString = new QueryString("?tenantId=tenant-c&returnUrl=%2Fdashboard");
+        _context.Response.Body = new MemoryStream();
+        _context.User = new ClaimsPrincipal(new ClaimsIdentity([new Claim("oid", "user-id")], "aad"));
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_reject_the_selection() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status400BadRequest);
+    [Fact] void should_not_set_the_selected_tenant_cookie() => _context.Response.Headers.SetCookie.ToString().ShouldNotContain(Cookies.Tenant);
+
+    sealed class FakeTenantsHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """[{"id":"tenant-a","name":"Tenant A"},{"id":"tenant-b","name":"Tenant B"}]""",
+                    Encoding.UTF8,
+                    "application/json")
+            });
+    }
+}

--- a/Source/AuthProxy/Configuration/AuthProxy.cs
+++ b/Source/AuthProxy/Configuration/AuthProxy.cs
@@ -25,6 +25,11 @@ public class AuthProxy
     public Invite? Invite { get; set; }
 
     /// <summary>
+    /// Gets or sets the logout configuration, including the post-logout redirect allow-list.
+    /// </summary>
+    public Logout Logout { get; set; } = new();
+
+    /// <summary>
     /// Gets or sets the tenant verification configuration.
     /// When set, the ingress calls the configured service to confirm that a resolved
     /// tenant exists before forwarding the request.

--- a/Source/AuthProxy/Configuration/Logout.cs
+++ b/Source/AuthProxy/Configuration/Logout.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Configuration;
+
+/// <summary>
+/// Represents the configuration for the logout endpoint.
+/// </summary>
+public class Logout
+{
+    /// <summary>
+    /// Gets or sets additional origins permitted as post-logout redirect targets.
+    /// Each entry is an absolute origin (scheme and host, optionally a port), e.g. <c>https://cratis.studio</c>.
+    /// These are added to the implicit allow-list — the proxy's own public origin plus the configured
+    /// service frontends and lobby frontend. Malformed or non-HTTP(S) entries are ignored.
+    /// </summary>
+    public IList<string> AllowedRedirectOrigins { get; set; } = [];
+}

--- a/Source/AuthProxy/IngressExtensions.cs
+++ b/Source/AuthProxy/IngressExtensions.cs
@@ -77,6 +77,7 @@ public static class IngressExtensions
         app.Map(WellKnownPaths.Pages, pagesApp => ConfigurePagesPipeline(pagesApp, app.Environment, app.Services.GetRequiredService<IOptionsMonitor<C.AuthProxy>>()));
         app.UseStaticFiles();
         app.UseAuthentication();
+        app.UseMiddleware<LogoutMiddleware>();
         app.UseMiddleware<Authentication.SelectProviderMiddleware>();
         app.UseAuthorization();
         app.UseMiddleware<TenantSelectionMiddleware>();

--- a/Source/AuthProxy/LogoutMiddleware.cs
+++ b/Source/AuthProxy/LogoutMiddleware.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.Extensions.Options;
+using C = Cratis.AuthProxy.Configuration;
+
+namespace Cratis.AuthProxy;
+
+/// <summary>
+/// Middleware that handles the well-known logout endpoint (<see cref="WellKnownPaths.Logout"/>).
+/// It signs the user out of the authentication cookie, clears every AuthProxy session cookie and
+/// redirects to the validated <c>redirect</c> query-string target.
+/// </summary>
+/// <remarks>
+/// The post-logout redirect target is an absolute URL and can therefore not be validated with the
+/// relative-URL check used for tenant selection. Instead it is validated against an allow-list of
+/// origins that combines the proxy's own public origin (honoring forwarded headers) with the
+/// configured service frontends and lobby frontend. A missing or disallowed target falls back to the
+/// application root (<c>/</c>) so the endpoint can never be turned into an open redirect.
+/// </remarks>
+/// <param name="next">The next middleware in the pipeline.</param>
+/// <param name="config">The auth proxy configuration monitor.</param>
+public class LogoutMiddleware(
+    RequestDelegate next,
+    IOptionsMonitor<C.AuthProxy> config)
+{
+    const string RedirectQueryKey = "redirect";
+    const string ApplicationRoot = "/";
+
+    /// <inheritdoc cref="IMiddleware.InvokeAsync"/>
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (!context.Request.Path.StartsWithSegments(WellKnownPaths.Logout))
+        {
+            await next(context);
+            return;
+        }
+
+        await context.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+        ClearSessionCookies(context);
+
+        context.Response.StatusCode = StatusCodes.Status302Found;
+        context.Response.Headers.Location = ResolveRedirectTarget(context, config.CurrentValue);
+    }
+
+    static void ClearSessionCookies(HttpContext context)
+    {
+        context.Response.Cookies.Delete(Cookies.Identity);
+        context.Response.Cookies.Delete(Cookies.Tenant);
+        context.Response.Cookies.Delete(Cookies.Tenants);
+        context.Response.Cookies.Delete(Cookies.InviteToken);
+        context.Response.Cookies.Delete(Cookies.Registration);
+        context.Response.Cookies.Delete(Cookies.Providers);
+    }
+
+    static string ResolveRedirectTarget(HttpContext context, C.AuthProxy authProxyConfig)
+    {
+        var requested = context.Request.Query[RedirectQueryKey].FirstOrDefault();
+        return IsAllowedRedirect(context, authProxyConfig, requested) ? requested! : ApplicationRoot;
+    }
+
+    static bool IsAllowedRedirect(HttpContext context, C.AuthProxy authProxyConfig, string? redirect)
+    {
+        if (string.IsNullOrWhiteSpace(redirect))
+        {
+            return false;
+        }
+
+        // A relative, single-slash URL is always same-site and therefore safe.
+        if (Uri.TryCreate(redirect, UriKind.Relative, out _) && redirect.StartsWith('/') && !redirect.StartsWith("//", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (!Uri.TryCreate(redirect, UriKind.Absolute, out var target)
+            || (target.Scheme != Uri.UriSchemeHttp && target.Scheme != Uri.UriSchemeHttps))
+        {
+            return false;
+        }
+
+        var targetOrigin = target.GetLeftPart(UriPartial.Authority);
+        return GetAllowedOrigins(context, authProxyConfig)
+            .Contains(targetOrigin, StringComparer.OrdinalIgnoreCase);
+    }
+
+    static IEnumerable<string> GetAllowedOrigins(HttpContext context, C.AuthProxy authProxyConfig)
+    {
+        // The proxy's own public origin as seen by the browser (X-Forwarded-Proto is honored upstream).
+        if (context.Request.Host.HasValue
+            && Uri.TryCreate($"{context.Request.Scheme}://{context.Request.Host.Value}", UriKind.Absolute, out var self))
+        {
+            yield return self.GetLeftPart(UriPartial.Authority);
+        }
+
+        // Reuse the configured service frontends as permitted post-logout destinations.
+        foreach (var service in authProxyConfig.Services.Values)
+        {
+            if (TryGetOrigin(service.Frontend?.BaseUrl, out var origin))
+            {
+                yield return origin;
+            }
+        }
+
+        // The lobby frontend is also a permitted destination when configured.
+        if (TryGetOrigin(authProxyConfig.Invite?.Lobby?.Frontend?.BaseUrl, out var lobbyOrigin))
+        {
+            yield return lobbyOrigin;
+        }
+    }
+
+    static bool TryGetOrigin(string? url, out string origin)
+    {
+        origin = string.Empty;
+        if (string.IsNullOrWhiteSpace(url)
+            || !Uri.TryCreate(url, UriKind.Absolute, out var uri)
+            || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            return false;
+        }
+
+        origin = uri.GetLeftPart(UriPartial.Authority);
+        return true;
+    }
+}

--- a/Source/AuthProxy/LogoutMiddleware.cs
+++ b/Source/AuthProxy/LogoutMiddleware.cs
@@ -108,6 +108,15 @@ public class LogoutMiddleware(
         {
             yield return lobbyOrigin;
         }
+
+        // Any explicitly configured post-logout redirect origins (e.g. a separate marketing site).
+        foreach (var configured in authProxyConfig.Logout.AllowedRedirectOrigins)
+        {
+            if (TryGetOrigin(configured, out var configuredOrigin))
+            {
+                yield return configuredOrigin;
+            }
+        }
     }
 
     static bool TryGetOrigin(string? url, out string origin)

--- a/Source/AuthProxy/TenantSelectionMiddleware.cs
+++ b/Source/AuthProxy/TenantSelectionMiddleware.cs
@@ -82,13 +82,15 @@ public class TenantSelectionMiddleware(
             return;
         }
 
+        // Written as a session cookie so that, once a multi-tenant user has selected a tenant, the
+        // tenant list remains available to the application's toolbar switcher for the rest of the
+        // browser session. It is intentionally not deleted on selection.
         var tenantsJson = JsonSerializer.Serialize(tenantOptions, _serializerOptions);
         context.Response.Cookies.Append(Cookies.Tenants, tenantsJson, new CookieOptions
         {
             HttpOnly = false,
             SameSite = SameSiteMode.Lax,
             Secure = context.Request.IsHttps,
-            MaxAge = TimeSpan.FromMinutes(15),
         });
 
         await errorPageProvider.WriteErrorPageAsync(
@@ -120,8 +122,8 @@ public class TenantSelectionMiddleware(
             Secure = context.Request.IsHttps,
         });
 
-        context.Response.Cookies.Delete(Cookies.Tenants);
-
+        // The tenant list is intentionally retained (not deleted) so a multi-tenant user keeps the
+        // ability to switch tenants from the application's toolbar after making a selection.
         var requestedReturnUrl = context.Request.Query["returnUrl"].FirstOrDefault();
         if (!IsSafeRelativeUrl(requestedReturnUrl))
         {

--- a/Source/AuthProxy/WellKnownPaths.cs
+++ b/Source/AuthProxy/WellKnownPaths.cs
@@ -42,6 +42,12 @@ public static class WellKnownPaths
     public const string SelectTenant = "/.cratis/select-tenant";
 
     /// <summary>
+    /// The well-known path that logs the current user out by clearing all session cookies
+    /// and redirecting to the URL supplied in the <c>redirect</c> query-string parameter.
+    /// </summary>
+    public const string Logout = "/.cratis/logout";
+
+    /// <summary>
     /// The well-known path prefix that triggers invite-token handling.
     /// Append the token to complete the URL (e.g. <c>/invite/&lt;token&gt;</c>).
     /// </summary>


### PR DESCRIPTION
Adds the AuthProxy pieces required by Studio's "log out and switch tenant" feature (Cratis/Studio#856). The Studio frontend is already live, but the flow was broken end-to-end because AuthProxy had no logout endpoint and never kept the tenant list available to the post-login toolbar switcher.

## Added

- `GET /.cratis/logout` — signs the user out of the authentication cookie and clears every AuthProxy session cookie (`.cratis-identity`, `.cratis-tenant`, `.cratis-tenants`, `.cratis-invite`, `.cratis-registration`, `.cratis-providers`), then redirects to the absolute URL in the `redirect` query parameter. The target is validated against an allow-list of origins (the proxy's own public origin plus configured service/lobby frontends) so it cannot be used as an open redirect; a missing or disallowed target falls back to the application root. The endpoint is anonymous and runs before the authentication-challenge stages, so it works without a valid session.

## Changed

- `.cratis-tenants` now persists for the post-login tenant switcher. It is written as a session cookie and is no longer deleted when a tenant is selected, so a user with more than one tenant keeps the list available for an in-app switch control for the rest of the browser session. Single-tenant users still have the cookie removed on auto-selection (no switcher), and every selection continues to re-validate membership against the tenants endpoint.

---

Closes the AuthProxy side of Cratis/Studio#856.
