### PR TITLE
Add session-preserving credential-linking endpoint

### DIFF
--- a/Documentation/configuration/link.md
+++ b/Documentation/configuration/link.md
@@ -1,0 +1,92 @@
+# Credential Linking
+
+AuthProxy can let an **already signed-in** user prove control of an additional identity-provider login and
+associate it with their existing account — without ever replacing their current session. This is the
+proof-of-control building block behind an application's "add a credential" feature.
+
+```
+GET /.cratis/link/{scheme}?returnUrl=<relative-url>&token=<one-time-link-token>
+```
+
+It is deliberately **not** the same as `/.cratis/login/{scheme}`: login signs the authenticated identity into
+the primary session cookie (which, for a second identity, would swap who the user is — effectively logging
+them out of the original account). The link flow authenticates the second provider, captures its subject,
+and hands that subject to the application, all while leaving the primary session untouched.
+
+---
+
+## Why a popup, not an iframe
+
+The application opens `/.cratis/link/{scheme}` in a **popup** (or a top-level redirect), never a nested
+iframe. Provider consent pages send `X-Frame-Options: DENY`, and AuthProxy's authentication and OAuth
+correlation/nonce cookies are `SameSite=Lax`, so a cross-site iframe cannot complete the flow. A same-origin
+popup avoids both problems.
+
+---
+
+## How it works
+
+1. **The application mints a one-time link token.** When the user starts "add a credential", the application
+   issues a short-lived, single-use token bound to that signed-in user, and opens the popup at
+   `/.cratis/link/{scheme}?returnUrl=…&token=…`. The `scheme` is a configured provider scheme (the same value
+   used by `/.cratis/login/{scheme}`, e.g. `github`).
+2. **AuthProxy challenges the provider.** The request must come from an authenticated session (an anonymous
+   request is rejected with `401`; an unknown scheme with `404`; a missing token with `400`). AuthProxy starts
+   an OAuth/OIDC challenge for the requested scheme, carrying a link-mode marker and the link token through the
+   authentication properties.
+3. **On the provider callback the identity is captured, not signed in.** Instead of writing the primary
+   authentication cookie, AuthProxy reads the freshly authenticated `subject` (and identity provider) and
+   `POST`s them to the configured [`ExchangeUrl`](#configuration), authenticated with the link token as the
+   bearer credential — exactly mirroring the [invite exchange](./lobby/invitation-to-organization.md). The
+   user's original session is preserved.
+4. **AuthProxy returns to the application.** The browser is redirected to the supplied `returnUrl`, where the
+   application correlates the token back to the signed-in user, records the association, and closes the popup.
+
+The request body posted to `ExchangeUrl` matches the invite exchange shape:
+
+```json
+{ "subject": "<provider subject>", "identityProvider": "<issuer / provider>" }
+```
+
+with `Authorization: Bearer <one-time-link-token>`.
+
+---
+
+## The `returnUrl` parameter
+
+`returnUrl` is echoed back to the browser after the link completes, so it is constrained to a **same-site
+relative path** (a single leading `/`, but not `//`). Anything else — including an absolute URL to another
+origin — falls back to the application root (`/`), so the endpoint can never be turned into an open redirect.
+
+---
+
+## Configuration
+
+Set the application endpoint that records the freshly authenticated subject under
+`Cratis:AuthProxy:Link:ExchangeUrl`. It is the link counterpart of `Cratis:AuthProxy:Invite:ExchangeUrl`.
+
+```json
+{
+  "Cratis": {
+    "AuthProxy": {
+      "Link": {
+        "ExchangeUrl": "https://studio.example.com/api/internal/identity-providers/link"
+      }
+    }
+  }
+}
+```
+
+Equivalent environment variable:
+
+```
+Cratis__AuthProxy__Link__ExchangeUrl=https://studio.example.com/api/internal/identity-providers/link
+```
+
+When `ExchangeUrl` is empty or the `Link` section is absent, the link callback is skipped (the subject is not
+posted anywhere) and the flow is effectively disabled.
+
+> **Security.** The exchange endpoint is a service-to-service back-channel: it is reachable by AuthProxy, not by
+> browsers, and it trusts the subject AuthProxy delivers from a real provider authentication together with the
+> one-time link token — never a client-supplied subject. Point `ExchangeUrl` at an internal application address
+> and keep the token short-lived and single-use, exactly as for the invite exchange.

--- a/Documentation/configuration/logout.md
+++ b/Documentation/configuration/logout.md
@@ -1,0 +1,64 @@
+# Logout
+
+AuthProxy exposes a well-known logout endpoint that ends the current session and returns the user to a
+validated destination:
+
+```
+GET /.cratis/logout?redirect=<absolute-url>
+```
+
+The endpoint is anonymous — it works even when the session is already invalid — and is handled before
+the authentication challenge stages, so it never bounces the user to a login provider.
+
+---
+
+## What it clears
+
+A logout request:
+
+1. Signs the user out of the authentication cookie (`.Cratis.AuthProxy.Auth.v2`), including any chunked variants.
+2. Deletes every AuthProxy session cookie:
+   - `.cratis-identity`
+   - `.cratis-tenant`
+   - `.cratis-tenants`
+   - `.cratis-invite`
+   - `.cratis-registration`
+   - `.cratis-providers`
+3. Redirects (`302 Found`) to the validated `redirect` target.
+
+---
+
+## The `redirect` parameter
+
+The post-logout destination is supplied as an **absolute URL** in the `redirect` query-string parameter,
+for example:
+
+```
+/.cratis/logout?redirect=https://cratis.studio
+```
+
+Because the target is absolute, it cannot be validated with the relative-URL check used elsewhere.
+Instead it is matched against an **allow-list of origins** so the endpoint can never be turned into an
+open redirect. A target is allowed when its origin (scheme + host + port) matches any of:
+
+- The proxy's **own public origin** as seen by the browser (derived from the request, honoring
+  `X-Forwarded-Proto`). This covers redirecting back to the site the user is already on.
+- Any configured **service frontend** (`Cratis:AuthProxy:Services:<name>:Frontend:BaseUrl`).
+- The configured **lobby frontend** (`Cratis:AuthProxy:Invite:Lobby:Frontend:BaseUrl`).
+
+Same-site **relative** URLs (a single leading `/`, but not `//`) are always allowed.
+
+If `redirect` is missing, empty, or fails validation, AuthProxy falls back to the application root (`/`).
+
+---
+
+## Example
+
+A "Log out" control in the application simply navigates the browser to the endpoint:
+
+```html
+<a href="/.cratis/logout?redirect=https://cratis.studio">Log out</a>
+```
+
+After the redirect the user lands on the target unauthenticated; requesting a protected resource then
+triggers the normal login flow.

--- a/Documentation/configuration/logout.md
+++ b/Documentation/configuration/logout.md
@@ -45,10 +45,44 @@ open redirect. A target is allowed when its origin (scheme + host + port) matche
   `X-Forwarded-Proto`). This covers redirecting back to the site the user is already on.
 - Any configured **service frontend** (`Cratis:AuthProxy:Services:<name>:Frontend:BaseUrl`).
 - The configured **lobby frontend** (`Cratis:AuthProxy:Invite:Lobby:Frontend:BaseUrl`).
+- Any origin listed in **`Cratis:AuthProxy:Logout:AllowedRedirectOrigins`** (see below).
 
 Same-site **relative** URLs (a single leading `/`, but not `//`) are always allowed.
 
 If `redirect` is missing, empty, or fails validation, AuthProxy falls back to the application root (`/`).
+
+---
+
+## Allowing additional post-logout origins
+
+The implicit origins above cover redirecting back to the app itself, but a deployment often wants to send
+the user somewhere else after logout — for example a separate marketing or landing site that is neither
+the proxy's own origin nor a configured frontend. List those origins under
+`Cratis:AuthProxy:Logout:AllowedRedirectOrigins`. Each entry is an absolute origin (scheme + host,
+optionally a port) with no path; malformed or non-HTTP(S) entries are ignored.
+
+```json
+{
+  "Cratis": {
+    "AuthProxy": {
+      "Logout": {
+        "AllowedRedirectOrigins": [
+          "https://cratis.studio"
+        ]
+      }
+    }
+  }
+}
+```
+
+Equivalent environment variables (one indexed key per entry):
+
+```
+Cratis__AuthProxy__Logout__AllowedRedirectOrigins__0=https://cratis.studio
+```
+
+With the example above, `GET /.cratis/logout?redirect=https://cratis.studio` is permitted even when the
+app itself is served from a different host such as `https://app.cratis.studio`.
 
 ---
 

--- a/Documentation/configuration/tenant-selection.md
+++ b/Documentation/configuration/tenant-selection.md
@@ -11,12 +11,34 @@ The page receives tenant data through a cookie, not by calling your tenant endpo
 
 1. Authenticated request arrives without a `.cratis-tenant` cookie.
 2. AuthProxy calls the configured `Selection.Options.TenantsEndpoint`.
-3. If exactly one tenant is returned, AuthProxy sets `.cratis-tenant` immediately and redirects to the original URL (no selection page shown).
-4. If more than one tenant is returned, AuthProxy writes `.cratis-tenants` (URL-encoded JSON array) and serves `select-tenant.html`.
+3. If exactly one tenant is returned, AuthProxy sets `.cratis-tenant` immediately, removes any `.cratis-tenants` cookie, and redirects to the original URL (no selection page shown).
+4. If more than one tenant is returned, AuthProxy writes `.cratis-tenants` (URL-encoded JSON array) as a session cookie and serves `select-tenant.html`.
 5. User clicks a tenant option.
 6. Browser navigates to `/.cratis/select-tenant?tenantId=<id>&returnUrl=<path>`.
 7. AuthProxy validates the selected `tenantId` against `TenantsEndpoint` and sets `.cratis-tenant`.
-8. AuthProxy redirects back to `returnUrl`.
+8. AuthProxy redirects back to `returnUrl`. The `.cratis-tenants` cookie is **retained** so the application can offer an in-app tenant switcher.
+
+---
+
+## Switching tenants after selection
+
+For a user with **more than one** tenant, `.cratis-tenants` is written as a **session cookie** and is
+**not** deleted when a tenant is selected. It therefore remains available for the rest of the browser
+session, which lets the application's toolbar decide whether to show a "switch tenant" control (show it
+only when the cookie lists more than one tenant).
+
+To switch, the toolbar navigates to the same selection endpoint used by the selection page:
+
+```
+/.cratis/select-tenant?tenantId=<id>&returnUrl=<current path>
+```
+
+Every switch re-validates the requested `tenantId` against `TenantsEndpoint`, so a stale cookie can
+never grant access to a tenant the user is no longer a member of — an unknown `tenantId` is rejected
+with `400 Bad Request`.
+
+A user with exactly **one** tenant never receives `.cratis-tenants` (it is removed when the single
+tenant is auto-selected), so no switcher is shown for single-tenant users.
 
 ---
 

--- a/Documentation/configuration/toc.yml
+++ b/Documentation/configuration/toc.yml
@@ -6,6 +6,8 @@
   href: tenancy.md
 - name: Tenant Selection Page
   href: tenant-selection.md
+- name: Logout
+  href: logout.md
 - name: Services
   href: services.md
 - name: Lobby

--- a/Documentation/configuration/toc.yml
+++ b/Documentation/configuration/toc.yml
@@ -8,6 +8,8 @@
   href: tenant-selection.md
 - name: Logout
   href: logout.md
+- name: Credential Linking
+  href: link.md
 - name: Services
   href: services.md
 - name: Lobby

--- a/Source/AuthProxy.Specs/Links/RecordingHttpMessageHandler.cs
+++ b/Source/AuthProxy.Specs/Links/RecordingHttpMessageHandler.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net;
+
+namespace Cratis.AuthProxy.Links;
+
+public class RecordingHttpMessageHandler(HttpStatusCode statusCode = HttpStatusCode.OK) : HttpMessageHandler
+{
+    public HttpRequestMessage? LastRequest { get; private set; }
+
+    public string? LastRequestBody { get; private set; }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        LastRequest = request;
+        LastRequestBody = request.Content is null ? null : await request.Content.ReadAsStringAsync(cancellationToken);
+        return new HttpResponseMessage(statusCode);
+    }
+}

--- a/Source/AuthProxy.Specs/Links/for_LinkSubjectExchanger/given/a_link_subject_exchanger.cs
+++ b/Source/AuthProxy.Specs/Links/for_LinkSubjectExchanger/given/a_link_subject_exchanger.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net;
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.Links.for_LinkSubjectExchanger.given;
+
+public class a_link_subject_exchanger : Specification
+{
+    protected const string ExchangeUrl = "https://studio.example.com/api/internal/identity-providers/link";
+    protected const string LinkToken = "the-one-time-link-token";
+
+    protected LinkSubjectExchanger _exchanger;
+    protected RecordingHttpMessageHandler _handler;
+    protected IOptionsMonitor<C.AuthProxy> _config;
+    protected ClaimsPrincipal _principal;
+    protected AuthenticationProperties _properties;
+
+    protected virtual C.AuthProxy CreateConfig() => new() { Link = new C.Link { ExchangeUrl = ExchangeUrl } };
+
+    protected virtual HttpStatusCode ExchangeStatusCode => HttpStatusCode.OK;
+
+    protected virtual AuthenticationProperties CreateProperties()
+    {
+        var properties = new AuthenticationProperties();
+        properties.Items[LinkMiddleware.LinkTokenPropertyKey] = LinkToken;
+        return properties;
+    }
+
+    void Establish()
+    {
+        _config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        _config.CurrentValue.Returns(CreateConfig());
+
+        _handler = new RecordingHttpMessageHandler(ExchangeStatusCode);
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        httpClientFactory.CreateClient(Arg.Any<string>()).Returns(_ => new HttpClient(_handler));
+
+        _principal = new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim("sub", "linked-subject-123"),
+            new Claim("iss", "https://github.com"),
+        ],
+        "github"));
+
+        _properties = CreateProperties();
+
+        _exchanger = new LinkSubjectExchanger(_config, httpClientFactory, Substitute.For<ILogger<LinkSubjectExchanger>>());
+    }
+}

--- a/Source/AuthProxy.Specs/Links/for_LinkSubjectExchanger/when_exchanging_a_subject.cs
+++ b/Source/AuthProxy.Specs/Links/for_LinkSubjectExchanger/when_exchanging_a_subject.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Links.for_LinkSubjectExchanger.given;
+
+namespace Cratis.AuthProxy.Links.for_LinkSubjectExchanger;
+
+public class when_exchanging_a_subject : a_link_subject_exchanger
+{
+    LinkExchangeResult _result;
+
+    async Task Because() => _result = await _exchanger.Exchange(_principal, _properties);
+
+    [Fact] void should_succeed() => _result.ShouldEqual(LinkExchangeResult.Success);
+    [Fact] void should_post_to_the_configured_exchange_url() => _handler.LastRequest!.RequestUri!.ToString().ShouldEqual(ExchangeUrl);
+    [Fact] void should_post() => _handler.LastRequest!.Method.ShouldEqual(HttpMethod.Post);
+    [Fact] void should_authenticate_with_the_link_token() => _handler.LastRequest!.Headers.Authorization!.Parameter.ShouldEqual(LinkToken);
+    [Fact] void should_use_the_bearer_scheme() => _handler.LastRequest!.Headers.Authorization!.Scheme.ShouldEqual("Bearer");
+    [Fact] void should_send_the_linked_subject() => _handler.LastRequestBody!.ShouldContain("linked-subject-123");
+    [Fact] void should_send_the_identity_provider() => _handler.LastRequestBody!.ShouldContain("https://github.com");
+}

--- a/Source/AuthProxy.Specs/Links/for_LinkSubjectExchanger/when_the_endpoint_returns_an_error.cs
+++ b/Source/AuthProxy.Specs/Links/for_LinkSubjectExchanger/when_the_endpoint_returns_an_error.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net;
+using Cratis.AuthProxy.Links.for_LinkSubjectExchanger.given;
+
+namespace Cratis.AuthProxy.Links.for_LinkSubjectExchanger;
+
+public class when_the_endpoint_returns_an_error : a_link_subject_exchanger
+{
+    LinkExchangeResult _result;
+
+    protected override HttpStatusCode ExchangeStatusCode => HttpStatusCode.InternalServerError;
+
+    async Task Because() => _result = await _exchanger.Exchange(_principal, _properties);
+
+    [Fact] void should_fail() => _result.ShouldEqual(LinkExchangeResult.Failed);
+}

--- a/Source/AuthProxy.Specs/Links/for_LinkSubjectExchanger/when_the_exchange_url_is_not_configured.cs
+++ b/Source/AuthProxy.Specs/Links/for_LinkSubjectExchanger/when_the_exchange_url_is_not_configured.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Links.for_LinkSubjectExchanger.given;
+
+namespace Cratis.AuthProxy.Links.for_LinkSubjectExchanger;
+
+public class when_the_exchange_url_is_not_configured : a_link_subject_exchanger
+{
+    LinkExchangeResult _result;
+
+    protected override C.AuthProxy CreateConfig() => new() { Link = null };
+
+    async Task Because() => _result = await _exchanger.Exchange(_principal, _properties);
+
+    [Fact] void should_fail() => _result.ShouldEqual(LinkExchangeResult.Failed);
+    [Fact] void should_not_post_anything() => _handler.LastRequest.ShouldBeNull();
+}

--- a/Source/AuthProxy.Specs/Links/for_LinkSubjectExchanger/when_the_link_token_is_missing.cs
+++ b/Source/AuthProxy.Specs/Links/for_LinkSubjectExchanger/when_the_link_token_is_missing.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Links.for_LinkSubjectExchanger.given;
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.Links.for_LinkSubjectExchanger;
+
+public class when_the_link_token_is_missing : a_link_subject_exchanger
+{
+    LinkExchangeResult _result;
+
+    protected override AuthenticationProperties CreateProperties() => new();
+
+    async Task Because() => _result = await _exchanger.Exchange(_principal, _properties);
+
+    [Fact] void should_fail() => _result.ShouldEqual(LinkExchangeResult.Failed);
+    [Fact] void should_not_post_anything() => _handler.LastRequest.ShouldBeNull();
+}

--- a/Source/AuthProxy.Specs/for_LinkMiddleware/when_initiating_a_link.cs
+++ b/Source/AuthProxy.Specs/for_LinkMiddleware/when_initiating_a_link.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Links;
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.for_LinkMiddleware;
+
+public class when_initiating_a_link : Specification
+{
+    LinkMiddleware _middleware;
+    DefaultHttpContext _context;
+    IAuthenticationService _authenticationService;
+    bool _nextCalled;
+
+    void Establish()
+    {
+        var authConfig = Substitute.For<IOptionsMonitor<C.Authentication>>();
+        authConfig.CurrentValue.Returns(new C.Authentication
+        {
+            OAuthProviders = [new C.OAuthProvider { Name = "GitHub" }],
+        });
+
+        _middleware = new LinkMiddleware(
+            _ =>
+            {
+                _nextCalled = true;
+                return Task.CompletedTask;
+            },
+            authConfig,
+            Substitute.For<ILogger<LinkMiddleware>>());
+
+        _context = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity("test")),
+        };
+        _context.Request.Path = $"{WellKnownPaths.Link}/github";
+        _context.Request.QueryString = QueryString.Create(new Dictionary<string, string?>
+        {
+            ["returnUrl"] = "/settings/link-complete",
+            ["token"] = "the-link-token",
+        });
+
+        _authenticationService = Substitute.For<IAuthenticationService>();
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IAuthenticationService)).Returns(_authenticationService);
+        _context.RequestServices = serviceProvider;
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_challenge_the_requested_scheme() =>
+        _authenticationService.Received(1).ChallengeAsync(_context, "github", Arg.Any<AuthenticationProperties>());
+
+    [Fact] void should_mark_the_challenge_as_link_mode() =>
+        _authenticationService.Received(1).ChallengeAsync(
+            _context,
+            "github",
+            Arg.Is<AuthenticationProperties>(properties => properties.Items[LinkMiddleware.LinkModePropertyKey] == "true"));
+
+    [Fact] void should_carry_the_link_token_on_the_challenge() =>
+        _authenticationService.Received(1).ChallengeAsync(
+            _context,
+            "github",
+            Arg.Is<AuthenticationProperties>(properties => properties.Items[LinkMiddleware.LinkTokenPropertyKey] == "the-link-token"));
+
+    [Fact] void should_return_to_the_requested_relative_url() =>
+        _authenticationService.Received(1).ChallengeAsync(
+            _context,
+            "github",
+            Arg.Is<AuthenticationProperties>(properties => properties.RedirectUri == "/settings/link-complete"));
+
+    [Fact] void should_not_call_next() => _nextCalled.ShouldBeFalse();
+}

--- a/Source/AuthProxy.Specs/for_LinkMiddleware/when_the_link_token_is_missing.cs
+++ b/Source/AuthProxy.Specs/for_LinkMiddleware/when_the_link_token_is_missing.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Links;
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.for_LinkMiddleware;
+
+public class when_the_link_token_is_missing : Specification
+{
+    LinkMiddleware _middleware;
+    DefaultHttpContext _context;
+    IAuthenticationService _authenticationService;
+    bool _nextCalled;
+
+    void Establish()
+    {
+        var authConfig = Substitute.For<IOptionsMonitor<C.Authentication>>();
+        authConfig.CurrentValue.Returns(new C.Authentication
+        {
+            OAuthProviders = [new C.OAuthProvider { Name = "GitHub" }],
+        });
+
+        _middleware = new LinkMiddleware(
+            _ =>
+            {
+                _nextCalled = true;
+                return Task.CompletedTask;
+            },
+            authConfig,
+            Substitute.For<ILogger<LinkMiddleware>>());
+
+        _context = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity("test")),
+        };
+        _context.Request.Path = $"{WellKnownPaths.Link}/github";
+
+        _authenticationService = Substitute.For<IAuthenticationService>();
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IAuthenticationService)).Returns(_authenticationService);
+        _context.RequestServices = serviceProvider;
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_respond_with_bad_request() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status400BadRequest);
+    [Fact] void should_not_challenge() => _authenticationService.DidNotReceive().ChallengeAsync(Arg.Any<HttpContext>(), Arg.Any<string>(), Arg.Any<AuthenticationProperties>());
+    [Fact] void should_not_call_next() => _nextCalled.ShouldBeFalse();
+}

--- a/Source/AuthProxy.Specs/for_LinkMiddleware/when_the_provider_is_not_configured.cs
+++ b/Source/AuthProxy.Specs/for_LinkMiddleware/when_the_provider_is_not_configured.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Links;
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.for_LinkMiddleware;
+
+public class when_the_provider_is_not_configured : Specification
+{
+    LinkMiddleware _middleware;
+    DefaultHttpContext _context;
+    IAuthenticationService _authenticationService;
+    bool _nextCalled;
+
+    void Establish()
+    {
+        var authConfig = Substitute.For<IOptionsMonitor<C.Authentication>>();
+        authConfig.CurrentValue.Returns(new C.Authentication());
+
+        _middleware = new LinkMiddleware(
+            _ =>
+            {
+                _nextCalled = true;
+                return Task.CompletedTask;
+            },
+            authConfig,
+            Substitute.For<ILogger<LinkMiddleware>>());
+
+        _context = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity("test")),
+        };
+        _context.Request.Path = $"{WellKnownPaths.Link}/unknown";
+        _context.Request.QueryString = QueryString.Create("token", "the-link-token");
+
+        _authenticationService = Substitute.For<IAuthenticationService>();
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IAuthenticationService)).Returns(_authenticationService);
+        _context.RequestServices = serviceProvider;
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_respond_with_not_found() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status404NotFound);
+    [Fact] void should_not_challenge() => _authenticationService.DidNotReceive().ChallengeAsync(Arg.Any<HttpContext>(), Arg.Any<string>(), Arg.Any<AuthenticationProperties>());
+    [Fact] void should_not_call_next() => _nextCalled.ShouldBeFalse();
+}

--- a/Source/AuthProxy.Specs/for_LinkMiddleware/when_the_request_is_not_a_link.cs
+++ b/Source/AuthProxy.Specs/for_LinkMiddleware/when_the_request_is_not_a_link.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Links;
+
+namespace Cratis.AuthProxy.for_LinkMiddleware;
+
+public class when_the_request_is_not_a_link : Specification
+{
+    LinkMiddleware _middleware;
+    DefaultHttpContext _context;
+    bool _nextCalled;
+
+    void Establish()
+    {
+        var authConfig = Substitute.For<IOptionsMonitor<C.Authentication>>();
+        authConfig.CurrentValue.Returns(new C.Authentication());
+
+        _middleware = new LinkMiddleware(
+            _ =>
+            {
+                _nextCalled = true;
+                return Task.CompletedTask;
+            },
+            authConfig,
+            Substitute.For<ILogger<LinkMiddleware>>());
+
+        _context = new DefaultHttpContext();
+        _context.Request.Path = "/some/application/path";
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_call_next() => _nextCalled.ShouldBeTrue();
+}

--- a/Source/AuthProxy.Specs/for_LinkMiddleware/when_the_return_url_is_not_relative.cs
+++ b/Source/AuthProxy.Specs/for_LinkMiddleware/when_the_return_url_is_not_relative.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Links;
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.for_LinkMiddleware;
+
+public class when_the_return_url_is_not_relative : Specification
+{
+    LinkMiddleware _middleware;
+    DefaultHttpContext _context;
+    IAuthenticationService _authenticationService;
+
+    void Establish()
+    {
+        var authConfig = Substitute.For<IOptionsMonitor<C.Authentication>>();
+        authConfig.CurrentValue.Returns(new C.Authentication
+        {
+            OAuthProviders = [new C.OAuthProvider { Name = "GitHub" }],
+        });
+
+        _middleware = new LinkMiddleware(
+            _ => Task.CompletedTask,
+            authConfig,
+            Substitute.For<ILogger<LinkMiddleware>>());
+
+        _context = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity("test")),
+        };
+        _context.Request.Path = $"{WellKnownPaths.Link}/github";
+        _context.Request.QueryString = QueryString.Create(new Dictionary<string, string?>
+        {
+            ["returnUrl"] = "https://evil.example.com/steal",
+            ["token"] = "the-link-token",
+        });
+
+        _authenticationService = Substitute.For<IAuthenticationService>();
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IAuthenticationService)).Returns(_authenticationService);
+        _context.RequestServices = serviceProvider;
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_fall_back_to_the_application_root() =>
+        _authenticationService.Received(1).ChallengeAsync(
+            _context,
+            "github",
+            Arg.Is<AuthenticationProperties>(properties => properties.RedirectUri == "/"));
+}

--- a/Source/AuthProxy.Specs/for_LinkMiddleware/when_the_user_is_not_authenticated.cs
+++ b/Source/AuthProxy.Specs/for_LinkMiddleware/when_the_user_is_not_authenticated.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Links;
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.for_LinkMiddleware;
+
+public class when_the_user_is_not_authenticated : Specification
+{
+    LinkMiddleware _middleware;
+    DefaultHttpContext _context;
+    IAuthenticationService _authenticationService;
+    bool _nextCalled;
+
+    void Establish()
+    {
+        var authConfig = Substitute.For<IOptionsMonitor<C.Authentication>>();
+        authConfig.CurrentValue.Returns(new C.Authentication
+        {
+            OAuthProviders = [new C.OAuthProvider { Name = "GitHub" }],
+        });
+
+        _middleware = new LinkMiddleware(
+            _ =>
+            {
+                _nextCalled = true;
+                return Task.CompletedTask;
+            },
+            authConfig,
+            Substitute.For<ILogger<LinkMiddleware>>());
+
+        // No authentication ticket - an anonymous ClaimsIdentity is not authenticated.
+        _context = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity()),
+        };
+        _context.Request.Path = $"{WellKnownPaths.Link}/github";
+        _context.Request.QueryString = QueryString.Create("token", "the-link-token");
+
+        _authenticationService = Substitute.For<IAuthenticationService>();
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IAuthenticationService)).Returns(_authenticationService);
+        _context.RequestServices = serviceProvider;
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_respond_with_unauthorized() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status401Unauthorized);
+    [Fact] void should_not_challenge() => _authenticationService.DidNotReceive().ChallengeAsync(Arg.Any<HttpContext>(), Arg.Any<string>(), Arg.Any<AuthenticationProperties>());
+    [Fact] void should_not_call_next() => _nextCalled.ShouldBeFalse();
+}

--- a/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_redirecting_outside_the_configured_allow_list.cs
+++ b/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_redirecting_outside_the_configured_allow_list.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.for_LogoutMiddleware;
+
+public class when_logging_out_redirecting_outside_the_configured_allow_list : Specification
+{
+    LogoutMiddleware _middleware;
+    DefaultHttpContext _context;
+
+    void Establish()
+    {
+        var authProxyConfig = new C.AuthProxy
+        {
+            Logout = new C.Logout
+            {
+                AllowedRedirectOrigins = ["https://cratis.studio"]
+            }
+        };
+        var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        config.CurrentValue.Returns(authProxyConfig);
+
+        _middleware = new LogoutMiddleware(_ => Task.CompletedTask, config);
+
+        _context = new DefaultHttpContext();
+        _context.Request.Scheme = "https";
+        _context.Request.Host = new HostString("app.cratis.studio");
+        _context.Request.Path = WellKnownPaths.Logout;
+        _context.Request.QueryString = QueryString.Create("redirect", "https://evil.example.com/steal");
+        _context.Response.Body = new MemoryStream();
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IAuthenticationService)).Returns(Substitute.For<IAuthenticationService>());
+        _context.RequestServices = serviceProvider;
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_fall_back_to_the_application_root() => _context.Response.Headers.Location.ToString().ShouldEqual("/");
+    [Fact] void should_respond_with_found() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status302Found);
+}

--- a/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_redirecting_to_a_configured_allowed_origin.cs
+++ b/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_redirecting_to_a_configured_allowed_origin.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.for_LogoutMiddleware;
+
+public class when_logging_out_redirecting_to_a_configured_allowed_origin : Specification
+{
+    LogoutMiddleware _middleware;
+    DefaultHttpContext _context;
+
+    void Establish()
+    {
+        var authProxyConfig = new C.AuthProxy
+        {
+            Logout = new C.Logout
+            {
+                AllowedRedirectOrigins = ["https://cratis.studio"]
+            }
+        };
+        var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        config.CurrentValue.Returns(authProxyConfig);
+
+        _middleware = new LogoutMiddleware(_ => Task.CompletedTask, config);
+
+        _context = new DefaultHttpContext();
+        _context.Request.Scheme = "https";
+        _context.Request.Host = new HostString("app.cratis.studio");
+        _context.Request.Path = WellKnownPaths.Logout;
+        _context.Request.QueryString = QueryString.Create("redirect", "https://cratis.studio");
+        _context.Response.Body = new MemoryStream();
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IAuthenticationService)).Returns(Substitute.For<IAuthenticationService>());
+        _context.RequestServices = serviceProvider;
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_redirect_to_the_configured_origin() => _context.Response.Headers.Location.ToString().ShouldEqual("https://cratis.studio");
+    [Fact] void should_respond_with_found() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status302Found);
+}

--- a/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_redirecting_to_a_configured_frontend.cs
+++ b/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_redirecting_to_a_configured_frontend.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.for_LogoutMiddleware;
+
+public class when_logging_out_redirecting_to_a_configured_frontend : Specification
+{
+    LogoutMiddleware _middleware;
+    DefaultHttpContext _context;
+
+    void Establish()
+    {
+        var authProxyConfig = new C.AuthProxy
+        {
+            Services = new Dictionary<string, C.Service>
+            {
+                ["app"] = new C.Service
+                {
+                    Frontend = new C.ServiceEndpoint { BaseUrl = "https://app.example.com/" }
+                }
+            }
+        };
+        var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        config.CurrentValue.Returns(authProxyConfig);
+
+        _middleware = new LogoutMiddleware(_ => Task.CompletedTask, config);
+
+        _context = new DefaultHttpContext();
+        _context.Request.Scheme = "https";
+        _context.Request.Host = new HostString("internal-proxy");
+        _context.Request.Path = WellKnownPaths.Logout;
+        _context.Request.QueryString = QueryString.Create("redirect", "https://app.example.com/goodbye");
+        _context.Response.Body = new MemoryStream();
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IAuthenticationService)).Returns(Substitute.For<IAuthenticationService>());
+        _context.RequestServices = serviceProvider;
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_redirect_to_the_configured_frontend() => _context.Response.Headers.Location.ToString().ShouldEqual("https://app.example.com/goodbye");
+    [Fact] void should_respond_with_found() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status302Found);
+}

--- a/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_with_a_disallowed_redirect.cs
+++ b/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_with_a_disallowed_redirect.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.for_LogoutMiddleware;
+
+public class when_logging_out_with_a_disallowed_redirect : Specification
+{
+    LogoutMiddleware _middleware;
+    DefaultHttpContext _context;
+    IAuthenticationService _authenticationService;
+
+    void Establish()
+    {
+        var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        config.CurrentValue.Returns(new C.AuthProxy());
+
+        _middleware = new LogoutMiddleware(_ => Task.CompletedTask, config);
+
+        _context = new DefaultHttpContext();
+        _context.Request.Scheme = "https";
+        _context.Request.Host = new HostString("cratis.studio");
+        _context.Request.Path = WellKnownPaths.Logout;
+        _context.Request.QueryString = QueryString.Create("redirect", "https://evil.example.com/steal");
+        _context.Response.Body = new MemoryStream();
+
+        _authenticationService = Substitute.For<IAuthenticationService>();
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IAuthenticationService)).Returns(_authenticationService);
+        _context.RequestServices = serviceProvider;
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_still_sign_the_user_out() => _authenticationService.Received(1).SignOutAsync(_context, Arg.Any<string>(), Arg.Any<AuthenticationProperties>());
+    [Fact] void should_still_clear_the_session_cookies() => _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.Identity}=;");
+    [Fact] void should_fall_back_to_the_application_root() => _context.Response.Headers.Location.ToString().ShouldEqual("/");
+    [Fact] void should_respond_with_found() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status302Found);
+}

--- a/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_with_a_valid_redirect.cs
+++ b/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_with_a_valid_redirect.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+
+namespace Cratis.AuthProxy.for_LogoutMiddleware;
+
+public class when_logging_out_with_a_valid_redirect : Specification
+{
+    LogoutMiddleware _middleware;
+    DefaultHttpContext _context;
+    IAuthenticationService _authenticationService;
+    bool _nextCalled;
+
+    void Establish()
+    {
+        var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        config.CurrentValue.Returns(new C.AuthProxy());
+
+        _middleware = new LogoutMiddleware(
+            _ =>
+            {
+                _nextCalled = true;
+                return Task.CompletedTask;
+            },
+            config);
+
+        _context = new DefaultHttpContext();
+        _context.Request.Scheme = "https";
+        _context.Request.Host = new HostString("cratis.studio");
+        _context.Request.Path = WellKnownPaths.Logout;
+        _context.Request.QueryString = QueryString.Create("redirect", "https://cratis.studio");
+        _context.Response.Body = new MemoryStream();
+
+        _authenticationService = Substitute.For<IAuthenticationService>();
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IAuthenticationService)).Returns(_authenticationService);
+        _context.RequestServices = serviceProvider;
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_sign_out_of_the_authentication_cookie() => _authenticationService.Received(1).SignOutAsync(_context, CookieAuthenticationDefaults.AuthenticationScheme, Arg.Any<AuthenticationProperties>());
+    [Fact] void should_clear_the_identity_cookie() => _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.Identity}=;");
+    [Fact] void should_clear_the_selected_tenant_cookie() => _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.Tenant}=;");
+    [Fact] void should_clear_the_tenant_list_cookie() => _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.Tenants}=;");
+    [Fact] void should_clear_the_invite_cookie() => _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.InviteToken}=;");
+    [Fact] void should_clear_the_registration_cookie() => _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.Registration}=;");
+    [Fact] void should_clear_the_providers_cookie() => _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.Providers}=;");
+    [Fact] void should_redirect_to_the_requested_target() => _context.Response.Headers.Location.ToString().ShouldEqual("https://cratis.studio");
+    [Fact] void should_respond_with_found() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status302Found);
+    [Fact] void should_not_call_next() => _nextCalled.ShouldBeFalse();
+}

--- a/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_without_a_redirect.cs
+++ b/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_without_a_redirect.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.for_LogoutMiddleware;
+
+public class when_logging_out_without_a_redirect : Specification
+{
+    LogoutMiddleware _middleware;
+    DefaultHttpContext _context;
+
+    void Establish()
+    {
+        var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        config.CurrentValue.Returns(new C.AuthProxy());
+
+        _middleware = new LogoutMiddleware(_ => Task.CompletedTask, config);
+
+        _context = new DefaultHttpContext();
+        _context.Request.Scheme = "https";
+        _context.Request.Host = new HostString("cratis.studio");
+        _context.Request.Path = WellKnownPaths.Logout;
+        _context.Response.Body = new MemoryStream();
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IAuthenticationService)).Returns(Substitute.For<IAuthenticationService>());
+        _context.RequestServices = serviceProvider;
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_fall_back_to_the_application_root() => _context.Response.Headers.Location.ToString().ShouldEqual("/");
+    [Fact] void should_respond_with_found() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status302Found);
+    [Fact] void should_clear_the_session_cookies() => _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.Tenant}=;");
+}

--- a/Source/AuthProxy.Specs/for_LogoutMiddleware/when_request_is_not_a_logout.cs
+++ b/Source/AuthProxy.Specs/for_LogoutMiddleware/when_request_is_not_a_logout.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.for_LogoutMiddleware;
+
+public class when_request_is_not_a_logout : Specification
+{
+    LogoutMiddleware _middleware;
+    DefaultHttpContext _context;
+    IAuthenticationService _authenticationService;
+    bool _nextCalled;
+
+    void Establish()
+    {
+        var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        config.CurrentValue.Returns(new C.AuthProxy());
+
+        _middleware = new LogoutMiddleware(
+            _ =>
+            {
+                _nextCalled = true;
+                return Task.CompletedTask;
+            },
+            config);
+
+        _context = new DefaultHttpContext();
+        _context.Request.Path = "/products";
+        _context.Response.Body = new MemoryStream();
+
+        _authenticationService = Substitute.For<IAuthenticationService>();
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IAuthenticationService)).Returns(_authenticationService);
+        _context.RequestServices = serviceProvider;
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_call_next() => _nextCalled.ShouldBeTrue();
+    [Fact] void should_not_sign_out() => _authenticationService.DidNotReceive().SignOutAsync(Arg.Any<HttpContext>(), Arg.Any<string>(), Arg.Any<AuthenticationProperties>());
+    [Fact] void should_not_clear_any_cookies() => _context.Response.Headers.SetCookie.ToString().ShouldBeEmpty();
+}

--- a/Source/AuthProxy.Specs/for_TenantSelectionMiddleware/when_switching_tenant_retains_the_tenant_list.cs
+++ b/Source/AuthProxy.Specs/for_TenantSelectionMiddleware/when_switching_tenant_retains_the_tenant_list.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net;
+using System.Text;
+
+namespace Cratis.AuthProxy.for_TenantSelectionMiddleware;
+
+public class when_switching_tenant_retains_the_tenant_list : Specification
+{
+    TenantSelectionMiddleware _middleware;
+    DefaultHttpContext _context;
+
+    void Establish()
+    {
+        var authProxyConfig = new C.AuthProxy
+        {
+            TenantResolutions =
+            [
+                new C.TenantResolution
+                {
+                    Strategy = C.TenantSourceIdentifierResolverType.Selection,
+                    Options = new SelectionOptions
+                    {
+                        TenantsEndpoint = "https://platform.example.com/api/tenants/selectable"
+                    }
+                }
+            ]
+        };
+        var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        config.CurrentValue.Returns(authProxyConfig);
+
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        httpClientFactory.CreateClient(Arg.Any<string>())
+            .Returns(new HttpClient(new FakeTenantsHandler()));
+
+        _middleware = new TenantSelectionMiddleware(
+            _ => Task.CompletedTask,
+            config,
+            Substitute.For<ITenantResolver>(),
+            httpClientFactory,
+            Substitute.For<IErrorPageProvider>());
+
+        _context = new DefaultHttpContext();
+        _context.Request.Path = WellKnownPaths.SelectTenant;
+        _context.Request.QueryString = new QueryString("?tenantId=tenant-b&returnUrl=%2Fdashboard");
+        _context.Request.Headers.Cookie = $"{Cookies.Tenants}=%5B%7B%22id%22%3A%22tenant-a%22%7D%5D";
+        _context.Response.Body = new MemoryStream();
+        _context.User = new ClaimsPrincipal(new ClaimsIdentity([new Claim("oid", "user-id")], "aad"));
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_set_selected_tenant_cookie() => _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.Tenant}=tenant-b");
+    [Fact] void should_not_clear_the_tenant_list_cookie() => _context.Response.Headers.SetCookie.ToString().ShouldNotContain($"{Cookies.Tenants}=;");
+    [Fact] void should_redirect_to_return_url() => _context.Response.Headers.Location.ToString().ShouldEqual("/dashboard");
+
+    sealed class FakeTenantsHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """[{"id":"tenant-a","name":"Tenant A"},{"id":"tenant-b","name":"Tenant B"}]""",
+                    Encoding.UTF8,
+                    "application/json")
+            });
+    }
+}

--- a/Source/AuthProxy.Specs/for_TenantSelectionMiddleware/when_switching_to_a_tenant_that_is_not_a_member.cs
+++ b/Source/AuthProxy.Specs/for_TenantSelectionMiddleware/when_switching_to_a_tenant_that_is_not_a_member.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net;
+using System.Text;
+
+namespace Cratis.AuthProxy.for_TenantSelectionMiddleware;
+
+public class when_switching_to_a_tenant_that_is_not_a_member : Specification
+{
+    TenantSelectionMiddleware _middleware;
+    DefaultHttpContext _context;
+
+    void Establish()
+    {
+        var authProxyConfig = new C.AuthProxy
+        {
+            TenantResolutions =
+            [
+                new C.TenantResolution
+                {
+                    Strategy = C.TenantSourceIdentifierResolverType.Selection,
+                    Options = new SelectionOptions
+                    {
+                        TenantsEndpoint = "https://platform.example.com/api/tenants/selectable"
+                    }
+                }
+            ]
+        };
+        var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        config.CurrentValue.Returns(authProxyConfig);
+
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        httpClientFactory.CreateClient(Arg.Any<string>())
+            .Returns(new HttpClient(new FakeTenantsHandler()));
+
+        _middleware = new TenantSelectionMiddleware(
+            _ => Task.CompletedTask,
+            config,
+            Substitute.For<ITenantResolver>(),
+            httpClientFactory,
+            Substitute.For<IErrorPageProvider>());
+
+        _context = new DefaultHttpContext();
+        _context.Request.Path = WellKnownPaths.SelectTenant;
+        _context.Request.QueryString = new QueryString("?tenantId=tenant-c&returnUrl=%2Fdashboard");
+        _context.Response.Body = new MemoryStream();
+        _context.User = new ClaimsPrincipal(new ClaimsIdentity([new Claim("oid", "user-id")], "aad"));
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_reject_the_selection() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status400BadRequest);
+    [Fact] void should_not_set_the_selected_tenant_cookie() => _context.Response.Headers.SetCookie.ToString().ShouldNotContain(Cookies.Tenant);
+
+    sealed class FakeTenantsHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """[{"id":"tenant-a","name":"Tenant A"},{"id":"tenant-b","name":"Tenant B"}]""",
+                    Encoding.UTF8,
+                    "application/json")
+            });
+    }
+}

--- a/Source/AuthProxy/Authentication/AuthenticationServiceCollectionExtensions.cs
+++ b/Source/AuthProxy/Authentication/AuthenticationServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Net.Http.Headers;
+using Cratis.AuthProxy.Links;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -172,20 +173,7 @@ public static class AuthenticationServiceCollectionExtensions
 
                 options.Events = new OpenIdConnectEvents
                 {
-                    OnTicketReceived = context =>
-                    {
-                        if (context.Properties is not null
-                            && TenantAuthenticationState.TryResolvePostAuthenticationRedirectUri(
-                                context.HttpContext,
-                                context.Properties,
-                                context.ReturnUri,
-                                out var redirectUri))
-                        {
-                            context.ReturnUri = redirectUri;
-                        }
-
-                        return Task.CompletedTask;
-                    }
+                    OnTicketReceived = HandleTicketReceived
                 };
             });
         }
@@ -238,22 +226,44 @@ public static class AuthenticationServiceCollectionExtensions
                             await response.Content.ReadAsStringAsync(ctx.HttpContext.RequestAborted));
                         ctx.RunClaimActions(user.RootElement);
                     },
-                    OnTicketReceived = context =>
-                    {
-                        if (context.Properties is not null
-                            && TenantAuthenticationState.TryResolvePostAuthenticationRedirectUri(
-                                context.HttpContext,
-                                context.Properties,
-                                context.ReturnUri,
-                                out var redirectUri))
-                        {
-                            context.ReturnUri = redirectUri;
-                        }
-
-                        return Task.CompletedTask;
-                    }
+                    OnTicketReceived = HandleTicketReceived
                 };
             });
+        }
+    }
+
+    /// <summary>
+    /// Shared provider-callback handler. In the session-preserving link flow it captures the freshly
+    /// authenticated subject and posts it to the application <em>without</em> signing the new identity in,
+    /// so the user's primary session is preserved; otherwise it applies the tenant post-authentication
+    /// redirect resolution used by the normal login flow.
+    /// </summary>
+    /// <param name="context">The ticket-received context.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    static async Task HandleTicketReceived(TicketReceivedContext context)
+    {
+        if (context.Properties is not null
+            && context.Properties.Items.TryGetValue(LinkMiddleware.LinkModePropertyKey, out var linkMode)
+            && linkMode == "true")
+        {
+            var exchanger = context.HttpContext.RequestServices.GetRequiredService<ILinkSubjectExchanger>();
+            await exchanger.Exchange(context.Principal, context.Properties);
+
+            // Short-circuit before the RemoteAuthenticationHandler signs the ticket into the cookie scheme:
+            // the linked identity must never replace the primary session. Hand the browser back to the app.
+            context.Response.Redirect(context.Properties.RedirectUri ?? "/");
+            context.HandleResponse();
+            return;
+        }
+
+        if (context.Properties is not null
+            && TenantAuthenticationState.TryResolvePostAuthenticationRedirectUri(
+                context.HttpContext,
+                context.Properties,
+                context.ReturnUri,
+                out var redirectUri))
+        {
+            context.ReturnUri = redirectUri;
         }
     }
 }

--- a/Source/AuthProxy/Configuration/AuthProxy.cs
+++ b/Source/AuthProxy/Configuration/AuthProxy.cs
@@ -25,6 +25,12 @@ public class AuthProxy
     public Invite? Invite { get; set; }
 
     /// <summary>
+    /// Gets or sets the credential-linking configuration.
+    /// Set this section to enable the session-preserving <c>/.cratis/link/{scheme}</c> flow.
+    /// </summary>
+    public Link? Link { get; set; }
+
+    /// <summary>
     /// Gets or sets the logout configuration, including the post-logout redirect allow-list.
     /// </summary>
     public Logout Logout { get; set; } = new();

--- a/Source/AuthProxy/Configuration/AuthProxy.cs
+++ b/Source/AuthProxy/Configuration/AuthProxy.cs
@@ -25,6 +25,11 @@ public class AuthProxy
     public Invite? Invite { get; set; }
 
     /// <summary>
+    /// Gets or sets the logout configuration, including the post-logout redirect allow-list.
+    /// </summary>
+    public Logout Logout { get; set; } = new();
+
+    /// <summary>
     /// Gets or sets the tenant verification configuration.
     /// When set, the ingress calls the configured service to confirm that a resolved
     /// tenant exists before forwarding the request.

--- a/Source/AuthProxy/Configuration/Link.cs
+++ b/Source/AuthProxy/Configuration/Link.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Configuration;
+
+/// <summary>
+/// Represents the configuration for the session-preserving credential-linking flow.
+/// </summary>
+/// <remarks>
+/// The link flow lets an already signed-in user prove control of an additional identity-provider login
+/// and associate it with their existing account, without ever replacing their primary session. AuthProxy
+/// runs a second OAuth challenge for the requested provider and, on the callback, posts the freshly
+/// authenticated subject to the configured <see cref="ExchangeUrl"/> instead of signing the new identity
+/// in. This mirrors the invite-exchange callback (<see cref="Invite.ExchangeUrl"/>).
+/// </remarks>
+public class Link
+{
+    /// <summary>
+    /// Gets or sets the absolute URL of the application endpoint that records the freshly authenticated
+    /// subject for a link, e.g. <c>https://studio.example.com/api/internal/identity-providers/link</c>.
+    /// AuthProxy posts <c>{ subject, identityProvider }</c> to it with the one-time link token supplied by
+    /// the application as the bearer token, exactly as the invite exchange does.
+    /// Leave empty to disable the link callback.
+    /// </summary>
+    public string ExchangeUrl { get; set; } = string.Empty;
+}

--- a/Source/AuthProxy/Configuration/Logout.cs
+++ b/Source/AuthProxy/Configuration/Logout.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Configuration;
+
+/// <summary>
+/// Represents the configuration for the logout endpoint.
+/// </summary>
+public class Logout
+{
+    /// <summary>
+    /// Gets or sets additional origins permitted as post-logout redirect targets.
+    /// Each entry is an absolute origin (scheme and host, optionally a port), e.g. <c>https://cratis.studio</c>.
+    /// These are added to the implicit allow-list — the proxy's own public origin plus the configured
+    /// service frontends and lobby frontend. Malformed or non-HTTP(S) entries are ignored.
+    /// </summary>
+    public IList<string> AllowedRedirectOrigins { get; set; } = [];
+}

--- a/Source/AuthProxy/IngressExtensions.cs
+++ b/Source/AuthProxy/IngressExtensions.cs
@@ -5,6 +5,7 @@ using Cratis.AuthProxy.Authentication;
 using Cratis.AuthProxy.ErrorPages;
 using Cratis.AuthProxy.Identity;
 using Cratis.AuthProxy.Invites;
+using Cratis.AuthProxy.Links;
 using Cratis.AuthProxy.Registrations;
 using Cratis.AuthProxy.ReverseProxy;
 using Cratis.AuthProxy.Tenancy;
@@ -79,6 +80,7 @@ public static class IngressExtensions
         app.UseAuthentication();
         app.UseMiddleware<LogoutMiddleware>();
         app.UseMiddleware<Authentication.SelectProviderMiddleware>();
+        app.UseMiddleware<LinkMiddleware>();
         app.UseAuthorization();
         app.UseMiddleware<TenantSelectionMiddleware>();
         app.UseMiddleware<TenancyMiddleware>();

--- a/Source/AuthProxy/IngressExtensions.cs
+++ b/Source/AuthProxy/IngressExtensions.cs
@@ -77,6 +77,7 @@ public static class IngressExtensions
         app.Map(WellKnownPaths.Pages, pagesApp => ConfigurePagesPipeline(pagesApp, app.Environment, app.Services.GetRequiredService<IOptionsMonitor<C.AuthProxy>>()));
         app.UseStaticFiles();
         app.UseAuthentication();
+        app.UseMiddleware<LogoutMiddleware>();
         app.UseMiddleware<Authentication.SelectProviderMiddleware>();
         app.UseAuthorization();
         app.UseMiddleware<TenantSelectionMiddleware>();

--- a/Source/AuthProxy/Links/ILinkSubjectExchanger.cs
+++ b/Source/AuthProxy/Links/ILinkSubjectExchanger.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.Links;
+
+/// <summary>
+/// Defines a system that posts the subject of a freshly authenticated link identity to the application's
+/// configured link-exchange endpoint, so the application can associate it with the signed-in user.
+/// </summary>
+public interface ILinkSubjectExchanger
+{
+    /// <summary>
+    /// Posts the authenticated subject and identity provider for a link to the application, authenticated
+    /// with the one-time link token carried in <paramref name="properties"/>.
+    /// </summary>
+    /// <param name="principal">The principal produced by the second provider authentication.</param>
+    /// <param name="properties">The round-tripped challenge properties holding the link token.</param>
+    /// <returns>The <see cref="LinkExchangeResult"/> describing the outcome.</returns>
+    Task<LinkExchangeResult> Exchange(ClaimsPrincipal? principal, AuthenticationProperties properties);
+}

--- a/Source/AuthProxy/Links/LinkExchangeResult.cs
+++ b/Source/AuthProxy/Links/LinkExchangeResult.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Links;
+
+/// <summary>
+/// Represents the outcome of posting a freshly authenticated subject to the application's link-exchange endpoint.
+/// </summary>
+public enum LinkExchangeResult
+{
+    /// <summary>The subject was recorded by the application successfully.</summary>
+    Success = 0,
+
+    /// <summary>The exchange could not be performed or was rejected by the application.</summary>
+    Failed = 1,
+}

--- a/Source/AuthProxy/Links/LinkMiddleware.cs
+++ b/Source/AuthProxy/Links/LinkMiddleware.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Authentication;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+using C = Cratis.AuthProxy.Configuration;
+
+namespace Cratis.AuthProxy.Links;
+
+/// <summary>
+/// Middleware that initiates the session-preserving credential-linking flow.
+/// <para>
+/// A request to <c>/.cratis/link/{scheme}?returnUrl=…&amp;token=…</c> triggers an OAuth/OIDC challenge for
+/// the requested provider — but, unlike the login flow, the resulting authentication does <em>not</em>
+/// replace the primary session cookie. Instead the freshly authenticated subject is captured on the
+/// provider callback and posted to the application (see
+/// <see cref="AuthenticationServiceCollectionExtensions"/> <c>OnTicketReceived</c> and
+/// <see cref="ILinkSubjectExchanger"/>). The link mode marker and the one-time link token travel through
+/// the challenge's <see cref="AuthenticationProperties"/> so the callback can recognize the flow.
+/// </para>
+/// <para>
+/// Linking only makes sense for an already signed-in user, so an unauthenticated request is rejected
+/// rather than challenged. The <c>returnUrl</c> is constrained to a same-site relative path so the flow
+/// can never be turned into an open redirect.
+/// </para>
+/// </summary>
+/// <param name="next">The next middleware in the pipeline.</param>
+/// <param name="authConfig">The authentication configuration monitor, used to validate the requested scheme.</param>
+/// <param name="logger">The logger.</param>
+public class LinkMiddleware(
+    RequestDelegate next,
+    IOptionsMonitor<C.Authentication> authConfig,
+    ILogger<LinkMiddleware> logger)
+{
+    /// <summary>
+    /// The <see cref="AuthenticationProperties"/> item key marking a challenge as a link (rather than login) flow.
+    /// </summary>
+    public const string LinkModePropertyKey = "Cratis.AuthProxy.LinkMode";
+
+    /// <summary>
+    /// The <see cref="AuthenticationProperties"/> item key carrying the one-time link token through the challenge.
+    /// </summary>
+    public const string LinkTokenPropertyKey = "Cratis.AuthProxy.LinkToken";
+
+    const string ApplicationRoot = "/";
+
+    /// <inheritdoc cref="IMiddleware.InvokeAsync"/>
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (!context.Request.Path.StartsWithSegments(WellKnownPaths.Link, out var remaining))
+        {
+            await next(context);
+            return;
+        }
+
+        var scheme = remaining.Value?.TrimStart('/') ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(scheme) || !SchemeExists(scheme))
+        {
+            logger.LinkProviderNotConfigured(scheme);
+            context.Response.StatusCode = StatusCodes.Status404NotFound;
+            return;
+        }
+
+        // Linking augments an existing account, so it requires a signed-in user. An anonymous request has
+        // no primary account to link to — reject it instead of starting a challenge.
+        if (context.User.Identity?.IsAuthenticated != true)
+        {
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            return;
+        }
+
+        var token = context.Request.Query["token"].FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            context.Response.StatusCode = StatusCodes.Status400BadRequest;
+            return;
+        }
+
+        var properties = new AuthenticationProperties
+        {
+            RedirectUri = ResolveReturnUrl(context.Request.Query["returnUrl"].FirstOrDefault()),
+        };
+        properties.Items[LinkModePropertyKey] = "true";
+        properties.Items[LinkTokenPropertyKey] = token;
+
+        logger.InitiatingLink(scheme);
+        await context.ChallengeAsync(scheme, properties);
+    }
+
+    static string ResolveReturnUrl(string? returnUrl)
+    {
+        // The return URL is echoed back to the browser after the link completes, so it must be a same-site
+        // relative path (a single leading slash, not '//') — anything else falls back to the application
+        // root so the endpoint can never be used as an open redirect.
+        if (string.IsNullOrWhiteSpace(returnUrl))
+        {
+            return ApplicationRoot;
+        }
+
+        var isSafeRelative = Uri.TryCreate(returnUrl, UriKind.Relative, out _)
+            && returnUrl.StartsWith('/')
+            && !returnUrl.StartsWith("//", StringComparison.Ordinal);
+
+        return isSafeRelative ? returnUrl : ApplicationRoot;
+    }
+
+    bool SchemeExists(string scheme)
+    {
+        var config = authConfig.CurrentValue;
+        return config.OidcProviders.Any(provider => OidcProviderScheme.FromName(provider.Name) == scheme)
+            || config.OAuthProviders.Any(provider => OidcProviderScheme.FromName(provider.Name) == scheme);
+    }
+}

--- a/Source/AuthProxy/Links/LinkMiddlewareLogging.cs
+++ b/Source/AuthProxy/Links/LinkMiddlewareLogging.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Links;
+
+internal static partial class LinkMiddlewareLogging
+{
+    [LoggerMessage(LogLevel.Debug, "Initiating credential link challenge for scheme {Scheme}")]
+    internal static partial void InitiatingLink(this ILogger logger, string scheme);
+
+    [LoggerMessage(LogLevel.Warning, "Credential link requested for provider {Scheme} which is not configured")]
+    internal static partial void LinkProviderNotConfigured(this ILogger logger, string scheme);
+}

--- a/Source/AuthProxy/Links/LinkSubjectExchanger.cs
+++ b/Source/AuthProxy/Links/LinkSubjectExchanger.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+using C = Cratis.AuthProxy.Configuration;
+
+namespace Cratis.AuthProxy.Links;
+
+/// <summary>
+/// Posts the freshly authenticated subject of a link challenge to the application's configured
+/// <see cref="C.Link.ExchangeUrl"/>. It mirrors the invite-exchange call
+/// (<see cref="Invites.InviteMiddleware"/>): the subject and identity provider are read from the second
+/// provider's principal and posted with the one-time link token as the bearer credential. Crucially, the
+/// new identity is never signed in, so the user's primary session is preserved.
+/// </summary>
+/// <param name="config">The auth proxy configuration monitor.</param>
+/// <param name="httpClientFactory">The HTTP client factory used for the exchange call.</param>
+/// <param name="logger">The logger.</param>
+public class LinkSubjectExchanger(
+    IOptionsMonitor<C.AuthProxy> config,
+    IHttpClientFactory httpClientFactory,
+    ILogger<LinkSubjectExchanger> logger) : ILinkSubjectExchanger
+{
+    /// <inheritdoc/>
+    public async Task<LinkExchangeResult> Exchange(ClaimsPrincipal? principal, AuthenticationProperties properties)
+    {
+        var exchangeUrl = config.CurrentValue.Link?.ExchangeUrl;
+        if (string.IsNullOrWhiteSpace(exchangeUrl))
+        {
+            logger.LinkExchangeUrlNotConfigured();
+            return LinkExchangeResult.Failed;
+        }
+
+        if (!properties.Items.TryGetValue(LinkMiddleware.LinkTokenPropertyKey, out var linkToken)
+            || string.IsNullOrWhiteSpace(linkToken))
+        {
+            logger.LinkTokenMissing();
+            return LinkExchangeResult.Failed;
+        }
+
+        var subject = principal?.FindFirst("sub")?.Value
+            ?? principal?.FindFirst("oid")?.Value
+            ?? principal?.FindFirst(ClaimTypes.NameIdentifier)?.Value
+            ?? principal?.FindFirst("id")?.Value
+            ?? string.Empty;
+
+        var identityProvider = principal?.FindFirst("iss")?.Value
+            ?? principal?.FindFirst("identity_provider")?.Value
+            ?? principal?.FindFirst("http://schemas.microsoft.com/accesscontrolservice/2010/07/claims/identityprovider")?.Value
+            ?? principal?.Identity?.AuthenticationType
+            ?? string.Empty;
+
+        if (string.IsNullOrWhiteSpace(subject))
+        {
+            logger.LinkSubjectMissing();
+            return LinkExchangeResult.Failed;
+        }
+
+        using var client = httpClientFactory.CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Post, exchangeUrl);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", linkToken);
+        request.Content = JsonContent.Create(new { subject, identityProvider });
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await client.SendAsync(request);
+        }
+        catch (Exception ex)
+        {
+            logger.FailedToCallLinkExchangeEndpoint(ex, exchangeUrl);
+            return LinkExchangeResult.Failed;
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            logger.LinkExchangeEndpointFailed((int)response.StatusCode);
+            return LinkExchangeResult.Failed;
+        }
+
+        logger.LinkExchangedSuccessfully();
+        return LinkExchangeResult.Success;
+    }
+}

--- a/Source/AuthProxy/Links/LinkSubjectExchangerLogging.cs
+++ b/Source/AuthProxy/Links/LinkSubjectExchangerLogging.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Links;
+
+internal static partial class LinkSubjectExchangerLogging
+{
+    [LoggerMessage(LogLevel.Warning, "Link exchange URL is not configured - skipping link exchange")]
+    internal static partial void LinkExchangeUrlNotConfigured(this ILogger logger);
+
+    [LoggerMessage(LogLevel.Warning, "Link exchange is missing the one-time link token - skipping link exchange")]
+    internal static partial void LinkTokenMissing(this ILogger logger);
+
+    [LoggerMessage(LogLevel.Warning, "Link exchange could not resolve a subject from the authenticated identity")]
+    internal static partial void LinkSubjectMissing(this ILogger logger);
+
+    [LoggerMessage(LogLevel.Error, "Failed to call link exchange endpoint at {Url}")]
+    internal static partial void FailedToCallLinkExchangeEndpoint(this ILogger logger, Exception exception, string url);
+
+    [LoggerMessage(LogLevel.Warning, "Link exchange endpoint returned {StatusCode}")]
+    internal static partial void LinkExchangeEndpointFailed(this ILogger logger, int statusCode);
+
+    [LoggerMessage(LogLevel.Information, "Link exchanged successfully")]
+    internal static partial void LinkExchangedSuccessfully(this ILogger logger);
+}

--- a/Source/AuthProxy/Links/LinksServiceCollectionExtensions.cs
+++ b/Source/AuthProxy/Links/LinksServiceCollectionExtensions.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Links;
+
+/// <summary>
+/// Extension methods for registering credential-linking services on <see cref="WebApplicationBuilder"/>.
+/// </summary>
+public static class LinksServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the <see cref="ILinkSubjectExchanger"/> used by the session-preserving link flow.
+    /// </summary>
+    /// <param name="builder">The <see cref="WebApplicationBuilder"/> to configure.</param>
+    /// <returns>The same <see cref="WebApplicationBuilder"/> for chaining.</returns>
+    public static WebApplicationBuilder AddLinks(this WebApplicationBuilder builder)
+    {
+        builder.Services.AddSingleton<ILinkSubjectExchanger, LinkSubjectExchanger>();
+
+        return builder;
+    }
+}

--- a/Source/AuthProxy/LogoutMiddleware.cs
+++ b/Source/AuthProxy/LogoutMiddleware.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.Extensions.Options;
+using C = Cratis.AuthProxy.Configuration;
+
+namespace Cratis.AuthProxy;
+
+/// <summary>
+/// Middleware that handles the well-known logout endpoint (<see cref="WellKnownPaths.Logout"/>).
+/// It signs the user out of the authentication cookie, clears every AuthProxy session cookie and
+/// redirects to the validated <c>redirect</c> query-string target.
+/// </summary>
+/// <remarks>
+/// The post-logout redirect target is an absolute URL and can therefore not be validated with the
+/// relative-URL check used for tenant selection. Instead it is validated against an allow-list of
+/// origins that combines the proxy's own public origin (honoring forwarded headers) with the
+/// configured service frontends and lobby frontend. A missing or disallowed target falls back to the
+/// application root (<c>/</c>) so the endpoint can never be turned into an open redirect.
+/// </remarks>
+/// <param name="next">The next middleware in the pipeline.</param>
+/// <param name="config">The auth proxy configuration monitor.</param>
+public class LogoutMiddleware(
+    RequestDelegate next,
+    IOptionsMonitor<C.AuthProxy> config)
+{
+    const string RedirectQueryKey = "redirect";
+    const string ApplicationRoot = "/";
+
+    /// <inheritdoc cref="IMiddleware.InvokeAsync"/>
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (!context.Request.Path.StartsWithSegments(WellKnownPaths.Logout))
+        {
+            await next(context);
+            return;
+        }
+
+        await context.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+        ClearSessionCookies(context);
+
+        context.Response.StatusCode = StatusCodes.Status302Found;
+        context.Response.Headers.Location = ResolveRedirectTarget(context, config.CurrentValue);
+    }
+
+    static void ClearSessionCookies(HttpContext context)
+    {
+        context.Response.Cookies.Delete(Cookies.Identity);
+        context.Response.Cookies.Delete(Cookies.Tenant);
+        context.Response.Cookies.Delete(Cookies.Tenants);
+        context.Response.Cookies.Delete(Cookies.InviteToken);
+        context.Response.Cookies.Delete(Cookies.Registration);
+        context.Response.Cookies.Delete(Cookies.Providers);
+    }
+
+    static string ResolveRedirectTarget(HttpContext context, C.AuthProxy authProxyConfig)
+    {
+        var requested = context.Request.Query[RedirectQueryKey].FirstOrDefault();
+        return IsAllowedRedirect(context, authProxyConfig, requested) ? requested! : ApplicationRoot;
+    }
+
+    static bool IsAllowedRedirect(HttpContext context, C.AuthProxy authProxyConfig, string? redirect)
+    {
+        if (string.IsNullOrWhiteSpace(redirect))
+        {
+            return false;
+        }
+
+        // A relative, single-slash URL is always same-site and therefore safe.
+        if (Uri.TryCreate(redirect, UriKind.Relative, out _) && redirect.StartsWith('/') && !redirect.StartsWith("//", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (!Uri.TryCreate(redirect, UriKind.Absolute, out var target)
+            || (target.Scheme != Uri.UriSchemeHttp && target.Scheme != Uri.UriSchemeHttps))
+        {
+            return false;
+        }
+
+        var targetOrigin = target.GetLeftPart(UriPartial.Authority);
+        return GetAllowedOrigins(context, authProxyConfig)
+            .Contains(targetOrigin, StringComparer.OrdinalIgnoreCase);
+    }
+
+    static IEnumerable<string> GetAllowedOrigins(HttpContext context, C.AuthProxy authProxyConfig)
+    {
+        // The proxy's own public origin as seen by the browser (X-Forwarded-Proto is honored upstream).
+        if (context.Request.Host.HasValue
+            && Uri.TryCreate($"{context.Request.Scheme}://{context.Request.Host.Value}", UriKind.Absolute, out var self))
+        {
+            yield return self.GetLeftPart(UriPartial.Authority);
+        }
+
+        // Reuse the configured service frontends as permitted post-logout destinations.
+        foreach (var service in authProxyConfig.Services.Values)
+        {
+            if (TryGetOrigin(service.Frontend?.BaseUrl, out var origin))
+            {
+                yield return origin;
+            }
+        }
+
+        // The lobby frontend is also a permitted destination when configured.
+        if (TryGetOrigin(authProxyConfig.Invite?.Lobby?.Frontend?.BaseUrl, out var lobbyOrigin))
+        {
+            yield return lobbyOrigin;
+        }
+    }
+
+    static bool TryGetOrigin(string? url, out string origin)
+    {
+        origin = string.Empty;
+        if (string.IsNullOrWhiteSpace(url)
+            || !Uri.TryCreate(url, UriKind.Absolute, out var uri)
+            || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            return false;
+        }
+
+        origin = uri.GetLeftPart(UriPartial.Authority);
+        return true;
+    }
+}

--- a/Source/AuthProxy/LogoutMiddleware.cs
+++ b/Source/AuthProxy/LogoutMiddleware.cs
@@ -108,6 +108,15 @@ public class LogoutMiddleware(
         {
             yield return lobbyOrigin;
         }
+
+        // Any explicitly configured post-logout redirect origins (e.g. a separate marketing site).
+        foreach (var configured in authProxyConfig.Logout.AllowedRedirectOrigins)
+        {
+            if (TryGetOrigin(configured, out var configuredOrigin))
+            {
+                yield return configuredOrigin;
+            }
+        }
     }
 
     static bool TryGetOrigin(string? url, out string origin)

--- a/Source/AuthProxy/Program.cs
+++ b/Source/AuthProxy/Program.cs
@@ -5,6 +5,7 @@ using Cratis.AuthProxy;
 using Cratis.AuthProxy.Authentication;
 using Cratis.AuthProxy.Identity;
 using Cratis.AuthProxy.Invites;
+using Cratis.AuthProxy.Links;
 using Cratis.AuthProxy.ReverseProxy;
 using Cratis.AuthProxy.Tenancy;
 
@@ -17,6 +18,7 @@ builder.AddIngressAuthentication();
 builder.AddTenancy();
 builder.AddIdentityResolution();
 builder.AddInvites();
+builder.AddLinks();
 builder.SetupReverseProxy();
 
 var app = builder.Build();

--- a/Source/AuthProxy/TenantSelectionMiddleware.cs
+++ b/Source/AuthProxy/TenantSelectionMiddleware.cs
@@ -82,13 +82,15 @@ public class TenantSelectionMiddleware(
             return;
         }
 
+        // Written as a session cookie so that, once a multi-tenant user has selected a tenant, the
+        // tenant list remains available to the application's toolbar switcher for the rest of the
+        // browser session. It is intentionally not deleted on selection.
         var tenantsJson = JsonSerializer.Serialize(tenantOptions, _serializerOptions);
         context.Response.Cookies.Append(Cookies.Tenants, tenantsJson, new CookieOptions
         {
             HttpOnly = false,
             SameSite = SameSiteMode.Lax,
             Secure = context.Request.IsHttps,
-            MaxAge = TimeSpan.FromMinutes(15),
         });
 
         await errorPageProvider.WriteErrorPageAsync(
@@ -120,8 +122,8 @@ public class TenantSelectionMiddleware(
             Secure = context.Request.IsHttps,
         });
 
-        context.Response.Cookies.Delete(Cookies.Tenants);
-
+        // The tenant list is intentionally retained (not deleted) so a multi-tenant user keeps the
+        // ability to switch tenants from the application's toolbar after making a selection.
         var requestedReturnUrl = context.Request.Query["returnUrl"].FirstOrDefault();
         if (!IsSafeRelativeUrl(requestedReturnUrl))
         {

--- a/Source/AuthProxy/WellKnownPaths.cs
+++ b/Source/AuthProxy/WellKnownPaths.cs
@@ -42,6 +42,12 @@ public static class WellKnownPaths
     public const string SelectTenant = "/.cratis/select-tenant";
 
     /// <summary>
+    /// The well-known path that logs the current user out by clearing all session cookies
+    /// and redirecting to the URL supplied in the <c>redirect</c> query-string parameter.
+    /// </summary>
+    public const string Logout = "/.cratis/logout";
+
+    /// <summary>
     /// The well-known path prefix that triggers invite-token handling.
     /// Append the token to complete the URL (e.g. <c>/invite/&lt;token&gt;</c>).
     /// </summary>

--- a/Source/AuthProxy/WellKnownPaths.cs
+++ b/Source/AuthProxy/WellKnownPaths.cs
@@ -48,6 +48,14 @@ public static class WellKnownPaths
     public const string Logout = "/.cratis/logout";
 
     /// <summary>
+    /// The well-known path prefix for initiating a session-preserving link flow for a specific provider.
+    /// Append the scheme name to complete the URL (e.g. <c>/.cratis/link/github</c>).
+    /// Unlike <see cref="LoginPrefix"/>, the link flow authenticates a second provider identity for the
+    /// already signed-in user <em>without</em> replacing the primary authentication cookie/session.
+    /// </summary>
+    public const string Link = "/.cratis/link";
+
+    /// <summary>
     /// The well-known path prefix that triggers invite-token handling.
     /// Append the token to complete the URL (e.g. <c>/invite/&lt;token&gt;</c>).
     /// </summary>


### PR DESCRIPTION
> **Stacks on #59** (`feature/logout-and-persistent-tenant-switch`). Merge #59 first — until then this PR's diff includes #59's commits. The link endpoint reuses the `IngressExtensions.cs` / `WellKnownPaths.cs` changes from #59.

Adds the AuthProxy half of the "add a credential" proof-of-control flow for [Cratis/Studio#862](https://github.com/Cratis/Studio/issues/862): a session-preserving link challenge that authenticates a *second* identity-provider login for an already signed-in user and hands the freshly authenticated subject to the application — without replacing the primary session.

## Added

- `GET /.cratis/link/{scheme}` — a session-preserving credential-linking challenge. It authenticates the requested provider for an already signed-in user but, on the provider callback, captures the authenticated `subject` and posts it to the application instead of signing the new identity in, so the user's primary session is preserved. The one-time link token and a same-site-only `returnUrl` travel through the flow. (Cratis/Studio#862)
- `Cratis:AuthProxy:Link:ExchangeUrl` configuration — the application back-channel endpoint AuthProxy posts `{ subject, identityProvider }` to (with the link token as the bearer credential), the link counterpart of `Cratis:AuthProxy:Invite:ExchangeUrl`. (Cratis/Studio#862)

## Security

- The link challenge requires an authenticated session (anonymous → `401`), validates the provider scheme (unknown → `404`) and requires a one-time token (missing → `400`). `returnUrl` is constrained to a same-site relative path so the endpoint can never be turned into an open redirect. The subject is delivered to the application server-to-server from a real provider authentication — never trusted from client input. (Cratis/Studio#862)

## Notes for review

- **Not an iframe.** The design in the issue calls for an iframe, but provider consent pages send `X-Frame-Options: DENY` and AuthProxy cookies are `SameSite=Lax`, so the flow is a **popup / top-level redirect**, as agreed in the issue's posted design.
- **Session preservation** is achieved by short-circuiting `OnTicketReceived` with `context.HandleResponse()` before the `RemoteAuthenticationHandler` signs the ticket into the cookie scheme (the "capture `sub`/`iss` and short-circuit" option from the design), rather than a throwaway sign-in scheme.
- **Same-account limitation (assumption):** the challenge does not force `prompt=select_account`, so a provider with an active SSO session may silently return the *same* account. Left out because prompt handling differs across OIDC/OAuth and GitHub has no standard equivalent; flagging for review — it can be added if linking a different account of the *same* provider must be guaranteed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)