### PR TITLE
Full-chain logout via OIDC RP-initiated logout

### DIFF
--- a/Documentation/configuration/logout.md
+++ b/Documentation/configuration/logout.md
@@ -12,19 +12,57 @@ the authentication challenge stages, so it never bounces the user to a login pro
 
 ---
 
+## Full-chain logout
+
+A plain cookie logout leaves the user signed in at the identity provider, so the next visit silently
+re-authenticates. To avoid that, AuthProxy performs a **full-chain logout**: it ends the session both
+locally *and* at the identity provider using OIDC [RP-initiated logout](https://openid.net/specs/openid-connect-rpinitiated-1_0.html).
+
+When the session was established through an **OIDC provider**, a logout request:
+
+1. Reads the stored `id_token` and the provider the session was established with from the authentication
+   cookie, and clears the local session (see [What it clears](#what-it-clears)).
+2. Redirects (`302 Found`) the browser to that provider's **end-session endpoint** (discovered from the
+   provider's OpenID configuration) with:
+   - `id_token_hint` — the stored `id_token`, so the provider knows which session to end.
+   - `post_logout_redirect_uri` — AuthProxy's own callback, `/.cratis/logout/callback`.
+
+   The validated final `redirect` target is carried across the round-trip in a short-lived, HTTP-only
+   cookie (`.cratis-logout`) rather than in the URL.
+3. The identity provider ends its own session and redirects back to `/.cratis/logout/callback`.
+4. The callback clears every AuthProxy cookie again (idempotent) and redirects (`302 Found`) to the
+   validated final `redirect` target.
+
+> **Register the callback with each OIDC provider.** `post_logout_redirect_uri` must be allow-listed at
+> the provider, so register `https://<your-proxy-host>/.cratis/logout/callback` as a permitted
+> post-logout redirect URI for every OIDC application.
+
+### OAuth 2.0 providers (e.g. GitHub)
+
+OAuth 2.0 providers have no standard OIDC end-session endpoint and cannot be force-logged-out via a
+redirect. When the session was established through an OAuth provider — or when there is no active OIDC
+session, or the provider's discovery document advertises no end-session endpoint — AuthProxy falls back to
+a **local-only logout**: it clears its own cookies and redirects straight to the validated `redirect`
+target. The user's session at the OAuth provider is left untouched, so a later visit may still
+re-authenticate silently without asking for credentials. This is a limitation of the OAuth providers, not
+of AuthProxy.
+
+---
+
 ## What it clears
 
-A logout request:
+Both the local logout and the post-logout callback:
 
-1. Signs the user out of the authentication cookie (`.Cratis.AuthProxy.Auth.v2`), including any chunked variants.
-2. Deletes every AuthProxy session cookie:
+1. Sign the user out of the authentication cookie (`.Cratis.AuthProxy.Auth.v2`), including any chunked variants.
+2. Delete every AuthProxy session cookie:
    - `.cratis-identity`
    - `.cratis-tenant`
    - `.cratis-tenants`
    - `.cratis-invite`
    - `.cratis-registration`
    - `.cratis-providers`
-3. Redirects (`302 Found`) to the validated `redirect` target.
+
+The `.cratis-logout` carry cookie is deleted by the callback once the final target has been read from it.
 
 ---
 
@@ -38,8 +76,9 @@ for example:
 ```
 
 Because the target is absolute, it cannot be validated with the relative-URL check used elsewhere.
-Instead it is matched against an **allow-list of origins** so the endpoint can never be turned into an
-open redirect. A target is allowed when its origin (scheme + host + port) matches any of:
+Instead it is matched against an **allow-list of origins** so neither the endpoint nor its callback can be
+turned into an open redirect. The target is validated on both legs of the round-trip. A target is allowed
+when its origin (scheme + host + port) matches any of:
 
 - The proxy's **own public origin** as seen by the browser (derived from the request, honoring
   `X-Forwarded-Proto`). This covers redirecting back to the site the user is already on.
@@ -94,5 +133,6 @@ A "Log out" control in the application simply navigates the browser to the endpo
 <a href="/.cratis/logout?redirect=https://cratis.studio">Log out</a>
 ```
 
-After the redirect the user lands on the target unauthenticated; requesting a protected resource then
-triggers the normal login flow.
+For an OIDC session the browser is taken through the provider's end-session endpoint and back via the
+callback; for an OAuth session it lands on the target directly. Either way the user ends up on the target
+unauthenticated at AuthProxy, and requesting a protected resource then triggers the normal login flow.

--- a/Source/AuthProxy.Specs/for_EndSessionEndpointResolver/when_resolving_for_an_oauth_provider.cs
+++ b/Source/AuthProxy.Specs/for_EndSessionEndpointResolver/when_resolving_for_an_oauth_provider.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Authentication;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+
+namespace Cratis.AuthProxy.for_EndSessionEndpointResolver;
+
+public class when_resolving_for_an_oauth_provider : Specification
+{
+    EndSessionEndpointResolver _resolver;
+    IOptionsMonitor<OpenIdConnectOptions> _oidcOptions;
+    string? _result;
+
+    void Establish()
+    {
+        // GitHub is an OAuth 2.0 provider, not an OIDC provider, so it has no end-session endpoint and must
+        // resolve to null without inspecting the OIDC options at all.
+        var authConfig = Substitute.For<IOptionsMonitor<C.Authentication>>();
+        authConfig.CurrentValue.Returns(new C.Authentication
+        {
+            OAuthProviders = [new C.OAuthProvider { Name = "GitHub" }],
+        });
+
+        _oidcOptions = Substitute.For<IOptionsMonitor<OpenIdConnectOptions>>();
+
+        _resolver = new EndSessionEndpointResolver(authConfig, _oidcOptions, Substitute.For<ILogger<EndSessionEndpointResolver>>());
+    }
+
+    async Task Because() => _result = await _resolver.Resolve("github", CancellationToken.None);
+
+    [Fact] void should_not_resolve_an_endpoint() => _result.ShouldBeNull();
+    [Fact] void should_not_inspect_the_oidc_options() => _oidcOptions.DidNotReceive().Get(Arg.Any<string>());
+}

--- a/Source/AuthProxy.Specs/for_EndSessionEndpointResolver/when_resolving_for_an_oidc_provider_with_an_end_session_endpoint.cs
+++ b/Source/AuthProxy.Specs/for_EndSessionEndpointResolver/when_resolving_for_an_oidc_provider_with_an_end_session_endpoint.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Authentication;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+
+namespace Cratis.AuthProxy.for_EndSessionEndpointResolver;
+
+public class when_resolving_for_an_oidc_provider_with_an_end_session_endpoint : Specification
+{
+    const string EndSessionEndpoint = "https://login.microsoftonline.com/common/oauth2/v2.0/logout";
+
+    EndSessionEndpointResolver _resolver;
+    string? _result;
+
+    void Establish()
+    {
+        var authConfig = Substitute.For<IOptionsMonitor<C.Authentication>>();
+        authConfig.CurrentValue.Returns(new C.Authentication
+        {
+            OidcProviders = [new C.OidcProvider { Name = "Microsoft" }],
+        });
+
+        var options = new OpenIdConnectOptions
+        {
+            ConfigurationManager = new StaticConfigurationManager<OpenIdConnectConfiguration>(
+                new OpenIdConnectConfiguration { EndSessionEndpoint = EndSessionEndpoint }),
+        };
+
+        var oidcOptions = Substitute.For<IOptionsMonitor<OpenIdConnectOptions>>();
+        oidcOptions.Get("microsoft").Returns(options);
+
+        _resolver = new EndSessionEndpointResolver(authConfig, oidcOptions, Substitute.For<ILogger<EndSessionEndpointResolver>>());
+    }
+
+    async Task Because() => _result = await _resolver.Resolve("microsoft", CancellationToken.None);
+
+    [Fact] void should_return_the_end_session_endpoint() => _result.ShouldEqual(EndSessionEndpoint);
+}

--- a/Source/AuthProxy.Specs/for_EndSessionEndpointResolver/when_resolving_for_an_oidc_provider_without_an_end_session_endpoint.cs
+++ b/Source/AuthProxy.Specs/for_EndSessionEndpointResolver/when_resolving_for_an_oidc_provider_without_an_end_session_endpoint.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Authentication;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+
+namespace Cratis.AuthProxy.for_EndSessionEndpointResolver;
+
+public class when_resolving_for_an_oidc_provider_without_an_end_session_endpoint : Specification
+{
+    EndSessionEndpointResolver _resolver;
+    string? _result;
+
+    void Establish()
+    {
+        var authConfig = Substitute.For<IOptionsMonitor<C.Authentication>>();
+        authConfig.CurrentValue.Returns(new C.Authentication
+        {
+            OidcProviders = [new C.OidcProvider { Name = "Contoso AD" }],
+        });
+
+        var options = new OpenIdConnectOptions
+        {
+            // The discovery document does not advertise an end-session endpoint.
+            ConfigurationManager = new StaticConfigurationManager<OpenIdConnectConfiguration>(new OpenIdConnectConfiguration()),
+        };
+
+        var oidcOptions = Substitute.For<IOptionsMonitor<OpenIdConnectOptions>>();
+        oidcOptions.Get("contoso-ad").Returns(options);
+
+        _resolver = new EndSessionEndpointResolver(authConfig, oidcOptions, Substitute.For<ILogger<EndSessionEndpointResolver>>());
+    }
+
+    async Task Because() => _result = await _resolver.Resolve("contoso-ad", CancellationToken.None);
+
+    [Fact] void should_not_resolve_an_endpoint() => _result.ShouldBeNull();
+}

--- a/Source/AuthProxy.Specs/for_EndSessionEndpointResolver/when_resolving_without_a_scheme.cs
+++ b/Source/AuthProxy.Specs/for_EndSessionEndpointResolver/when_resolving_without_a_scheme.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Authentication;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+
+namespace Cratis.AuthProxy.for_EndSessionEndpointResolver;
+
+public class when_resolving_without_a_scheme : Specification
+{
+    EndSessionEndpointResolver _resolver;
+    string? _result;
+
+    void Establish()
+    {
+        var authConfig = Substitute.For<IOptionsMonitor<C.Authentication>>();
+        authConfig.CurrentValue.Returns(new C.Authentication());
+
+        _resolver = new EndSessionEndpointResolver(
+            authConfig,
+            Substitute.For<IOptionsMonitor<OpenIdConnectOptions>>(),
+            Substitute.For<ILogger<EndSessionEndpointResolver>>());
+    }
+
+    async Task Because() => _result = await _resolver.Resolve(null, CancellationToken.None);
+
+    [Fact] void should_not_resolve_an_endpoint() => _result.ShouldBeNull();
+}

--- a/Source/AuthProxy.Specs/for_LogoutMiddleware/when_completing_logout_from_the_callback.cs
+++ b/Source/AuthProxy.Specs/for_LogoutMiddleware/when_completing_logout_from_the_callback.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Authentication;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+
+namespace Cratis.AuthProxy.for_LogoutMiddleware;
+
+public class when_completing_logout_from_the_callback : Specification
+{
+    LogoutMiddleware _middleware;
+    DefaultHttpContext _context;
+    IAuthenticationService _authenticationService;
+    bool _nextCalled;
+
+    void Establish()
+    {
+        var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        config.CurrentValue.Returns(new C.AuthProxy());
+
+        _middleware = new LogoutMiddleware(
+            _ =>
+            {
+                _nextCalled = true;
+                return Task.CompletedTask;
+            },
+            config,
+            Substitute.For<IEndSessionEndpointResolver>(),
+            Substitute.For<ILogger<LogoutMiddleware>>());
+
+        _context = new DefaultHttpContext();
+        _context.Request.Scheme = "https";
+        _context.Request.Host = new HostString("cratis.studio");
+        _context.Request.Path = WellKnownPaths.LogoutCallback;
+
+        // The identity provider redirects back to the callback carrying the validated final target in the
+        // proxy-set logout cookie.
+        _context.Request.Headers.Cookie = $"{Cookies.LogoutRedirect}=https://cratis.studio";
+        _context.Response.Body = new MemoryStream();
+
+        _authenticationService = Substitute.For<IAuthenticationService>();
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IAuthenticationService)).Returns(_authenticationService);
+        _context.RequestServices = serviceProvider;
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_respond_with_found() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status302Found);
+    [Fact] void should_redirect_to_the_carried_target() => _context.Response.Headers.Location.ToString().ShouldEqual("https://cratis.studio");
+    [Fact] void should_sign_out_of_the_authentication_cookie() => _authenticationService.Received(1).SignOutAsync(_context, CookieAuthenticationDefaults.AuthenticationScheme, Arg.Any<AuthenticationProperties>());
+    [Fact] void should_clear_the_identity_cookie() => _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.Identity}=;");
+    [Fact] void should_clear_the_selected_tenant_cookie() => _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.Tenant}=;");
+    [Fact] void should_clear_the_logout_redirect_cookie() => _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.LogoutRedirect}=;");
+    [Fact] void should_not_call_next() => _nextCalled.ShouldBeFalse();
+}

--- a/Source/AuthProxy.Specs/for_LogoutMiddleware/when_completing_logout_with_a_disallowed_carried_target.cs
+++ b/Source/AuthProxy.Specs/for_LogoutMiddleware/when_completing_logout_with_a_disallowed_carried_target.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Authentication;
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.for_LogoutMiddleware;
+
+public class when_completing_logout_with_a_disallowed_carried_target : Specification
+{
+    LogoutMiddleware _middleware;
+    DefaultHttpContext _context;
+
+    void Establish()
+    {
+        var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        config.CurrentValue.Returns(new C.AuthProxy());
+
+        _middleware = new LogoutMiddleware(_ => Task.CompletedTask, config, Substitute.For<IEndSessionEndpointResolver>(), Substitute.For<ILogger<LogoutMiddleware>>());
+
+        _context = new DefaultHttpContext();
+        _context.Request.Scheme = "https";
+        _context.Request.Host = new HostString("cratis.studio");
+        _context.Request.Path = WellKnownPaths.LogoutCallback;
+
+        // Defense in depth: even though the logout cookie is proxy-set and HTTP-only, the callback re-validates
+        // the carried target against the allow-list so a forged or stale value can never open-redirect.
+        _context.Request.Headers.Cookie = $"{Cookies.LogoutRedirect}=https://evil.example.com/steal";
+        _context.Response.Body = new MemoryStream();
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IAuthenticationService)).Returns(Substitute.For<IAuthenticationService>());
+        _context.RequestServices = serviceProvider;
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_respond_with_found() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status302Found);
+    [Fact] void should_fall_back_to_the_application_root() => _context.Response.Headers.Location.ToString().ShouldEqual("/");
+    [Fact] void should_clear_the_logout_redirect_cookie() => _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.LogoutRedirect}=;");
+}

--- a/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_redirecting_outside_the_configured_allow_list.cs
+++ b/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_redirecting_outside_the_configured_allow_list.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.AuthProxy.Authentication;
 using Microsoft.AspNetCore.Authentication;
 
 namespace Cratis.AuthProxy.for_LogoutMiddleware;
@@ -22,7 +23,7 @@ public class when_logging_out_redirecting_outside_the_configured_allow_list : Sp
         var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
         config.CurrentValue.Returns(authProxyConfig);
 
-        _middleware = new LogoutMiddleware(_ => Task.CompletedTask, config);
+        _middleware = new LogoutMiddleware(_ => Task.CompletedTask, config, Substitute.For<IEndSessionEndpointResolver>(), Substitute.For<ILogger<LogoutMiddleware>>());
 
         _context = new DefaultHttpContext();
         _context.Request.Scheme = "https";

--- a/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_redirecting_to_a_configured_allowed_origin.cs
+++ b/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_redirecting_to_a_configured_allowed_origin.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.AuthProxy.Authentication;
 using Microsoft.AspNetCore.Authentication;
 
 namespace Cratis.AuthProxy.for_LogoutMiddleware;
@@ -22,7 +23,7 @@ public class when_logging_out_redirecting_to_a_configured_allowed_origin : Speci
         var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
         config.CurrentValue.Returns(authProxyConfig);
 
-        _middleware = new LogoutMiddleware(_ => Task.CompletedTask, config);
+        _middleware = new LogoutMiddleware(_ => Task.CompletedTask, config, Substitute.For<IEndSessionEndpointResolver>(), Substitute.For<ILogger<LogoutMiddleware>>());
 
         _context = new DefaultHttpContext();
         _context.Request.Scheme = "https";

--- a/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_redirecting_to_a_configured_frontend.cs
+++ b/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_redirecting_to_a_configured_frontend.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.AuthProxy.Authentication;
 using Microsoft.AspNetCore.Authentication;
 
 namespace Cratis.AuthProxy.for_LogoutMiddleware;
@@ -25,7 +26,7 @@ public class when_logging_out_redirecting_to_a_configured_frontend : Specificati
         var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
         config.CurrentValue.Returns(authProxyConfig);
 
-        _middleware = new LogoutMiddleware(_ => Task.CompletedTask, config);
+        _middleware = new LogoutMiddleware(_ => Task.CompletedTask, config, Substitute.For<IEndSessionEndpointResolver>(), Substitute.For<ILogger<LogoutMiddleware>>());
 
         _context = new DefaultHttpContext();
         _context.Request.Scheme = "https";

--- a/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_with_a_disallowed_redirect.cs
+++ b/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_with_a_disallowed_redirect.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.AuthProxy.Authentication;
 using Microsoft.AspNetCore.Authentication;
 
 namespace Cratis.AuthProxy.for_LogoutMiddleware;
@@ -16,7 +17,7 @@ public class when_logging_out_with_a_disallowed_redirect : Specification
         var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
         config.CurrentValue.Returns(new C.AuthProxy());
 
-        _middleware = new LogoutMiddleware(_ => Task.CompletedTask, config);
+        _middleware = new LogoutMiddleware(_ => Task.CompletedTask, config, Substitute.For<IEndSessionEndpointResolver>(), Substitute.For<ILogger<LogoutMiddleware>>());
 
         _context = new DefaultHttpContext();
         _context.Request.Scheme = "https";

--- a/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_with_a_valid_redirect.cs
+++ b/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_with_a_valid_redirect.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.AuthProxy.Authentication;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 
@@ -24,7 +25,9 @@ public class when_logging_out_with_a_valid_redirect : Specification
                 _nextCalled = true;
                 return Task.CompletedTask;
             },
-            config);
+            config,
+            Substitute.For<IEndSessionEndpointResolver>(),
+            Substitute.For<ILogger<LogoutMiddleware>>());
 
         _context = new DefaultHttpContext();
         _context.Request.Scheme = "https";

--- a/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_with_an_oauth_session.cs
+++ b/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_with_an_oauth_session.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Authentication;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+
+namespace Cratis.AuthProxy.for_LogoutMiddleware;
+
+public class when_logging_out_with_an_oauth_session : Specification
+{
+    LogoutMiddleware _middleware;
+    DefaultHttpContext _context;
+    IAuthenticationService _authenticationService;
+    IEndSessionEndpointResolver _endSessionEndpointResolver;
+
+    void Establish()
+    {
+        var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        config.CurrentValue.Returns(new C.AuthProxy());
+
+        // An OAuth 2.0 provider (such as GitHub) has no standard OIDC end-session endpoint, so the resolver
+        // returns null and the middleware must fall back to a local-only logout instead of redirecting.
+        _endSessionEndpointResolver = Substitute.For<IEndSessionEndpointResolver>();
+        _endSessionEndpointResolver.Resolve(Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns((string?)null);
+
+        _middleware = new LogoutMiddleware(_ => Task.CompletedTask, config, _endSessionEndpointResolver, Substitute.For<ILogger<LogoutMiddleware>>());
+
+        _context = new DefaultHttpContext();
+        _context.Request.Scheme = "https";
+        _context.Request.Host = new HostString("cratis.studio");
+        _context.Request.Path = WellKnownPaths.Logout;
+        _context.Request.QueryString = QueryString.Create("redirect", "https://cratis.studio");
+        _context.Response.Body = new MemoryStream();
+
+        var properties = new AuthenticationProperties();
+        properties.Items[AuthenticationServiceCollectionExtensions.AuthenticationSchemeStateKey] = "github";
+        var ticket = new AuthenticationTicket(new ClaimsPrincipal(new ClaimsIdentity("test")), properties, CookieAuthenticationDefaults.AuthenticationScheme);
+
+        _authenticationService = Substitute.For<IAuthenticationService>();
+        _authenticationService.AuthenticateAsync(Arg.Any<HttpContext>(), CookieAuthenticationDefaults.AuthenticationScheme)
+            .Returns(AuthenticateResult.Success(ticket));
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IAuthenticationService)).Returns(_authenticationService);
+        _context.RequestServices = serviceProvider;
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_respond_with_found() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status302Found);
+    [Fact] void should_redirect_straight_to_the_final_target() => _context.Response.Headers.Location.ToString().ShouldEqual("https://cratis.studio");
+    [Fact] void should_not_carry_a_logout_redirect_cookie() => _context.Response.Headers.SetCookie.ToString().ShouldNotContain(Cookies.LogoutRedirect);
+    [Fact] void should_sign_out_of_the_authentication_cookie() => _authenticationService.Received(1).SignOutAsync(_context, CookieAuthenticationDefaults.AuthenticationScheme, Arg.Any<AuthenticationProperties>());
+    [Fact] void should_clear_the_identity_cookie() => _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.Identity}=;");
+}

--- a/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_with_an_oidc_session.cs
+++ b/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_with_an_oidc_session.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Authentication;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+
+namespace Cratis.AuthProxy.for_LogoutMiddleware;
+
+public class when_logging_out_with_an_oidc_session : Specification
+{
+    const string EndSessionEndpoint = "https://login.microsoftonline.com/common/oauth2/v2.0/logout";
+    const string IdToken = "the-id-token";
+
+    LogoutMiddleware _middleware;
+    DefaultHttpContext _context;
+    IAuthenticationService _authenticationService;
+    IEndSessionEndpointResolver _endSessionEndpointResolver;
+
+    void Establish()
+    {
+        var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        config.CurrentValue.Returns(new C.AuthProxy());
+
+        _endSessionEndpointResolver = Substitute.For<IEndSessionEndpointResolver>();
+        _endSessionEndpointResolver.Resolve("microsoft", Arg.Any<CancellationToken>()).Returns(EndSessionEndpoint);
+
+        _middleware = new LogoutMiddleware(_ => Task.CompletedTask, config, _endSessionEndpointResolver, Substitute.For<ILogger<LogoutMiddleware>>());
+
+        _context = new DefaultHttpContext();
+        _context.Request.Scheme = "https";
+        _context.Request.Host = new HostString("cratis.studio");
+        _context.Request.Path = WellKnownPaths.Logout;
+        _context.Request.QueryString = QueryString.Create("redirect", "https://cratis.studio");
+        _context.Response.Body = new MemoryStream();
+
+        var properties = new AuthenticationProperties();
+        properties.StoreTokens([new AuthenticationToken { Name = "id_token", Value = IdToken }]);
+        properties.Items[AuthenticationServiceCollectionExtensions.AuthenticationSchemeStateKey] = "microsoft";
+
+        var ticket = new AuthenticationTicket(new ClaimsPrincipal(new ClaimsIdentity("test")), properties, CookieAuthenticationDefaults.AuthenticationScheme);
+
+        _authenticationService = Substitute.For<IAuthenticationService>();
+        _authenticationService.AuthenticateAsync(Arg.Any<HttpContext>(), CookieAuthenticationDefaults.AuthenticationScheme)
+            .Returns(AuthenticateResult.Success(ticket));
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IAuthenticationService)).Returns(_authenticationService);
+        _context.RequestServices = serviceProvider;
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_respond_with_found() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status302Found);
+    [Fact] void should_redirect_to_the_end_session_endpoint() => _context.Response.Headers.Location.ToString().ShouldContain(EndSessionEndpoint);
+    [Fact] void should_pass_the_id_token_hint() => _context.Response.Headers.Location.ToString().ShouldContain($"id_token_hint={IdToken}");
+    [Fact] void should_pass_the_post_logout_redirect_uri_pointing_at_the_callback() => _context.Response.Headers.Location.ToString().ShouldContain($"post_logout_redirect_uri={Uri.EscapeDataString($"https://cratis.studio{WellKnownPaths.LogoutCallback}")}");
+    [Fact] void should_carry_the_final_target_in_a_cookie() => _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.LogoutRedirect}=https");
+    [Fact] void should_sign_out_of_the_authentication_cookie() => _authenticationService.Received(1).SignOutAsync(_context, CookieAuthenticationDefaults.AuthenticationScheme, Arg.Any<AuthenticationProperties>());
+    [Fact] void should_clear_the_identity_cookie() => _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.Identity}=;");
+}

--- a/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_without_a_redirect.cs
+++ b/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_without_a_redirect.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.AuthProxy.Authentication;
 using Microsoft.AspNetCore.Authentication;
 
 namespace Cratis.AuthProxy.for_LogoutMiddleware;
@@ -15,7 +16,7 @@ public class when_logging_out_without_a_redirect : Specification
         var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
         config.CurrentValue.Returns(new C.AuthProxy());
 
-        _middleware = new LogoutMiddleware(_ => Task.CompletedTask, config);
+        _middleware = new LogoutMiddleware(_ => Task.CompletedTask, config, Substitute.For<IEndSessionEndpointResolver>(), Substitute.For<ILogger<LogoutMiddleware>>());
 
         _context = new DefaultHttpContext();
         _context.Request.Scheme = "https";

--- a/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_without_an_active_session.cs
+++ b/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_without_an_active_session.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Authentication;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+
+namespace Cratis.AuthProxy.for_LogoutMiddleware;
+
+public class when_logging_out_without_an_active_session : Specification
+{
+    LogoutMiddleware _middleware;
+    DefaultHttpContext _context;
+    IAuthenticationService _authenticationService;
+    IEndSessionEndpointResolver _endSessionEndpointResolver;
+
+    void Establish()
+    {
+        var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        config.CurrentValue.Returns(new C.AuthProxy());
+
+        _endSessionEndpointResolver = Substitute.For<IEndSessionEndpointResolver>();
+
+        _middleware = new LogoutMiddleware(_ => Task.CompletedTask, config, _endSessionEndpointResolver, Substitute.For<ILogger<LogoutMiddleware>>());
+
+        _context = new DefaultHttpContext();
+        _context.Request.Scheme = "https";
+        _context.Request.Host = new HostString("cratis.studio");
+        _context.Request.Path = WellKnownPaths.Logout;
+        _context.Request.QueryString = QueryString.Create("redirect", "https://cratis.studio");
+        _context.Response.Body = new MemoryStream();
+
+        // No active session: there is no ticket to read an id_token or provider scheme from, so the middleware
+        // must still clear cookies and redirect safely without attempting an RP-initiated logout.
+        _authenticationService = Substitute.For<IAuthenticationService>();
+        _authenticationService.AuthenticateAsync(Arg.Any<HttpContext>(), CookieAuthenticationDefaults.AuthenticationScheme)
+            .Returns(AuthenticateResult.NoResult());
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IAuthenticationService)).Returns(_authenticationService);
+        _context.RequestServices = serviceProvider;
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_respond_with_found() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status302Found);
+    [Fact] void should_redirect_to_the_final_target() => _context.Response.Headers.Location.ToString().ShouldEqual("https://cratis.studio");
+    [Fact] void should_not_attempt_to_resolve_an_end_session_endpoint() => _endSessionEndpointResolver.Received(1).Resolve(null, Arg.Any<CancellationToken>());
+    [Fact] void should_clear_the_identity_cookie() => _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.Identity}=;");
+    [Fact] void should_sign_out_of_the_authentication_cookie() => _authenticationService.Received(1).SignOutAsync(_context, CookieAuthenticationDefaults.AuthenticationScheme, Arg.Any<AuthenticationProperties>());
+}

--- a/Source/AuthProxy.Specs/for_LogoutMiddleware/when_request_is_not_a_logout.cs
+++ b/Source/AuthProxy.Specs/for_LogoutMiddleware/when_request_is_not_a_logout.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.AuthProxy.Authentication;
 using Microsoft.AspNetCore.Authentication;
 
 namespace Cratis.AuthProxy.for_LogoutMiddleware;
@@ -23,7 +24,9 @@ public class when_request_is_not_a_logout : Specification
                 _nextCalled = true;
                 return Task.CompletedTask;
             },
-            config);
+            config,
+            Substitute.For<IEndSessionEndpointResolver>(),
+            Substitute.For<ILogger<LogoutMiddleware>>());
 
         _context = new DefaultHttpContext();
         _context.Request.Path = "/products";

--- a/Source/AuthProxy/Authentication/AuthenticationServiceCollectionExtensions.cs
+++ b/Source/AuthProxy/Authentication/AuthenticationServiceCollectionExtensions.cs
@@ -19,6 +19,13 @@ namespace Cratis.AuthProxy.Authentication;
 public static class AuthenticationServiceCollectionExtensions
 {
     /// <summary>
+    /// The <see cref="AuthenticationProperties"/> item key recording which provider scheme established the
+    /// session. It is persisted into the authentication cookie on sign-in so a later RP-initiated logout can
+    /// resolve the correct identity provider's end-session endpoint.
+    /// </summary>
+    public const string AuthenticationSchemeStateKey = "Cratis.AuthProxy.AuthenticationScheme";
+
+    /// <summary>
     /// Registers cookie authentication, all configured OIDC providers, all configured OAuth providers,
     /// and (optionally) JWT Bearer for machine-to-machine flows.
     /// </summary>
@@ -56,6 +63,7 @@ public static class AuthenticationServiceCollectionExtensions
         builder.Services.AddSingleton<ClientCredentialsVerifier>();
         builder.Services.AddSingleton<ClientCredentialsTokenProtector>();
         builder.Services.AddSingleton<ClientCredentialsGrantService>();
+        builder.Services.AddSingleton<IEndSessionEndpointResolver, EndSessionEndpointResolver>();
         builder.Services.AddHttpClient(nameof(ClientCredentialsVerifier), client => client.Timeout = TimeSpan.FromSeconds(10));
 
         if (jwtSection.Exists())
@@ -235,8 +243,9 @@ public static class AuthenticationServiceCollectionExtensions
     /// <summary>
     /// Shared provider-callback handler. In the session-preserving link flow it captures the freshly
     /// authenticated subject and posts it to the application <em>without</em> signing the new identity in,
-    /// so the user's primary session is preserved; otherwise it applies the tenant post-authentication
-    /// redirect resolution used by the normal login flow.
+    /// so the user's primary session is preserved; otherwise it records the authenticating provider scheme
+    /// for later RP-initiated logout and applies the tenant post-authentication redirect resolution used by
+    /// the normal login flow.
     /// </summary>
     /// <param name="context">The ticket-received context.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
@@ -255,6 +264,12 @@ public static class AuthenticationServiceCollectionExtensions
             context.HandleResponse();
             return;
         }
+
+        // A non-link ticket means a real sign-in is completing. Record which provider established this session
+        // so a later RP-initiated logout can target the correct identity provider's end-session endpoint.
+        // These properties are persisted into the authentication cookie by the RemoteAuthenticationHandler that
+        // signs the ticket in.
+        context.Properties?.Items.TryAdd(AuthenticationSchemeStateKey, context.Scheme.Name);
 
         if (context.Properties is not null
             && TenantAuthenticationState.TryResolvePostAuthenticationRedirectUri(

--- a/Source/AuthProxy/Authentication/EndSessionEndpointResolver.cs
+++ b/Source/AuthProxy/Authentication/EndSessionEndpointResolver.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.Extensions.Options;
+using C = Cratis.AuthProxy.Configuration;
+
+namespace Cratis.AuthProxy.Authentication;
+
+/// <summary>
+/// Resolves the OIDC end-session endpoint by consulting the configured providers and the corresponding
+/// <see cref="OpenIdConnectOptions"/> discovery document.
+/// </summary>
+/// <param name="authConfig">The authentication configuration monitor, used to tell OIDC providers apart from OAuth providers.</param>
+/// <param name="oidcOptions">The monitor for the per-scheme <see cref="OpenIdConnectOptions"/>.</param>
+/// <param name="logger">The logger.</param>
+public class EndSessionEndpointResolver(
+    IOptionsMonitor<C.Authentication> authConfig,
+    IOptionsMonitor<OpenIdConnectOptions> oidcOptions,
+    ILogger<EndSessionEndpointResolver> logger) : IEndSessionEndpointResolver
+{
+    /// <inheritdoc/>
+    public async Task<string?> Resolve(string? scheme, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(scheme))
+        {
+            return null;
+        }
+
+        // Only OIDC providers expose a standard end-session endpoint. OAuth 2.0 providers such as GitHub
+        // cannot be force-logged-out via a redirect, so anything that is not a configured OIDC provider
+        // resolves to null and the caller performs a local-only logout.
+        var isOidcProvider = authConfig.CurrentValue.OidcProviders
+            .Any(provider => OidcProviderScheme.FromName(provider.Name) == scheme);
+        if (!isOidcProvider)
+        {
+            return null;
+        }
+
+        var options = oidcOptions.Get(scheme);
+        if (options.ConfigurationManager is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            var configuration = await options.ConfigurationManager.GetConfigurationAsync(cancellationToken);
+            return string.IsNullOrWhiteSpace(configuration.EndSessionEndpoint)
+                ? null
+                : configuration.EndSessionEndpoint;
+        }
+        catch (Exception ex)
+        {
+            // Discovery is best-effort: a provider that is unreachable or omits the end-session endpoint must
+            // never break logout. Fall back to a local-only logout instead.
+            logger.EndSessionDiscoveryFailed(scheme, ex);
+            return null;
+        }
+    }
+}

--- a/Source/AuthProxy/Authentication/EndSessionEndpointResolverLogging.cs
+++ b/Source/AuthProxy/Authentication/EndSessionEndpointResolverLogging.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authentication;
+
+internal static partial class EndSessionEndpointResolverLogging
+{
+    [LoggerMessage(LogLevel.Warning, "Could not resolve the end-session endpoint for scheme {Scheme}; falling back to a local-only logout")]
+    internal static partial void EndSessionDiscoveryFailed(this ILogger logger, string scheme, Exception exception);
+}

--- a/Source/AuthProxy/Authentication/IEndSessionEndpointResolver.cs
+++ b/Source/AuthProxy/Authentication/IEndSessionEndpointResolver.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authentication;
+
+/// <summary>
+/// Resolves the OIDC end-session endpoint (RP-initiated logout URL) for the provider a session was
+/// established with.
+/// </summary>
+public interface IEndSessionEndpointResolver
+{
+    /// <summary>
+    /// Resolves the end-session endpoint for the authentication scheme that established the current session.
+    /// </summary>
+    /// <param name="scheme">The authentication scheme name the user signed in with, or <see langword="null"/>.</param>
+    /// <param name="cancellationToken">A token to cancel the discovery lookup.</param>
+    /// <returns>
+    /// The absolute end-session endpoint URL when the scheme is an OIDC provider whose discovery document
+    /// advertises one; otherwise <see langword="null"/>. OAuth 2.0 providers (which have no standard OIDC
+    /// end-session endpoint), unknown schemes, and discovery failures all resolve to <see langword="null"/>
+    /// so the caller can fall back to a local-only logout.
+    /// </returns>
+    Task<string?> Resolve(string? scheme, CancellationToken cancellationToken);
+}

--- a/Source/AuthProxy/Cookies.cs
+++ b/Source/AuthProxy/Cookies.cs
@@ -43,4 +43,11 @@ public static class Cookies
     /// Cookie that stores the selected tenant identifier for subsequent requests.
     /// </summary>
     public const string Tenant = ".cratis-tenant";
+
+    /// <summary>
+    /// Short-lived HTTP-only cookie used to carry the validated final post-logout redirect target across
+    /// the RP-initiated logout round-trip to the identity provider's end-session endpoint and back to the
+    /// logout callback (<see cref="WellKnownPaths.LogoutCallback"/>).
+    /// </summary>
+    public const string LogoutRedirect = ".cratis-logout";
 }

--- a/Source/AuthProxy/LogoutMiddleware.cs
+++ b/Source/AuthProxy/LogoutMiddleware.cs
@@ -1,52 +1,139 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.AuthProxy.Authentication;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using AuthState = Cratis.AuthProxy.Authentication.AuthenticationServiceCollectionExtensions;
 using C = Cratis.AuthProxy.Configuration;
 
 namespace Cratis.AuthProxy;
 
 /// <summary>
-/// Middleware that handles the well-known logout endpoint (<see cref="WellKnownPaths.Logout"/>).
-/// It signs the user out of the authentication cookie, clears every AuthProxy session cookie and
-/// redirects to the validated <c>redirect</c> query-string target.
+/// Middleware that handles the well-known logout endpoint (<see cref="WellKnownPaths.Logout"/>) and its
+/// post-logout callback (<see cref="WellKnownPaths.LogoutCallback"/>). It performs a full-chain logout:
+/// when the session was established through an OIDC provider it initiates RP-initiated logout by redirecting
+/// the browser to that provider's end-session endpoint with an <c>id_token_hint</c> and a
+/// <c>post_logout_redirect_uri</c> pointing back to the callback; the callback then clears every AuthProxy
+/// cookie and redirects to the validated final destination. OAuth 2.0 providers (such as GitHub) have no
+/// standard OIDC end-session endpoint, so for those — and whenever there is no active OIDC session — it
+/// falls back to a local-only logout that clears cookies and redirects directly.
 /// </summary>
 /// <remarks>
-/// The post-logout redirect target is an absolute URL and can therefore not be validated with the
-/// relative-URL check used for tenant selection. Instead it is validated against an allow-list of
-/// origins that combines the proxy's own public origin (honoring forwarded headers) with the
-/// configured service frontends and lobby frontend. A missing or disallowed target falls back to the
-/// application root (<c>/</c>) so the endpoint can never be turned into an open redirect.
+/// The final destination is validated against an allow-list of origins on both legs of the round-trip (see
+/// <see cref="PostLogoutRedirectPolicy"/>) so neither the endpoint nor the callback can be turned into an
+/// open redirect. The final target is carried across the identity-provider round-trip in a short-lived
+/// HTTP-only cookie rather than in the URL, and is re-validated on the callback.
 /// </remarks>
 /// <param name="next">The next middleware in the pipeline.</param>
 /// <param name="config">The auth proxy configuration monitor.</param>
+/// <param name="endSessionEndpointResolver">Resolves the OIDC end-session endpoint for the authenticating provider.</param>
+/// <param name="logger">The logger.</param>
 public class LogoutMiddleware(
     RequestDelegate next,
-    IOptionsMonitor<C.AuthProxy> config)
+    IOptionsMonitor<C.AuthProxy> config,
+    IEndSessionEndpointResolver endSessionEndpointResolver,
+    ILogger<LogoutMiddleware> logger)
 {
     const string RedirectQueryKey = "redirect";
-    const string ApplicationRoot = "/";
 
     /// <inheritdoc cref="IMiddleware.InvokeAsync"/>
     public async Task InvokeAsync(HttpContext context)
     {
+        // The callback path is a segment under the logout path, so it must be matched first.
+        if (context.Request.Path.StartsWithSegments(WellKnownPaths.LogoutCallback))
+        {
+            await CompleteLogout(context, config.CurrentValue);
+            return;
+        }
+
         if (!context.Request.Path.StartsWithSegments(WellKnownPaths.Logout))
         {
             await next(context);
             return;
         }
 
-        await context.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
-        ClearSessionCookies(context);
-
-        context.Response.StatusCode = StatusCodes.Status302Found;
-        context.Response.Headers.Location = ResolveRedirectTarget(context, config.CurrentValue);
+        await InitiateLogout(context, config.CurrentValue, endSessionEndpointResolver, logger);
     }
 
-    static void ClearSessionCookies(HttpContext context)
+    static async Task InitiateLogout(
+        HttpContext context,
+        C.AuthProxy authProxyConfig,
+        IEndSessionEndpointResolver endSessionEndpointResolver,
+        ILogger logger)
     {
+        var target = PostLogoutRedirectPolicy.ResolveTarget(context, authProxyConfig, context.Request.Query[RedirectQueryKey].FirstOrDefault());
+
+        // Read the id_token and the authenticating provider scheme from the authentication cookie before it is
+        // cleared, so an RP-initiated logout can be attempted at the identity provider.
+        var authenticated = await context.AuthenticateAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+        var idToken = authenticated?.Properties?.GetTokenValue(OpenIdConnectParameterNames.IdToken);
+        var scheme = ResolveAuthenticationScheme(authenticated?.Properties);
+        var endSessionEndpoint = await endSessionEndpointResolver.Resolve(scheme, context.RequestAborted);
+
+        // Always clear the local session immediately. Even when the identity provider cannot be reached the
+        // user must end up logged out locally.
+        await SignOutAndClearCookies(context);
+
+        context.Response.StatusCode = StatusCodes.Status302Found;
+
+        if (!string.IsNullOrWhiteSpace(endSessionEndpoint) && !string.IsNullOrWhiteSpace(idToken))
+        {
+            // Carry the validated final destination across the round-trip in a short-lived cookie instead of
+            // exposing it to the identity provider in the URL. It is re-validated on the callback.
+            SetLogoutRedirectCookie(context, target);
+            context.Response.Headers.Location = BuildEndSessionRedirect(context, endSessionEndpoint!, idToken!);
+            logger.RedirectingToEndSession(scheme!);
+            return;
+        }
+
+        // OAuth 2.0 provider, no advertised end-session endpoint, or no active OIDC session: fall back to a
+        // local-only logout that redirects straight to the validated destination.
+        logger.LocalLogoutOnly(scheme ?? "(none)");
+        context.Response.Headers.Location = target;
+    }
+
+    static async Task CompleteLogout(HttpContext context, C.AuthProxy authProxyConfig)
+    {
+        // The identity provider has redirected back after ending its own session. Clear every AuthProxy cookie
+        // (idempotent with the initiation leg) and redirect to the validated final destination.
+        await SignOutAndClearCookies(context);
+
+        var target = PostLogoutRedirectPolicy.ApplicationRoot;
+        if (context.Request.Cookies.TryGetValue(Cookies.LogoutRedirect, out var carried))
+        {
+            target = PostLogoutRedirectPolicy.ResolveTarget(context, authProxyConfig, carried);
+        }
+
+        context.Response.Cookies.Delete(Cookies.LogoutRedirect);
+        context.Response.StatusCode = StatusCodes.Status302Found;
+        context.Response.Headers.Location = target;
+    }
+
+    static string BuildEndSessionRedirect(HttpContext context, string endSessionEndpoint, string idToken)
+    {
+        var callbackUri = $"{context.Request.Scheme}://{context.Request.Host}{WellKnownPaths.LogoutCallback}";
+        var parameters = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            [OpenIdConnectParameterNames.IdTokenHint] = idToken,
+            [OpenIdConnectParameterNames.PostLogoutRedirectUri] = callbackUri,
+        };
+
+        return QueryHelpers.AddQueryString(endSessionEndpoint, parameters);
+    }
+
+    static string? ResolveAuthenticationScheme(AuthenticationProperties? properties) =>
+        properties is not null
+        && properties.Items.TryGetValue(AuthState.AuthenticationSchemeStateKey, out var scheme)
+            ? scheme
+            : null;
+
+    static async Task SignOutAndClearCookies(HttpContext context)
+    {
+        await context.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
         context.Response.Cookies.Delete(Cookies.Identity);
         context.Response.Cookies.Delete(Cookies.Tenant);
         context.Response.Cookies.Delete(Cookies.Tenants);
@@ -55,81 +142,16 @@ public class LogoutMiddleware(
         context.Response.Cookies.Delete(Cookies.Providers);
     }
 
-    static string ResolveRedirectTarget(HttpContext context, C.AuthProxy authProxyConfig)
+    static void SetLogoutRedirectCookie(HttpContext context, string target)
     {
-        var requested = context.Request.Query[RedirectQueryKey].FirstOrDefault();
-        return IsAllowedRedirect(context, authProxyConfig, requested) ? requested! : ApplicationRoot;
-    }
-
-    static bool IsAllowedRedirect(HttpContext context, C.AuthProxy authProxyConfig, string? redirect)
-    {
-        if (string.IsNullOrWhiteSpace(redirect))
+        context.Response.Cookies.Append(Cookies.LogoutRedirect, target, new CookieOptions
         {
-            return false;
-        }
-
-        // A relative, single-slash URL is always same-site and therefore safe.
-        if (Uri.TryCreate(redirect, UriKind.Relative, out _) && redirect.StartsWith('/') && !redirect.StartsWith("//", StringComparison.Ordinal))
-        {
-            return true;
-        }
-
-        if (!Uri.TryCreate(redirect, UriKind.Absolute, out var target)
-            || (target.Scheme != Uri.UriSchemeHttp && target.Scheme != Uri.UriSchemeHttps))
-        {
-            return false;
-        }
-
-        var targetOrigin = target.GetLeftPart(UriPartial.Authority);
-        return GetAllowedOrigins(context, authProxyConfig)
-            .Contains(targetOrigin, StringComparer.OrdinalIgnoreCase);
-    }
-
-    static IEnumerable<string> GetAllowedOrigins(HttpContext context, C.AuthProxy authProxyConfig)
-    {
-        // The proxy's own public origin as seen by the browser (X-Forwarded-Proto is honored upstream).
-        if (context.Request.Host.HasValue
-            && Uri.TryCreate($"{context.Request.Scheme}://{context.Request.Host.Value}", UriKind.Absolute, out var self))
-        {
-            yield return self.GetLeftPart(UriPartial.Authority);
-        }
-
-        // Reuse the configured service frontends as permitted post-logout destinations.
-        foreach (var service in authProxyConfig.Services.Values)
-        {
-            if (TryGetOrigin(service.Frontend?.BaseUrl, out var origin))
-            {
-                yield return origin;
-            }
-        }
-
-        // The lobby frontend is also a permitted destination when configured.
-        if (TryGetOrigin(authProxyConfig.Invite?.Lobby?.Frontend?.BaseUrl, out var lobbyOrigin))
-        {
-            yield return lobbyOrigin;
-        }
-
-        // Any explicitly configured post-logout redirect origins (e.g. a separate marketing site).
-        foreach (var configured in authProxyConfig.Logout.AllowedRedirectOrigins)
-        {
-            if (TryGetOrigin(configured, out var configuredOrigin))
-            {
-                yield return configuredOrigin;
-            }
-        }
-    }
-
-    static bool TryGetOrigin(string? url, out string origin)
-    {
-        origin = string.Empty;
-        if (string.IsNullOrWhiteSpace(url)
-            || !Uri.TryCreate(url, UriKind.Absolute, out var uri)
-            || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
-        {
-            return false;
-        }
-
-        origin = uri.GetLeftPart(UriPartial.Authority);
-        return true;
+            HttpOnly = true,
+            SameSite = SameSiteMode.Lax,
+            Secure = context.Request.IsHttps,
+            Path = "/",
+            MaxAge = TimeSpan.FromMinutes(5),
+            IsEssential = true,
+        });
     }
 }

--- a/Source/AuthProxy/LogoutMiddlewareLogging.cs
+++ b/Source/AuthProxy/LogoutMiddlewareLogging.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy;
+
+internal static partial class LogoutMiddlewareLogging
+{
+    [LoggerMessage(LogLevel.Debug, "Redirecting to the end-session endpoint for provider {Scheme} to complete RP-initiated logout")]
+    internal static partial void RedirectingToEndSession(this ILogger logger, string scheme);
+
+    [LoggerMessage(LogLevel.Debug, "Performing a local-only logout for provider {Scheme} (no end-session endpoint available)")]
+    internal static partial void LocalLogoutOnly(this ILogger logger, string scheme);
+}

--- a/Source/AuthProxy/PostLogoutRedirectPolicy.cs
+++ b/Source/AuthProxy/PostLogoutRedirectPolicy.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using C = Cratis.AuthProxy.Configuration;
+
+namespace Cratis.AuthProxy;
+
+/// <summary>
+/// Validates post-logout redirect targets against an allow-list so the logout endpoint and its callback can
+/// never be turned into an open redirect.
+/// </summary>
+/// <remarks>
+/// The post-logout redirect target is an absolute URL and can therefore not be validated with the
+/// relative-URL check used for tenant selection. Instead it is validated against an allow-list of origins
+/// that combines the proxy's own public origin (honoring forwarded headers) with the configured service
+/// frontends, the lobby frontend, and any explicitly configured origins. A missing or disallowed target
+/// falls back to the application root (<c>/</c>).
+/// </remarks>
+public static class PostLogoutRedirectPolicy
+{
+    /// <summary>
+    /// The application root, used as the safe fallback destination when no valid target is supplied.
+    /// </summary>
+    public const string ApplicationRoot = "/";
+
+    /// <summary>
+    /// Resolves the effective redirect target, returning the requested value when it is allowed and the
+    /// application root otherwise.
+    /// </summary>
+    /// <param name="context">The current HTTP context.</param>
+    /// <param name="authProxyConfig">The auth proxy configuration.</param>
+    /// <param name="requested">The requested redirect target.</param>
+    /// <returns>The validated redirect target, or <see cref="ApplicationRoot"/> when the request is missing or disallowed.</returns>
+    public static string ResolveTarget(HttpContext context, C.AuthProxy authProxyConfig, string? requested) =>
+        IsAllowed(context, authProxyConfig, requested) ? requested! : ApplicationRoot;
+
+    /// <summary>
+    /// Determines whether the supplied redirect target is allowed.
+    /// </summary>
+    /// <param name="context">The current HTTP context.</param>
+    /// <param name="authProxyConfig">The auth proxy configuration.</param>
+    /// <param name="redirect">The redirect target to validate.</param>
+    /// <returns><see langword="true"/> when the target is a safe same-site relative path or an allow-listed absolute origin; otherwise <see langword="false"/>.</returns>
+    public static bool IsAllowed(HttpContext context, C.AuthProxy authProxyConfig, string? redirect)
+    {
+        if (string.IsNullOrWhiteSpace(redirect))
+        {
+            return false;
+        }
+
+        // A relative, single-slash URL is always same-site and therefore safe.
+        if (Uri.TryCreate(redirect, UriKind.Relative, out _) && redirect.StartsWith('/') && !redirect.StartsWith("//", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (!Uri.TryCreate(redirect, UriKind.Absolute, out var target)
+            || (target.Scheme != Uri.UriSchemeHttp && target.Scheme != Uri.UriSchemeHttps))
+        {
+            return false;
+        }
+
+        var targetOrigin = target.GetLeftPart(UriPartial.Authority);
+        return GetAllowedOrigins(context, authProxyConfig)
+            .Contains(targetOrigin, StringComparer.OrdinalIgnoreCase);
+    }
+
+    static IEnumerable<string> GetAllowedOrigins(HttpContext context, C.AuthProxy authProxyConfig)
+    {
+        // The proxy's own public origin as seen by the browser (X-Forwarded-Proto is honored upstream).
+        if (context.Request.Host.HasValue
+            && Uri.TryCreate($"{context.Request.Scheme}://{context.Request.Host.Value}", UriKind.Absolute, out var self))
+        {
+            yield return self.GetLeftPart(UriPartial.Authority);
+        }
+
+        // Reuse the configured service frontends as permitted post-logout destinations.
+        foreach (var service in authProxyConfig.Services.Values)
+        {
+            if (TryGetOrigin(service.Frontend?.BaseUrl, out var origin))
+            {
+                yield return origin;
+            }
+        }
+
+        // The lobby frontend is also a permitted destination when configured.
+        if (TryGetOrigin(authProxyConfig.Invite?.Lobby?.Frontend?.BaseUrl, out var lobbyOrigin))
+        {
+            yield return lobbyOrigin;
+        }
+
+        // Any explicitly configured post-logout redirect origins (e.g. a separate marketing site).
+        foreach (var configured in authProxyConfig.Logout.AllowedRedirectOrigins)
+        {
+            if (TryGetOrigin(configured, out var configuredOrigin))
+            {
+                yield return configuredOrigin;
+            }
+        }
+    }
+
+    static bool TryGetOrigin(string? url, out string origin)
+    {
+        origin = string.Empty;
+        if (string.IsNullOrWhiteSpace(url)
+            || !Uri.TryCreate(url, UriKind.Absolute, out var uri)
+            || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            return false;
+        }
+
+        origin = uri.GetLeftPart(UriPartial.Authority);
+        return true;
+    }
+}

--- a/Source/AuthProxy/WellKnownPaths.cs
+++ b/Source/AuthProxy/WellKnownPaths.cs
@@ -42,10 +42,20 @@ public static class WellKnownPaths
     public const string SelectTenant = "/.cratis/select-tenant";
 
     /// <summary>
-    /// The well-known path that logs the current user out by clearing all session cookies
-    /// and redirecting to the URL supplied in the <c>redirect</c> query-string parameter.
+    /// The well-known path that logs the current user out. It initiates a full-chain logout: when the
+    /// session was established through an OIDC provider it redirects the browser to that provider's
+    /// end-session endpoint (RP-initiated logout), otherwise it clears the local session directly. The
+    /// final destination is supplied in the <c>redirect</c> query-string parameter.
     /// </summary>
     public const string Logout = "/.cratis/logout";
+
+    /// <summary>
+    /// The well-known path the identity provider redirects back to after an RP-initiated logout completes.
+    /// It clears every AuthProxy-generated cookie and redirects to the validated final <c>redirect</c>
+    /// target that was carried across the round-trip. Must be a segment under <see cref="Logout"/> so the
+    /// logout middleware can distinguish it from the initiation request.
+    /// </summary>
+    public const string LogoutCallback = "/.cratis/logout/callback";
 
     /// <summary>
     /// The well-known path prefix for initiating a session-preserving link flow for a specific provider.


### PR DESCRIPTION
Logging out only cleared the local AuthProxy session, leaving the user signed in at the identity provider so the next visit silently re-authenticated. `/.cratis/logout` now performs a full-chain logout that also ends the session at the provider.

## Added

- `/.cratis/logout` now performs OIDC RP-initiated logout: for a session established through an OIDC provider it redirects the browser to the provider's `end_session_endpoint` with `id_token_hint` and a `post_logout_redirect_uri` pointing at the new `/.cratis/logout/callback`, which then clears every AuthProxy cookie and redirects to the validated final target.
- `Cratis:AuthProxy:...` OIDC applications should register `https://<proxy-host>/.cratis/logout/callback` as a permitted post-logout redirect URI.

## Changed

- The final `redirect` target is now validated against the post-logout allow-list on both legs of the round-trip (initiation and callback), and is carried across the identity-provider round-trip in a short-lived HTTP-only cookie rather than in the URL.
- OAuth 2.0 providers (such as GitHub) have no standard OIDC end-session endpoint and cannot be force-logged-out via a redirect; those sessions — and any request with no active OIDC session — fall back to the previous local-only logout (clear cookies + redirect). See `Documentation/configuration/logout.md`.