### PR TITLE
Notify the application when a user completes a sign-in

### DIFF
--- a/Documentation/configuration/sign-in.md
+++ b/Documentation/configuration/sign-in.md
@@ -1,0 +1,113 @@
+# Sign-in Notifications
+
+AuthProxy can notify the application every time a user **actually signs in** — that is, when a signed-out
+user completes an interactive identity-provider login and a fresh session is established. The application can
+then record the sign-in, for example to alert the user of a new sign-in from an unfamiliar location or device.
+
+The notification is a service-to-service back-channel, mirroring the [invite exchange](./lobby/invitation-to-organization.md)
+and the [credential link callback](./link.md): AuthProxy `POST`s a small JSON payload to a configured
+application endpoint.
+
+---
+
+## When it fires
+
+The notification fires **only on a genuine logged-out → signed-in transition**:
+
+- ✅ A signed-out user is redirected to an identity provider, authenticates, and returns with a fresh ticket.
+- ❌ An already-authenticated user making ordinary proxied requests — the existing session cookie is reused,
+  no provider round-trip happens, and no notification is sent.
+- ❌ The [credential-linking](./link.md) flow — that authenticates a *second* provider without establishing a
+  new primary session, so it is never reported as a sign-in.
+
+Technically, AuthProxy hooks the provider **callback** (`OnTicketReceived`), which the framework raises only
+when a new authentication ticket is delivered from a provider — not when an existing session is validated.
+That is what scopes the event to real sign-ins rather than every request. A notification failure never breaks
+the sign-in: the call is best-effort and any error is logged and swallowed.
+
+---
+
+## The payload
+
+AuthProxy posts the following JSON to the configured [`NotifyUrl`](#configuration):
+
+```json
+{
+  "subject": "<provider subject>",
+  "identityProvider": "<issuer / provider>",
+  "ipAddress": "<resolved client IP>",
+  "location": "<approximate location, may be empty>",
+  "browser": "<parsed browser, e.g. Chrome>",
+  "operatingSystem": "<parsed OS, e.g. Windows>",
+  "userAgent": "<raw User-Agent header>"
+}
+```
+
+- **`subject`** / **`identityProvider`** — read from the freshly authenticated principal, exactly as the invite
+  and link exchanges do.
+- **`ipAddress`** — the client IP, taken from the left-most `X-Forwarded-For` entry (falling back to the
+  connection's remote address).
+- **`location`** — a best-effort, coarse location. See [Approximate location](#approximate-location) below.
+- **`browser`** / **`operatingSystem`** — parsed from the `User-Agent` header with a lightweight built-in
+  heuristic (no third-party user-agent database). Unrecognized values are sent as empty strings rather than
+  guessed.
+- **`userAgent`** — the raw header, so the application can do its own richer parsing if it wants to.
+
+Unlike the invite and link exchanges, the sign-in notification carries **no bearer token** — there is no
+user-supplied token in this flow. It relies on the endpoint being network-isolated (see [Security](#security)).
+
+---
+
+## Approximate location
+
+AuthProxy deliberately does **not** bundle a geo-IP database — that would be a heavy dependency and a data
+pipeline of its own. The `location` is instead derived from what is already on the request:
+
+- the resolved client IP (always sent); and
+- coarse geo headers that a fronting CDN or reverse proxy may add — Cloudflare's `CF-IPCountry`, and the
+  conventional `X-Geo-City` / `X-Geo-Region` / `X-Geo-Country` and `X-AppEngine-City` / `-Region` / `-Country`
+  headers.
+
+When those headers are present, `location` is assembled as `City, Region, Country`. When they are **not**
+present, `location` is empty and only the IP travels — the application can resolve a fuller location from the
+IP itself if it needs one. This keeps AuthProxy dependency-light while still recording a genuine approximate
+location wherever the infrastructure provides one.
+
+> **Note.** The client IP and any derived location are personal data. Handle and retain them in the application
+> accordingly.
+
+---
+
+## Configuration
+
+Set the application endpoint that records a completed sign-in under `Cratis:AuthProxy:SignIn:NotifyUrl`.
+
+```json
+{
+  "Cratis": {
+    "AuthProxy": {
+      "SignIn": {
+        "NotifyUrl": "https://studio.example.com/api/internal/sign-ins"
+      }
+    }
+  }
+}
+```
+
+Equivalent environment variable:
+
+```
+Cratis__AuthProxy__SignIn__NotifyUrl=https://studio.example.com/api/internal/sign-ins
+```
+
+When `NotifyUrl` is empty or the `SignIn` section is absent, sign-in notifications are disabled (nothing is
+posted).
+
+---
+
+## Security
+
+The notification endpoint is a service-to-service back-channel: it is reachable by AuthProxy, not by browsers.
+It trusts the subject AuthProxy delivers from a real provider authentication — never a client-supplied subject.
+Point `NotifyUrl` at an internal application address that is **network-isolated** from public traffic, exactly
+as for the invite and link exchanges.

--- a/Documentation/configuration/toc.yml
+++ b/Documentation/configuration/toc.yml
@@ -10,6 +10,8 @@
   href: logout.md
 - name: Credential Linking
   href: link.md
+- name: Sign-in Notifications
+  href: sign-in.md
 - name: Services
   href: services.md
 - name: Lobby

--- a/Source/AuthProxy.Specs/SignIns/RecordingHttpMessageHandler.cs
+++ b/Source/AuthProxy.Specs/SignIns/RecordingHttpMessageHandler.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net;
+
+namespace Cratis.AuthProxy.SignIns;
+
+public class RecordingHttpMessageHandler(HttpStatusCode statusCode = HttpStatusCode.OK) : HttpMessageHandler
+{
+    public HttpRequestMessage? LastRequest { get; private set; }
+
+    public string? LastRequestBody { get; private set; }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        LastRequest = request;
+        LastRequestBody = request.Content is null ? null : await request.Content.ReadAsStringAsync(cancellationToken);
+        return new HttpResponseMessage(statusCode);
+    }
+}

--- a/Source/AuthProxy.Specs/SignIns/for_ClientLocationResolver/when_resolving_from_forwarded_and_geo_headers.cs
+++ b/Source/AuthProxy.Specs/SignIns/for_ClientLocationResolver/when_resolving_from_forwarded_and_geo_headers.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.SignIns.for_ClientLocationResolver;
+
+public class when_resolving_from_forwarded_and_geo_headers : Specification
+{
+    ClientLocation _result;
+
+    void Because()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers["X-Forwarded-For"] = "203.0.113.7, 10.0.0.1";
+        context.Request.Headers["X-Geo-City"] = "Oslo";
+        context.Request.Headers["X-Geo-Region"] = "Oslo";
+        context.Request.Headers["X-Geo-Country"] = "NO";
+
+        // The left-most X-Forwarded-For entry is the original client, not the intermediate proxies.
+        _result = new ClientLocationResolver().Resolve(context);
+    }
+
+    [Fact] void should_use_the_original_client_ip() => _result.IpAddress.ShouldEqual("203.0.113.7");
+    [Fact] void should_assemble_the_location_from_geo_headers() => _result.Location.ShouldEqual("Oslo, Oslo, NO");
+}

--- a/Source/AuthProxy.Specs/SignIns/for_ClientLocationResolver/when_there_are_no_geo_headers.cs
+++ b/Source/AuthProxy.Specs/SignIns/for_ClientLocationResolver/when_there_are_no_geo_headers.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net;
+
+namespace Cratis.AuthProxy.SignIns.for_ClientLocationResolver;
+
+public class when_there_are_no_geo_headers : Specification
+{
+    ClientLocation _result;
+
+    void Because()
+    {
+        var context = new DefaultHttpContext();
+        context.Connection.RemoteIpAddress = IPAddress.Parse("198.51.100.5");
+
+        // With no forwarded header the resolver falls back to the connection's remote address.
+        _result = new ClientLocationResolver().Resolve(context);
+    }
+
+    [Fact] void should_fall_back_to_the_remote_address() => _result.IpAddress.ShouldEqual("198.51.100.5");
+    [Fact] void should_leave_the_location_empty() => _result.Location.ShouldBeEmpty();
+}

--- a/Source/AuthProxy.Specs/SignIns/for_SignInNotifier/given/a_sign_in_notifier.cs
+++ b/Source/AuthProxy.Specs/SignIns/for_SignInNotifier/given/a_sign_in_notifier.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net;
+
+namespace Cratis.AuthProxy.SignIns.for_SignInNotifier.given;
+
+public class a_sign_in_notifier : Specification
+{
+    protected const string NotifyUrl = "https://studio.example.com/api/internal/sign-ins";
+    protected const string UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+    protected SignInNotifier _notifier;
+    protected RecordingHttpMessageHandler _handler;
+    protected IOptionsMonitor<C.AuthProxy> _config;
+    protected ClaimsPrincipal _principal;
+    protected DefaultHttpContext _httpContext;
+
+    protected virtual C.AuthProxy CreateConfig() => new() { SignIn = new C.SignIn { NotifyUrl = NotifyUrl } };
+
+    protected virtual HttpStatusCode NotifyStatusCode => HttpStatusCode.OK;
+
+    protected virtual ClaimsPrincipal CreatePrincipal() => new(new ClaimsIdentity(
+    [
+        new Claim("sub", "subject-123"),
+        new Claim("iss", "https://github.com"),
+    ],
+    "github"));
+
+    void Establish()
+    {
+        _config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        _config.CurrentValue.Returns(CreateConfig());
+
+        _handler = new RecordingHttpMessageHandler(NotifyStatusCode);
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        httpClientFactory.CreateClient(Arg.Any<string>()).Returns(_ => new HttpClient(_handler));
+
+        _principal = CreatePrincipal();
+
+        _httpContext = new DefaultHttpContext();
+        _httpContext.Request.Headers.UserAgent = UserAgent;
+        _httpContext.Request.Headers["X-Forwarded-For"] = "203.0.113.7, 10.0.0.1";
+        _httpContext.Request.Headers["X-Geo-City"] = "Oslo";
+        _httpContext.Request.Headers["X-Geo-Country"] = "NO";
+
+        _notifier = new SignInNotifier(
+            _config,
+            new ClientLocationResolver(),
+            httpClientFactory,
+            Substitute.For<ILogger<SignInNotifier>>());
+    }
+}

--- a/Source/AuthProxy.Specs/SignIns/for_SignInNotifier/when_notifying_a_completed_sign_in.cs
+++ b/Source/AuthProxy.Specs/SignIns/for_SignInNotifier/when_notifying_a_completed_sign_in.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.SignIns.for_SignInNotifier.given;
+
+namespace Cratis.AuthProxy.SignIns.for_SignInNotifier;
+
+public class when_notifying_a_completed_sign_in : a_sign_in_notifier
+{
+    SignInNotificationResult _result;
+
+    async Task Because() => _result = await _notifier.Notify(_httpContext, _principal);
+
+    [Fact] void should_notify() => _result.ShouldEqual(SignInNotificationResult.Notified);
+    [Fact] void should_post_to_the_configured_notify_url() => _handler.LastRequest!.RequestUri!.ToString().ShouldEqual(NotifyUrl);
+    [Fact] void should_post() => _handler.LastRequest!.Method.ShouldEqual(HttpMethod.Post);
+    [Fact] void should_send_the_subject() => _handler.LastRequestBody!.ShouldContain("subject-123");
+    [Fact] void should_send_the_identity_provider() => _handler.LastRequestBody!.ShouldContain("https://github.com");
+    [Fact] void should_send_the_client_ip_from_the_forwarded_header() => _handler.LastRequestBody!.ShouldContain("203.0.113.7");
+    [Fact] void should_send_the_approximate_location() => _handler.LastRequestBody!.ShouldContain("Oslo");
+    [Fact] void should_send_the_parsed_browser() => _handler.LastRequestBody!.ShouldContain("Chrome");
+    [Fact] void should_send_the_parsed_operating_system() => _handler.LastRequestBody!.ShouldContain("Windows");
+}

--- a/Source/AuthProxy.Specs/SignIns/for_SignInNotifier/when_the_endpoint_returns_an_error.cs
+++ b/Source/AuthProxy.Specs/SignIns/for_SignInNotifier/when_the_endpoint_returns_an_error.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net;
+using Cratis.AuthProxy.SignIns.for_SignInNotifier.given;
+
+namespace Cratis.AuthProxy.SignIns.for_SignInNotifier;
+
+public class when_the_endpoint_returns_an_error : a_sign_in_notifier
+{
+    SignInNotificationResult _result;
+
+    protected override HttpStatusCode NotifyStatusCode => HttpStatusCode.InternalServerError;
+
+    async Task Because() => _result = await _notifier.Notify(_httpContext, _principal);
+
+    [Fact] void should_fail() => _result.ShouldEqual(SignInNotificationResult.Failed);
+    [Fact] void should_still_have_posted() => _handler.LastRequest.ShouldNotBeNull();
+}

--- a/Source/AuthProxy.Specs/SignIns/for_SignInNotifier/when_the_notify_url_is_not_configured.cs
+++ b/Source/AuthProxy.Specs/SignIns/for_SignInNotifier/when_the_notify_url_is_not_configured.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.SignIns.for_SignInNotifier.given;
+
+namespace Cratis.AuthProxy.SignIns.for_SignInNotifier;
+
+public class when_the_notify_url_is_not_configured : a_sign_in_notifier
+{
+    SignInNotificationResult _result;
+
+    protected override C.AuthProxy CreateConfig() => new() { SignIn = null };
+
+    async Task Because() => _result = await _notifier.Notify(_httpContext, _principal);
+
+    [Fact] void should_skip() => _result.ShouldEqual(SignInNotificationResult.Skipped);
+    [Fact] void should_not_post_anything() => _handler.LastRequest.ShouldBeNull();
+}

--- a/Source/AuthProxy.Specs/SignIns/for_SignInNotifier/when_the_subject_cannot_be_resolved.cs
+++ b/Source/AuthProxy.Specs/SignIns/for_SignInNotifier/when_the_subject_cannot_be_resolved.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.SignIns.for_SignInNotifier.given;
+
+namespace Cratis.AuthProxy.SignIns.for_SignInNotifier;
+
+public class when_the_subject_cannot_be_resolved : a_sign_in_notifier
+{
+    SignInNotificationResult _result;
+
+    protected override ClaimsPrincipal CreatePrincipal() => new(new ClaimsIdentity([new Claim("name", "Ada")], "github"));
+
+    async Task Because() => _result = await _notifier.Notify(_httpContext, _principal);
+
+    [Fact] void should_fail() => _result.ShouldEqual(SignInNotificationResult.Failed);
+    [Fact] void should_not_post_anything() => _handler.LastRequest.ShouldBeNull();
+}

--- a/Source/AuthProxy.Specs/SignIns/for_SignInsServiceCollectionExtensions/when_adding_sign_ins.cs
+++ b/Source/AuthProxy.Specs/SignIns/for_SignInsServiceCollectionExtensions/when_adding_sign_ins.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.AuthProxy.SignIns.for_SignInsServiceCollectionExtensions;
+
+public class when_adding_sign_ins : Specification
+{
+    ServiceProvider _serviceProvider;
+
+    void Establish()
+    {
+        var builder = WebApplication.CreateBuilder();
+
+        // The notifier depends on the shared HTTP client factory, registered by the ingress configuration in
+        // the real host; the spec adds it directly so the notifier can be constructed in isolation.
+        builder.Services.AddHttpClient();
+        builder.AddSignIns();
+        _serviceProvider = builder.Services.BuildServiceProvider();
+    }
+
+    [Fact] void should_register_the_sign_in_notifier() =>
+        _serviceProvider.GetRequiredService<ISignInNotifier>().ShouldBeOfExactType<SignInNotifier>();
+
+    [Fact] void should_register_the_client_location_resolver() =>
+        _serviceProvider.GetRequiredService<IClientLocationResolver>().ShouldBeOfExactType<ClientLocationResolver>();
+}

--- a/Source/AuthProxy.Specs/SignIns/for_UserAgentParser/when_parsing_an_empty_user_agent.cs
+++ b/Source/AuthProxy.Specs/SignIns/for_UserAgentParser/when_parsing_an_empty_user_agent.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.SignIns.for_UserAgentParser;
+
+public class when_parsing_an_empty_user_agent : Specification
+{
+    UserAgentInfo _result;
+
+    void Because() => _result = UserAgentParser.Parse(string.Empty);
+
+    [Fact] void should_be_unknown() => _result.ShouldEqual(UserAgentInfo.Unknown);
+    [Fact] void should_have_no_browser() => _result.Browser.ShouldBeEmpty();
+    [Fact] void should_have_no_operating_system() => _result.OperatingSystem.ShouldBeEmpty();
+}

--- a/Source/AuthProxy.Specs/SignIns/for_UserAgentParser/when_parsing_chrome_on_windows.cs
+++ b/Source/AuthProxy.Specs/SignIns/for_UserAgentParser/when_parsing_chrome_on_windows.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.SignIns.for_UserAgentParser;
+
+public class when_parsing_chrome_on_windows : Specification
+{
+    const string UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+    UserAgentInfo _result;
+
+    void Because() => _result = UserAgentParser.Parse(UserAgent);
+
+    [Fact] void should_detect_chrome() => _result.Browser.ShouldEqual("Chrome");
+    [Fact] void should_detect_windows() => _result.OperatingSystem.ShouldEqual("Windows");
+    [Fact] void should_keep_the_raw_value() => _result.Raw.ShouldEqual(UserAgent);
+}

--- a/Source/AuthProxy.Specs/SignIns/for_UserAgentParser/when_parsing_edge_on_windows.cs
+++ b/Source/AuthProxy.Specs/SignIns/for_UserAgentParser/when_parsing_edge_on_windows.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.SignIns.for_UserAgentParser;
+
+public class when_parsing_edge_on_windows : Specification
+{
+    const string UserAgent =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0";
+
+    UserAgentInfo _result;
+
+    void Because()
+    {
+        // Edge embeds the Chrome token, so the more specific "Edg" token has to win over "Chrome".
+        _result = UserAgentParser.Parse(UserAgent);
+    }
+
+    [Fact] void should_detect_edge() => _result.Browser.ShouldEqual("Edge");
+    [Fact] void should_detect_windows() => _result.OperatingSystem.ShouldEqual("Windows");
+}

--- a/Source/AuthProxy.Specs/SignIns/for_UserAgentParser/when_parsing_safari_on_iphone.cs
+++ b/Source/AuthProxy.Specs/SignIns/for_UserAgentParser/when_parsing_safari_on_iphone.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.SignIns.for_UserAgentParser;
+
+public class when_parsing_safari_on_iphone : Specification
+{
+    const string UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
+
+    UserAgentInfo _result;
+
+    void Because()
+    {
+        // The iPhone user-agent embeds "Mac OS X", so this also proves iOS wins over macOS.
+        _result = UserAgentParser.Parse(UserAgent);
+    }
+
+    [Fact] void should_detect_safari() => _result.Browser.ShouldEqual("Safari");
+    [Fact] void should_detect_ios() => _result.OperatingSystem.ShouldEqual("iOS");
+}

--- a/Source/AuthProxy/Authentication/AuthenticationServiceCollectionExtensions.cs
+++ b/Source/AuthProxy/Authentication/AuthenticationServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Net.Http.Headers;
 using Cratis.AuthProxy.Links;
+using Cratis.AuthProxy.SignIns;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -235,11 +236,18 @@ public static class AuthenticationServiceCollectionExtensions
     /// <summary>
     /// Shared provider-callback handler. In the session-preserving link flow it captures the freshly
     /// authenticated subject and posts it to the application <em>without</em> signing the new identity in,
-    /// so the user's primary session is preserved; otherwise it applies the tenant post-authentication
-    /// redirect resolution used by the normal login flow.
+    /// so the user's primary session is preserved; otherwise it is a genuine sign-in — a logged-out user has
+    /// completed an identity-provider login and a fresh session is about to be established — so it notifies
+    /// the application of the sign-in and applies the tenant post-authentication redirect resolution used by
+    /// the normal login flow.
     /// </summary>
     /// <param name="context">The ticket-received context.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    /// <remarks>
+    /// This handler only runs when a provider callback delivers a fresh ticket — that is, on the exact
+    /// logged-out to signed-in transition. A request that reuses an existing session cookie never reaches it,
+    /// so a sign-in is notified once per real sign-in and never on ordinary proxied traffic.
+    /// </remarks>
     static async Task HandleTicketReceived(TicketReceivedContext context)
     {
         if (context.Properties is not null
@@ -255,6 +263,12 @@ public static class AuthenticationServiceCollectionExtensions
             context.HandleResponse();
             return;
         }
+
+        // A non-link ticket means a real sign-in is completing. Notifying the application here — rather than on
+        // every proxied request — is what scopes the sign-in event to the actual logged-out to signed-in
+        // transition. It never throws, so a notification failure can never break the sign-in.
+        var notifier = context.HttpContext.RequestServices.GetRequiredService<ISignInNotifier>();
+        await notifier.Notify(context.HttpContext, context.Principal);
 
         if (context.Properties is not null
             && TenantAuthenticationState.TryResolvePostAuthenticationRedirectUri(

--- a/Source/AuthProxy/Configuration/AuthProxy.cs
+++ b/Source/AuthProxy/Configuration/AuthProxy.cs
@@ -31,6 +31,13 @@ public class AuthProxy
     public Link? Link { get; set; }
 
     /// <summary>
+    /// Gets or sets the sign-in notification configuration.
+    /// Set this section to have AuthProxy post a notification to the application whenever a user
+    /// completes an interactive sign-in.
+    /// </summary>
+    public SignIn? SignIn { get; set; }
+
+    /// <summary>
     /// Gets or sets the logout configuration, including the post-logout redirect allow-list.
     /// </summary>
     public Logout Logout { get; set; } = new();

--- a/Source/AuthProxy/Configuration/SignIn.cs
+++ b/Source/AuthProxy/Configuration/SignIn.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Configuration;
+
+/// <summary>
+/// Represents the configuration for sign-in notifications.
+/// </summary>
+/// <remarks>
+/// When a user who was signed out completes an interactive identity-provider login and a fresh session is
+/// established, AuthProxy posts a small notification to the configured <see cref="NotifyUrl"/> so the
+/// application can record the sign-in (for example to alert the user of a new sign-in). It is a
+/// service-to-service back-channel, mirroring the invite exchange (<see cref="Invite.ExchangeUrl"/>) and the
+/// credential link callback (<see cref="Link.ExchangeUrl"/>). The notification fires only on a genuine
+/// logged-out to signed-in transition — never on an already-authenticated proxied request or a session that
+/// is merely being reused.
+/// </remarks>
+public class SignIn
+{
+    /// <summary>
+    /// Gets or sets the absolute URL of the application endpoint that records a completed sign-in,
+    /// e.g. <c>https://studio.example.com/api/internal/sign-ins</c>.
+    /// AuthProxy posts <c>{ subject, identityProvider, ipAddress, location, browser, operatingSystem, userAgent }</c>
+    /// to it. Leave empty to disable sign-in notifications.
+    /// </summary>
+    public string NotifyUrl { get; set; } = string.Empty;
+}

--- a/Source/AuthProxy/Program.cs
+++ b/Source/AuthProxy/Program.cs
@@ -7,6 +7,7 @@ using Cratis.AuthProxy.Identity;
 using Cratis.AuthProxy.Invites;
 using Cratis.AuthProxy.Links;
 using Cratis.AuthProxy.ReverseProxy;
+using Cratis.AuthProxy.SignIns;
 using Cratis.AuthProxy.Tenancy;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -19,6 +20,7 @@ builder.AddTenancy();
 builder.AddIdentityResolution();
 builder.AddInvites();
 builder.AddLinks();
+builder.AddSignIns();
 builder.SetupReverseProxy();
 
 var app = builder.Build();

--- a/Source/AuthProxy/SignIns/ClientLocation.cs
+++ b/Source/AuthProxy/SignIns/ClientLocation.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.SignIns;
+
+/// <summary>
+/// Represents the approximate origin of a request — the resolved client IP address and a best-effort,
+/// human-readable location derived from it.
+/// </summary>
+/// <param name="IpAddress">The resolved client IP address, honoring <c>X-Forwarded-For</c>. Empty when it cannot be resolved.</param>
+/// <param name="Location">
+/// A best-effort, coarse location string (for example <c>"San Francisco, California, US"</c> or <c>"US"</c>),
+/// assembled from geo headers a fronting CDN/proxy may add. Empty when no geo information is available.
+/// </param>
+public record ClientLocation(string IpAddress, string Location)
+{
+    /// <summary>
+    /// Represents an unknown <see cref="ClientLocation"/> with no IP address or location.
+    /// </summary>
+    public static readonly ClientLocation Unknown = new(string.Empty, string.Empty);
+}

--- a/Source/AuthProxy/SignIns/ClientLocationResolver.cs
+++ b/Source/AuthProxy/SignIns/ClientLocationResolver.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.SignIns;
+
+/// <summary>
+/// Resolves the approximate origin of a request from its client IP address and any geo headers a fronting
+/// CDN or reverse proxy may add.
+/// </summary>
+/// <remarks>
+/// <para>
+/// AuthProxy deliberately does not bundle a geo-IP database — that would be a heavy dependency and a data
+/// pipeline of its own. Instead the location is derived from what is already on the request:
+/// </para>
+/// <list type="bullet">
+///   <item>the client IP, taken from the left-most entry of <c>X-Forwarded-For</c> (falling back to the
+///   connection's remote address), which the forwarded-headers middleware has already normalized; and</item>
+///   <item>coarse geo headers that popular fronting layers add — Cloudflare's <c>CF-IPCountry</c>, and the
+///   conventional <c>X-Geo-*</c> / <c>X-AppEngine-*</c> city/region/country headers.</item>
+/// </list>
+/// <para>
+/// When no geo headers are present the location is left empty and only the IP travels; the application can
+/// resolve a fuller location from the IP later if it chooses. This keeps AuthProxy dependency-light while
+/// still recording a genuine approximate location wherever the infrastructure provides one.
+/// </para>
+/// </remarks>
+public class ClientLocationResolver : IClientLocationResolver
+{
+    static readonly string[] _cityHeaders = ["X-Geo-City", "X-AppEngine-City", "CF-IPCity"];
+    static readonly string[] _regionHeaders = ["X-Geo-Region", "X-AppEngine-Region", "CF-Region"];
+    static readonly string[] _countryHeaders = ["X-Geo-Country", "X-AppEngine-Country", "CF-IPCountry"];
+
+    /// <inheritdoc/>
+    public ClientLocation Resolve(HttpContext context)
+    {
+        var ipAddress = ResolveIpAddress(context);
+        var location = ResolveLocation(context.Request.Headers);
+        return new ClientLocation(ipAddress, location);
+    }
+
+    static string ResolveIpAddress(HttpContext context)
+    {
+        // The forwarded-headers middleware normally rewrites the connection's remote address from
+        // X-Forwarded-For, but the header is read directly too so the left-most (original client) address is
+        // used even when the middleware is not in play or multiple proxies are chained.
+        var forwardedFor = context.Request.Headers["X-Forwarded-For"].FirstOrDefault();
+        if (!string.IsNullOrWhiteSpace(forwardedFor))
+        {
+            var firstHop = forwardedFor.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).FirstOrDefault();
+            if (!string.IsNullOrWhiteSpace(firstHop))
+            {
+                return firstHop;
+            }
+        }
+
+        return context.Connection.RemoteIpAddress?.ToString() ?? string.Empty;
+    }
+
+    static string ResolveLocation(IHeaderDictionary headers)
+    {
+        var city = FirstHeaderValue(headers, _cityHeaders);
+        var region = FirstHeaderValue(headers, _regionHeaders);
+        var country = FirstHeaderValue(headers, _countryHeaders);
+
+        var parts = new[] { city, region, country }.Where(part => !string.IsNullOrWhiteSpace(part));
+        return string.Join(", ", parts);
+    }
+
+    static string FirstHeaderValue(IHeaderDictionary headers, string[] names)
+    {
+        foreach (var name in names)
+        {
+            var value = headers[name].FirstOrDefault();
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value.Trim();
+            }
+        }
+
+        return string.Empty;
+    }
+}

--- a/Source/AuthProxy/SignIns/IClientLocationResolver.cs
+++ b/Source/AuthProxy/SignIns/IClientLocationResolver.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.SignIns;
+
+/// <summary>
+/// Defines a system that resolves the approximate origin of a request from its transport metadata.
+/// </summary>
+public interface IClientLocationResolver
+{
+    /// <summary>
+    /// Resolves the client IP address and a best-effort approximate location for the request.
+    /// </summary>
+    /// <param name="context">The <see cref="HttpContext"/> to resolve from.</param>
+    /// <returns>The resolved <see cref="ClientLocation"/>.</returns>
+    ClientLocation Resolve(HttpContext context);
+}

--- a/Source/AuthProxy/SignIns/ISignInNotifier.cs
+++ b/Source/AuthProxy/SignIns/ISignInNotifier.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Security.Claims;
+
+namespace Cratis.AuthProxy.SignIns;
+
+/// <summary>
+/// Defines a system that notifies the application when a user completes an interactive sign-in, so the
+/// application can record it.
+/// </summary>
+public interface ISignInNotifier
+{
+    /// <summary>
+    /// Posts a completed sign-in for the freshly authenticated <paramref name="principal"/> to the
+    /// application's configured notification endpoint, together with the approximate location and browser
+    /// information derived from <paramref name="context"/>.
+    /// </summary>
+    /// <param name="context">The provider-callback request, used to derive the client's location and browser.</param>
+    /// <param name="principal">The principal established by the identity-provider authentication.</param>
+    /// <returns>The <see cref="SignInNotificationResult"/> describing the outcome.</returns>
+    /// <remarks>
+    /// Recording a sign-in must never break the sign-in itself, so an implementation is expected to be fully
+    /// resilient — it reports failures through the returned result rather than throwing.
+    /// </remarks>
+    Task<SignInNotificationResult> Notify(HttpContext context, ClaimsPrincipal? principal);
+}

--- a/Source/AuthProxy/SignIns/SignInNotificationResult.cs
+++ b/Source/AuthProxy/SignIns/SignInNotificationResult.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.SignIns;
+
+/// <summary>
+/// Represents the outcome of posting a completed sign-in to the application's sign-in notification endpoint.
+/// </summary>
+public enum SignInNotificationResult
+{
+    /// <summary>The sign-in was recorded by the application successfully.</summary>
+    Notified = 0,
+
+    /// <summary>No notification URL is configured, so nothing was posted.</summary>
+    Skipped = 1,
+
+    /// <summary>The notification could not be performed or was rejected by the application.</summary>
+    Failed = 2,
+}

--- a/Source/AuthProxy/SignIns/SignInNotifier.cs
+++ b/Source/AuthProxy/SignIns/SignInNotifier.cs
@@ -1,0 +1,93 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Security.Claims;
+using Microsoft.Extensions.Options;
+using C = Cratis.AuthProxy.Configuration;
+
+namespace Cratis.AuthProxy.SignIns;
+
+/// <summary>
+/// Posts a completed sign-in to the application's configured <see cref="C.SignIn.NotifyUrl"/>. It mirrors the
+/// invite exchange (<see cref="Invites.InviteMiddleware"/>) and credential-link callback
+/// (<see cref="Links.LinkSubjectExchanger"/>): the subject and identity provider are read from the freshly
+/// authenticated principal, enriched with the approximate location and browser derived from the request, and
+/// posted server-to-server. Recording a sign-in must never break the sign-in, so every failure is swallowed
+/// and reported through the returned <see cref="SignInNotificationResult"/>.
+/// </summary>
+/// <param name="config">The auth proxy configuration monitor.</param>
+/// <param name="locationResolver">The resolver for the request's approximate location.</param>
+/// <param name="httpClientFactory">The HTTP client factory used for the notification call.</param>
+/// <param name="logger">The logger.</param>
+public class SignInNotifier(
+    IOptionsMonitor<C.AuthProxy> config,
+    IClientLocationResolver locationResolver,
+    IHttpClientFactory httpClientFactory,
+    ILogger<SignInNotifier> logger) : ISignInNotifier
+{
+    /// <inheritdoc/>
+    public async Task<SignInNotificationResult> Notify(HttpContext context, ClaimsPrincipal? principal)
+    {
+        var notifyUrl = config.CurrentValue.SignIn?.NotifyUrl;
+        if (string.IsNullOrWhiteSpace(notifyUrl))
+        {
+            return SignInNotificationResult.Skipped;
+        }
+
+        var subject = principal?.FindFirst("sub")?.Value
+            ?? principal?.FindFirst("oid")?.Value
+            ?? principal?.FindFirst(ClaimTypes.NameIdentifier)?.Value
+            ?? principal?.FindFirst("id")?.Value
+            ?? string.Empty;
+
+        if (string.IsNullOrWhiteSpace(subject))
+        {
+            logger.SignInSubjectMissing();
+            return SignInNotificationResult.Failed;
+        }
+
+        var identityProvider = principal?.FindFirst("iss")?.Value
+            ?? principal?.FindFirst("identity_provider")?.Value
+            ?? principal?.FindFirst("http://schemas.microsoft.com/accesscontrolservice/2010/07/claims/identityprovider")?.Value
+            ?? principal?.Identity?.AuthenticationType
+            ?? string.Empty;
+
+        var location = locationResolver.Resolve(context);
+        var userAgent = UserAgentParser.Parse(context.Request.Headers.UserAgent.ToString());
+
+        using var client = httpClientFactory.CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Post, notifyUrl)
+        {
+            Content = JsonContent.Create(new
+            {
+                subject,
+                identityProvider,
+                ipAddress = location.IpAddress,
+                location = location.Location,
+                browser = userAgent.Browser,
+                operatingSystem = userAgent.OperatingSystem,
+                userAgent = userAgent.Raw,
+            }),
+        };
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await client.SendAsync(request);
+        }
+        catch (Exception ex)
+        {
+            logger.FailedToCallSignInNotifyEndpoint(ex, notifyUrl);
+            return SignInNotificationResult.Failed;
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            logger.SignInNotifyEndpointFailed((int)response.StatusCode);
+            return SignInNotificationResult.Failed;
+        }
+
+        logger.SignInNotified(subject);
+        return SignInNotificationResult.Notified;
+    }
+}

--- a/Source/AuthProxy/SignIns/SignInNotifierLogging.cs
+++ b/Source/AuthProxy/SignIns/SignInNotifierLogging.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.SignIns;
+
+internal static partial class SignInNotifierLogging
+{
+    [LoggerMessage(LogLevel.Warning, "Sign-in notification could not resolve a subject from the authenticated identity")]
+    internal static partial void SignInSubjectMissing(this ILogger logger);
+
+    [LoggerMessage(LogLevel.Error, "Failed to call sign-in notification endpoint at {Url}")]
+    internal static partial void FailedToCallSignInNotifyEndpoint(this ILogger logger, Exception exception, string url);
+
+    [LoggerMessage(LogLevel.Warning, "Sign-in notification endpoint returned {StatusCode}")]
+    internal static partial void SignInNotifyEndpointFailed(this ILogger logger, int statusCode);
+
+    [LoggerMessage(LogLevel.Information, "Sign-in notified for subject {Subject}")]
+    internal static partial void SignInNotified(this ILogger logger, string subject);
+}

--- a/Source/AuthProxy/SignIns/SignInsServiceCollectionExtensions.cs
+++ b/Source/AuthProxy/SignIns/SignInsServiceCollectionExtensions.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.SignIns;
+
+/// <summary>
+/// Extension methods for registering sign-in notification services on <see cref="WebApplicationBuilder"/>.
+/// </summary>
+public static class SignInsServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the <see cref="ISignInNotifier"/> and its <see cref="IClientLocationResolver"/> used to
+    /// notify the application of completed sign-ins.
+    /// </summary>
+    /// <param name="builder">The <see cref="WebApplicationBuilder"/> to configure.</param>
+    /// <returns>The same <see cref="WebApplicationBuilder"/> for chaining.</returns>
+    public static WebApplicationBuilder AddSignIns(this WebApplicationBuilder builder)
+    {
+        builder.Services.AddSingleton<IClientLocationResolver, ClientLocationResolver>();
+        builder.Services.AddSingleton<ISignInNotifier, SignInNotifier>();
+
+        return builder;
+    }
+}

--- a/Source/AuthProxy/SignIns/UserAgentInfo.cs
+++ b/Source/AuthProxy/SignIns/UserAgentInfo.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.SignIns;
+
+/// <summary>
+/// Represents the browser and operating system parsed from a request's <c>User-Agent</c> header.
+/// </summary>
+/// <param name="Browser">The browser name (for example <c>Chrome</c>, <c>Safari</c>, <c>Firefox</c>), or an empty string when unknown.</param>
+/// <param name="OperatingSystem">The operating system name (for example <c>Windows</c>, <c>macOS</c>, <c>iOS</c>), or an empty string when unknown.</param>
+/// <param name="Raw">The raw <c>User-Agent</c> header value.</param>
+public record UserAgentInfo(string Browser, string OperatingSystem, string Raw)
+{
+    /// <summary>
+    /// Represents an unknown <see cref="UserAgentInfo"/> with no browser, operating system, or raw value.
+    /// </summary>
+    public static readonly UserAgentInfo Unknown = new(string.Empty, string.Empty, string.Empty);
+}

--- a/Source/AuthProxy/SignIns/UserAgentParser.cs
+++ b/Source/AuthProxy/SignIns/UserAgentParser.cs
@@ -1,0 +1,106 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.SignIns;
+
+/// <summary>
+/// Parses a <c>User-Agent</c> header into a coarse browser and operating-system description.
+/// </summary>
+/// <remarks>
+/// This is a deliberately lightweight, dependency-free heuristic — it recognizes the mainstream browsers and
+/// operating systems well enough to tell a user "you signed in from Chrome on Windows", without pulling in a
+/// full user-agent database. It is not intended to be exhaustive; anything it does not recognize is reported
+/// as an empty string rather than guessed.
+/// </remarks>
+public static class UserAgentParser
+{
+    /// <summary>
+    /// Parses the supplied <c>User-Agent</c> header value.
+    /// </summary>
+    /// <param name="userAgent">The raw <c>User-Agent</c> header value.</param>
+    /// <returns>The parsed <see cref="UserAgentInfo"/>; <see cref="UserAgentInfo.Unknown"/> when the value is empty.</returns>
+    public static UserAgentInfo Parse(string? userAgent)
+    {
+        if (string.IsNullOrWhiteSpace(userAgent))
+        {
+            return UserAgentInfo.Unknown;
+        }
+
+        return new UserAgentInfo(ResolveBrowser(userAgent), ResolveOperatingSystem(userAgent), userAgent);
+    }
+
+    static string ResolveBrowser(string userAgent)
+    {
+        // Order matters: several browsers embed the tokens of the browsers they are derived from. Edge and
+        // Opera carry "Chrome"; Chrome carries "Safari"; so the most specific token has to be checked first.
+        if (Contains(userAgent, "Edg"))
+        {
+            return "Edge";
+        }
+
+        if (Contains(userAgent, "OPR") || Contains(userAgent, "Opera"))
+        {
+            return "Opera";
+        }
+
+        if (Contains(userAgent, "SamsungBrowser"))
+        {
+            return "Samsung Internet";
+        }
+
+        if (Contains(userAgent, "Firefox") || Contains(userAgent, "FxiOS"))
+        {
+            return "Firefox";
+        }
+
+        if (Contains(userAgent, "Chrome") || Contains(userAgent, "CriOS"))
+        {
+            return "Chrome";
+        }
+
+        if (Contains(userAgent, "Safari"))
+        {
+            return "Safari";
+        }
+
+        return string.Empty;
+    }
+
+    static string ResolveOperatingSystem(string userAgent)
+    {
+        // iOS and iPadOS have to be recognized before macOS: an iPad's user-agent contains "Mac OS X".
+        if (Contains(userAgent, "iPhone") || Contains(userAgent, "iPad") || Contains(userAgent, "iPod"))
+        {
+            return "iOS";
+        }
+
+        if (Contains(userAgent, "Android"))
+        {
+            return "Android";
+        }
+
+        if (Contains(userAgent, "Windows"))
+        {
+            return "Windows";
+        }
+
+        if (Contains(userAgent, "Mac OS X") || Contains(userAgent, "Macintosh"))
+        {
+            return "macOS";
+        }
+
+        if (Contains(userAgent, "CrOS"))
+        {
+            return "ChromeOS";
+        }
+
+        if (Contains(userAgent, "Linux"))
+        {
+            return "Linux";
+        }
+
+        return string.Empty;
+    }
+
+    static bool Contains(string value, string token) => value.Contains(token, StringComparison.OrdinalIgnoreCase);
+}


### PR DESCRIPTION
Adds a service-to-service back-channel that notifies the application every time a user **actually signs in** — when a signed-out user completes an interactive identity-provider login and a fresh session is established. This is the AuthProxy half of Cratis/Studio#877; the application (Studio) records a sign-in event so users can later be notified of new sign-ins.

## Added

- Sign-in notification back-channel: on a genuine logged-out → signed-in transition, AuthProxy `POST`s `{ subject, identityProvider, ipAddress, location, browser, operatingSystem, userAgent }` to a configured application endpoint (Cratis/Studio#877).
- New configuration key `Cratis:AuthProxy:SignIn:NotifyUrl`, alongside the existing `Invite:ExchangeUrl` and `Link:ExchangeUrl`. Leave it unset to disable notifications (Cratis/Studio#877).
- Approximate location derived from the client IP (honoring `X-Forwarded-For`) and any geo headers a fronting CDN/proxy adds (`CF-IPCountry`, `X-Geo-*`, `X-AppEngine-*`) — no heavy geo-IP dependency; when no geo headers are present only the IP travels (Cratis/Studio#877).
- Lightweight built-in `User-Agent` parsing into browser and operating system, with the raw header also forwarded (Cratis/Studio#877).
- Documentation: `Documentation/configuration/sign-in.md`, wired into the configuration TOC (Cratis/Studio#877).

## Behavior notes

- The notification fires **only** from the provider callback (`OnTicketReceived`), so it is scoped to real sign-ins — never on reused sessions or ordinary proxied requests. The credential-link flow short-circuits before this point, so a link is never reported as a sign-in.
- Recording a sign-in is best-effort: any failure is logged and swallowed, and never breaks the sign-in itself.

## Security

- The endpoint is a service-to-service back-channel that carries no bearer token (there is no user-supplied token in this flow); it relies on being **network-isolated** from browser traffic, exactly like the invite and link exchanges. It trusts the subject AuthProxy delivers from a real provider authentication, never a client-supplied subject.
- The client IP and derived location are personal data; the application is responsible for handling and retention.

Deployment wiring (set `Cratis:AuthProxy:SignIn:NotifyUrl` to the Studio Core internal endpoint) is a follow-up and is not part of this PR.