### PR TITLE
Add configurable anonymous paths for proxied services

### DIFF
--- a/Documentation/configuration/services.md
+++ b/Documentation/configuration/services.md
@@ -17,6 +17,7 @@ Services are configured under `Cratis:AuthProxy:Services`, keyed by a friendly n
         "Backend": { "BaseUrl": "http://portal-api:8080/" },
         "Frontend": { "BaseUrl": "http://portal-web:3000/" },
         "ResolveIdentityDetails": true,
+        "AnonymousPaths": [ "/welcome", "/api/webhooks/payments" ],
         "ClientCredentials": {
           "RoutePrefix": "/api",
           "VerificationPath": "/.cratis/client-credentials/verify"
@@ -37,6 +38,7 @@ Services are configured under `Cratis:AuthProxy:Services`, keyed by a friendly n
 | `Backend` | `ServiceEndpointConfig` | `null` | API backend endpoint. |
 | `Frontend` | `ServiceEndpointConfig` | `null` | SPA / static-asset frontend endpoint. |
 | `ResolveIdentityDetails` | `bool?` | `true` when Backend is set | Whether to call `/.cratis/me` on this service to enrich the identity cookie. |
+| `AnonymousPaths` | `string[]` | `[]` | Path prefixes on this service served to unauthenticated callers. See [Anonymous paths](#anonymous-paths). |
 | `ClientCredentials` | `ServiceClientCredentialsConfig` | `null` | Enables back-channel client-credentials verification and token minting for this service. |
 
 ### ServiceEndpointConfig properties
@@ -74,6 +76,77 @@ With more than one service, clients must indicate the target using one of:
 | `service` query parameter | `?service=portal` |
 
 Routes are matched case-insensitively.
+
+---
+
+## Anonymous paths
+
+By default every path behind AuthProxy requires a session. An unauthenticated request is answered by
+the provider-selection page — with **HTTP 200**, so a webhook or other non-browser caller records
+success and never retries — and anything that does reach the reverse proxy is refused by the default
+authorization policy.
+
+`AnonymousPaths` declares the paths a service genuinely serves without a session: a magic-link landing
+page, a signed-token report, a public webhook receiver.
+
+```json
+{
+  "Cratis": {
+    "AuthProxy": {
+      "Services": {
+        "portal": {
+          "Frontend": { "BaseUrl": "http://portal-web:3000/" },
+          "Backend": { "BaseUrl": "http://portal-api:8080/" },
+          "AnonymousPaths": [ "/welcome", "/api/webhooks/payments" ]
+        }
+      }
+    }
+  }
+}
+```
+
+From Aspire:
+
+```csharp
+authProxy.WithAnonymousPaths("portal", "/welcome", "/api/webhooks/payments");
+```
+
+### Matching
+
+Each entry is a **path prefix**, matched case-insensitively on segment boundaries — the same semantics
+as the built-in invite, registration and authentication-UI paths.
+
+| Declared | Matches | Does not match |
+|----------|---------|----------------|
+| `/welcome` | `/welcome`, `/welcome/`, `/WELCOME`, `/welcome/abc/def` | `/welcomex`, `/app/welcome` |
+| `/api/webhooks/payments` | `/api/webhooks/payments/...` | `/api/webhooks`, `/api/webhooks/invoices` |
+
+Because an entry covers everything below it, name the specific leaf path whenever a sibling under the
+same parent is not public.
+
+An entry must be a rooted path of literal segments. Anything else — blank, unrooted, the bare `/`, a
+doubled `//`, or a value containing `{`, `}`, `?`, `#`, `*`, `[`, `]`, `\`, `%` or whitespace — is
+**discarded**, leaving that path authenticated. Discarding is deliberate: a blank value would otherwise
+match every request and turn the whole service anonymous. A discarded entry is silent, so if a declared
+path still returns the selection page, check its spelling first.
+
+`/api` chooses the endpoint the same way the authenticated routes do: a prefix under `/api` is served by
+the service's `Backend`, anything else by its `Frontend`, falling back to whichever endpoint the service
+actually declares.
+
+### What it does and does not change
+
+- The request still travels through AuthProxy. Inbound `x-ms-client-principal`,
+  `x-ms-client-principal-id`, `x-ms-client-principal-name` and `Tenant-ID` headers are stripped as they
+  are for every other request, so a caller cannot assert an identity on an anonymous path.
+- No principal headers are injected for a caller with no session. A caller that *does* present a valid
+  session is still authenticated normally and still gets its identity headers — the path is
+  identity-*optional*, not identity-free.
+- The application remains responsible for authorizing these paths. This only stops the proxy from
+  demanding a login before the application is ever reached.
+- A declared prefix is claimed for the whole proxy. An anonymous caller cannot send a `Service-ID`
+  header, so the path itself identifies the service — in a multi-service deployment no other service can
+  serve anything under a declared prefix.
 
 ---
 

--- a/Source/Aspire/AuthProxyConfigAnnotation.cs
+++ b/Source/Aspire/AuthProxyConfigAnnotation.cs
@@ -20,4 +20,10 @@ sealed class AuthProxyConfigAnnotation : IResourceAnnotation
 
     /// <summary>Gets or sets the number of invite claim-forwarding entries that have been registered.</summary>
     public int InviteClaimForwardingCount { get; set; }
+
+    /// <summary>
+    /// Gets the number of anonymous paths registered per service key, so that repeated calls append
+    /// rather than overwrite the indices an earlier call already wrote.
+    /// </summary>
+    public Dictionary<string, int> AnonymousPathCounts { get; } = new(StringComparer.Ordinal);
 }

--- a/Source/Aspire/AuthProxyExtensions.cs
+++ b/Source/Aspire/AuthProxyExtensions.cs
@@ -93,6 +93,58 @@ public static class AuthProxyExtensions
     }
 
     /// <summary>
+    /// Declares the request paths on a named service that are served to unauthenticated callers.
+    /// </summary>
+    /// <typeparam name="T">The resource type (must support environment variables).</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="serviceName">
+    /// The service key used in the AuthProxy <c>Services</c> configuration (e.g. <c>"main"</c>).
+    /// </param>
+    /// <param name="paths">
+    /// The path prefixes to serve anonymously. Each must be a rooted path of literal segments
+    /// (e.g. <c>/portal</c>), and is matched case-insensitively on segment boundaries — <c>/portal</c>
+    /// covers <c>/portal</c> and <c>/portal/anything</c>, but not <c>/portalx</c>. Anything else is
+    /// discarded by AuthProxy, leaving that path authenticated.
+    /// </param>
+    /// <returns>The same <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    /// <remarks>
+    /// Use this for paths an application genuinely serves without a session — a magic-link landing page, a
+    /// signed-token report, a public webhook receiver. Without it those paths are unreachable: an
+    /// unauthenticated caller is answered with the provider-selection page instead, at <c>HTTP 200</c>, so
+    /// a webhook or other non-browser caller records success and never retries.
+    /// <para>
+    /// Each entry is a prefix and covers everything under it, so name the specific leaf path whenever a
+    /// sibling under the same parent is not public. Requests still pass through AuthProxy, which keeps
+    /// stripping inbound identity headers, so this makes a path reachable — it does not make it trusted.
+    /// The application still authorizes it.
+    /// </para>
+    /// <para>
+    /// The declared prefix is claimed for the whole proxy: an anonymous caller cannot send a
+    /// service-selection header, so in a multi-service deployment no other service can serve anything
+    /// under a prefix declared here.
+    /// </para>
+    /// </remarks>
+    public static IResourceBuilder<T> WithAnonymousPaths<T>(
+        this IResourceBuilder<T> builder,
+        string serviceName,
+        params string[] paths)
+        where T : IResourceWithEnvironment
+    {
+        var annotation = GetOrCreateAnnotation(builder.Resource);
+        annotation.AnonymousPathCounts.TryGetValue(serviceName, out var index);
+
+        foreach (var path in paths)
+        {
+            builder.WithEnvironment($"{ConfigPrefix}__Services__{serviceName}__AnonymousPaths__{index}", path);
+            index++;
+        }
+
+        annotation.AnonymousPathCounts[serviceName] = index;
+
+        return builder;
+    }
+
+    /// <summary>
     /// Adds an OIDC provider to the AuthProxy authentication configuration.
     /// </summary>
     /// <typeparam name="T">The resource type (must support environment variables).</typeparam>

--- a/Source/AuthProxy.Specs/Authentication/for_SelectProviderMiddleware/when_path_is_anonymous.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_SelectProviderMiddleware/when_path_is_anonymous.cs
@@ -1,0 +1,92 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authentication.for_SelectProviderMiddleware;
+
+/// <summary>
+/// An unauthenticated request to a declared anonymous path must be forwarded, while a sibling path that
+/// was not declared must still be answered with the provider-selection page.
+/// <para>
+/// The selection page is served with <c>HTTP 200</c>, so a caller that is not a browser records success
+/// and never retries. Both facts are asserted from the same setup so that the skip cannot be mistaken for
+/// a middleware that simply forwards everything.
+/// </para>
+/// </summary>
+public class when_path_is_anonymous : Specification
+{
+    const string AnonymousPath = "/portal";
+
+    SelectProviderMiddleware _middleware;
+    DefaultHttpContext _anonymousContext;
+    DefaultHttpContext _undeclaredContext;
+    IErrorPageProvider _errorPageProvider;
+    bool _nextCalledForAnonymousPath;
+    bool _nextCalledForUndeclaredPath;
+
+    void Establish()
+    {
+        var proxyConfig = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        proxyConfig.CurrentValue.Returns(new C.AuthProxy
+        {
+            Services = new Dictionary<string, C.Service>
+            {
+                ["test"] = new() { AnonymousPaths = [AnonymousPath] }
+            }
+        });
+
+        var authConfig = Substitute.For<IOptionsMonitor<C.Authentication>>();
+        authConfig.CurrentValue.Returns(new C.Authentication
+        {
+            OidcProviders =
+            [
+                new C.OidcProvider { Name = "p1", Authority = "https://a.example.com", ClientId = "c1" },
+                new C.OidcProvider { Name = "p2", Authority = "https://b.example.com", ClientId = "c2" }
+            ]
+        });
+
+        _errorPageProvider = Substitute.For<IErrorPageProvider>();
+
+        _anonymousContext = new DefaultHttpContext();
+        _anonymousContext.Request.Path = $"{AnonymousPath}/some-token";
+
+        _undeclaredContext = new DefaultHttpContext();
+        _undeclaredContext.Request.Path = "/portalx";
+
+        _middleware = new SelectProviderMiddleware(
+            context =>
+            {
+                if (context == _anonymousContext)
+                {
+                    _nextCalledForAnonymousPath = true;
+                }
+                else
+                {
+                    _nextCalledForUndeclaredPath = true;
+                }
+
+                return Task.CompletedTask;
+            },
+            proxyConfig,
+            authConfig,
+            _errorPageProvider,
+            Substitute.For<ITenantResolver>());
+    }
+
+    async Task Because()
+    {
+        await _middleware.InvokeAsync(_anonymousContext);
+        await _middleware.InvokeAsync(_undeclaredContext);
+    }
+
+    [Fact] void should_forward_the_declared_path() => _nextCalledForAnonymousPath.ShouldBeTrue();
+    [Fact] void should_not_forward_a_path_sharing_only_a_string_prefix() => _nextCalledForUndeclaredPath.ShouldBeFalse();
+
+    [Fact] void should_not_serve_the_selection_page_for_the_declared_path() =>
+        _errorPageProvider.DidNotReceive().WriteErrorPageAsync(_anonymousContext, Arg.Any<string>(), Arg.Any<int>());
+
+    [Fact] void should_serve_the_selection_page_for_a_path_sharing_only_a_string_prefix() =>
+        _errorPageProvider.Received(1).WriteErrorPageAsync(
+            _undeclaredContext,
+            WellKnownPageNames.SelectProvider,
+            StatusCodes.Status200OK);
+}

--- a/Source/AuthProxy.Specs/ReverseProxy/for_MicroserviceReverseProxyConfigProvider/when_declared_anonymous_paths_are_unusable.cs
+++ b/Source/AuthProxy.Specs/ReverseProxy/for_MicroserviceReverseProxyConfigProvider/when_declared_anonymous_paths_are_unusable.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Yarp.ReverseProxy.Configuration;
+
+namespace Cratis.AuthProxy.ReverseProxy.for_MicroserviceReverseProxyConfigProvider;
+
+/// <summary>
+/// An entry that is not a rooted path of literal segments must produce no route at all.
+/// <para>
+/// A declared prefix is interpolated into an ASP.NET route template, so an unvalidated entry would be
+/// read as template syntax rather than as a literal: <c>/route{parameter}</c> would match
+/// <c>/routeanything/…</c> anonymously, and <c>//double</c> or <c>/catch/{**all}</c> is not a legal
+/// template at all and would fail the proxy's configuration load at startup. Neither can be reached from
+/// configuration, and this pins that the route table sees exactly what the middlewares see.
+/// </para>
+/// </summary>
+public class when_declared_anonymous_paths_are_unusable : Specification
+{
+    MicroserviceReverseProxyConfigProvider _provider;
+    IReadOnlyList<RouteConfig> _routes;
+
+    void Establish()
+    {
+        var authProxy = new C.AuthProxy
+        {
+            Services = new Dictionary<string, C.Service>
+            {
+                ["App"] = new()
+                {
+                    Backend = new C.ServiceEndpoint { BaseUrl = "https://backend.local/" },
+                    Frontend = new C.ServiceEndpoint { BaseUrl = "https://frontend.local/" },
+                    AnonymousPaths =
+                    [
+                        string.Empty,
+                        "   ",
+                        "/",
+                        "//double",
+                        "unrooted",
+                        "/route{parameter}",
+                        "/catch/{**all}",
+                        "/query?token=1",
+                    ],
+                },
+            },
+        };
+
+        var monitor = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        monitor.CurrentValue.Returns(authProxy);
+
+        _provider = new MicroserviceReverseProxyConfigProvider(monitor);
+    }
+
+    void Because() => _routes = _provider.GetConfig().Routes;
+
+    [Fact] void should_generate_no_anonymous_routes() =>
+        _routes.Any(_ => _.RouteId.StartsWith("app-anonymous-", StringComparison.Ordinal)).ShouldBeFalse();
+
+    [Fact] void should_leave_every_route_requiring_an_authenticated_user() =>
+        _routes.All(_ => _.AuthorizationPolicy == "default").ShouldBeTrue();
+
+    [Fact] void should_produce_the_same_routes_as_a_service_declaring_nothing() =>
+        _routes.Select(_ => _.RouteId).ShouldContainOnly(RouteIdsWithoutAnyDeclaration());
+
+    static IEnumerable<string> RouteIdsWithoutAnyDeclaration()
+    {
+        var authProxy = new C.AuthProxy
+        {
+            Services = new Dictionary<string, C.Service>
+            {
+                ["App"] = new()
+                {
+                    Backend = new C.ServiceEndpoint { BaseUrl = "https://backend.local/" },
+                    Frontend = new C.ServiceEndpoint { BaseUrl = "https://frontend.local/" },
+                },
+            },
+        };
+
+        var monitor = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        monitor.CurrentValue.Returns(authProxy);
+
+        return new MicroserviceReverseProxyConfigProvider(monitor).GetConfig().Routes.Select(_ => _.RouteId);
+    }
+}

--- a/Source/AuthProxy.Specs/ReverseProxy/for_MicroserviceReverseProxyConfigProvider/when_service_declares_anonymous_paths.cs
+++ b/Source/AuthProxy.Specs/ReverseProxy/for_MicroserviceReverseProxyConfigProvider/when_service_declares_anonymous_paths.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Yarp.ReverseProxy.Configuration;
+
+namespace Cratis.AuthProxy.ReverseProxy.for_MicroserviceReverseProxyConfigProvider;
+
+/// <summary>
+/// A declared anonymous path must produce a route that relaxes the authorization policy, and nothing else
+/// in the table may be relaxed with it.
+/// <para>
+/// Every other generated route carries <c>AuthorizationPolicy = "default"</c>, which is
+/// <c>RequireAuthenticatedUser()</c>. Clearing <c>SelectProviderMiddleware</c> and <c>TenancyMiddleware</c>
+/// gets a request as far as authorization and no further, so this is the third of the three places that
+/// have to agree before a declared path is actually reachable.
+/// </para>
+/// </summary>
+public class when_service_declares_anonymous_paths : Specification
+{
+    MicroserviceReverseProxyConfigProvider _provider;
+    IReadOnlyList<RouteConfig> _routes;
+
+    void Establish()
+    {
+        var authProxy = new C.AuthProxy
+        {
+            Services = new Dictionary<string, C.Service>
+            {
+                ["App"] = new()
+                {
+                    Backend = new C.ServiceEndpoint { BaseUrl = "https://backend.local/" },
+                    Frontend = new C.ServiceEndpoint { BaseUrl = "https://frontend.local/" },
+                    AnonymousPaths = ["/portal", "/api/reports/public"],
+                },
+            },
+        };
+
+        var monitor = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        monitor.CurrentValue.Returns(authProxy);
+
+        _provider = new MicroserviceReverseProxyConfigProvider(monitor);
+    }
+
+    void Because() => _routes = _provider.GetConfig().Routes;
+
+    [Fact] void should_generate_one_route_per_declared_path() =>
+        _routes.Count(_ => _.RouteId.StartsWith("app-anonymous-", StringComparison.Ordinal)).ShouldEqual(2);
+
+    [Fact] void should_serve_the_frontend_prefix_from_the_frontend_cluster() =>
+        _routes.Single(_ => _.Match.Path == "/portal/{**catch-all}").ClusterId.ShouldEqual("app-frontend-cluster");
+
+    [Fact] void should_serve_the_api_prefix_from_the_backend_cluster() =>
+        _routes.Single(_ => _.Match.Path == "/api/reports/public/{**catch-all}").ClusterId.ShouldEqual("app-backend-cluster");
+
+    [Fact] void should_relax_the_authorization_policy_on_the_declared_routes() =>
+        _routes.Where(_ => _.RouteId.StartsWith("app-anonymous-", StringComparison.Ordinal))
+            .ShouldContainOnly(_routes.Where(_ => _.AuthorizationPolicy == "anonymous"));
+
+    [Fact] void should_keep_the_default_policy_on_every_other_route() =>
+        _routes.Where(_ => !_.RouteId.StartsWith("app-anonymous-", StringComparison.Ordinal))
+            .All(_ => _.AuthorizationPolicy == "default").ShouldBeTrue();
+
+    [Fact] void should_order_the_declared_routes_ahead_of_every_other_route() =>
+        _routes.Where(_ => _.RouteId.StartsWith("app-anonymous-", StringComparison.Ordinal))
+            .All(anonymous => _routes
+                .Where(other => !other.RouteId.StartsWith("app-anonymous-", StringComparison.Ordinal))
+                .All(other => anonymous.Order < other.Order))
+            .ShouldBeTrue();
+
+    [Fact] void should_not_constrain_the_declared_routes_by_service_selection() =>
+        _routes.Where(_ => _.RouteId.StartsWith("app-anonymous-", StringComparison.Ordinal))
+            .All(_ => _.Match.Headers is null && _.Match.QueryParameters is null)
+            .ShouldBeTrue();
+}

--- a/Source/AuthProxy.Specs/Scenarios/when_anonymous_paths_are_configured/AuthProxyFactory.cs
+++ b/Source/AuthProxy.Specs/Scenarios/when_anonymous_paths_are_configured/AuthProxyFactory.cs
@@ -1,0 +1,128 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.AuthProxy.Scenarios.when_anonymous_paths_are_configured;
+
+/// <summary>
+/// WebApplicationFactory that configures two OIDC providers — so an unauthenticated request would
+/// otherwise be answered with the provider-selection page — alongside a service that declares two
+/// anonymous path prefixes.
+/// </summary>
+public class AuthProxyFactory : WebApplicationFactory<Program>
+{
+    public const string TenantId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+
+    /// <summary>The declared anonymous SPA prefix, served by the frontend endpoint.</summary>
+    public const string AnonymousFrontendPath = "/portal";
+
+    /// <summary>The declared anonymous API leaf path, served by the backend endpoint.</summary>
+    public const string AnonymousBackendPath = "/api/portal/report";
+
+    readonly string _pagesPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+    /// <summary>Initializes a new instance of the <see cref="AuthProxyFactory"/> class.</summary>
+    public AuthProxyFactory()
+    {
+        Directory.CreateDirectory(_pagesPath);
+        File.WriteAllText(Path.Combine(_pagesPath, "select-provider.html"), "<html><body><h1>Select Provider</h1></body></html>");
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        if (disposing && Directory.Exists(_pagesPath))
+            Directory.Delete(_pagesPath, recursive: true);
+    }
+
+    /// <summary>
+    /// Gets the tenant-resolution settings the host runs with.
+    /// Defaults to a strategy that always resolves, so that <c>TenancyMiddleware</c> never reaches its
+    /// tenant-unresolved branch and the scenario measures the other enforcement points on their own.
+    /// </summary>
+    protected virtual IEnumerable<KeyValuePair<string, string?>> TenantResolutionSettings =>
+    [
+        new($"{C.AuthProxy.SectionKey}:TenantResolutions:0:Strategy", nameof(C.TenantSourceIdentifierResolverType.Specified)),
+        new($"{C.AuthProxy.SectionKey}:TenantResolutions:0:Options:TenantId", TenantId),
+    ];
+
+    /// <inheritdoc/>
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureAppConfiguration((_, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"{C.AuthProxy.SectionKey}:Services:test:Backend:BaseUrl"] = "http://backend.test/",
+                [$"{C.AuthProxy.SectionKey}:Services:test:Frontend:BaseUrl"] = "http://frontend.test/",
+                [$"{C.AuthProxy.SectionKey}:Services:test:AnonymousPaths:0"] = AnonymousFrontendPath,
+                [$"{C.AuthProxy.SectionKey}:Services:test:AnonymousPaths:1"] = AnonymousBackendPath,
+
+                [$"{C.AuthProxy.SectionKey}:PagesPath"] = _pagesPath,
+
+                [$"{C.Authentication.SectionKey}:OidcProviders:0:Name"] = "Provider One",
+                [$"{C.Authentication.SectionKey}:OidcProviders:0:Authority"] = "https://login.example.com/one",
+                [$"{C.Authentication.SectionKey}:OidcProviders:0:ClientId"] = "client-one",
+                [$"{C.Authentication.SectionKey}:OidcProviders:1:Name"] = "Provider Two",
+                [$"{C.Authentication.SectionKey}:OidcProviders:1:Authority"] = "https://login.example.com/two",
+                [$"{C.Authentication.SectionKey}:OidcProviders:1:ClientId"] = "client-two",
+            });
+
+            config.AddInMemoryCollection(TenantResolutionSettings);
+        });
+
+        builder.ConfigureTestServices(services =>
+        {
+            services.AddAuthentication(TestAuthHandler.Scheme)
+                .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(TestAuthHandler.Scheme, _ => { });
+
+            services.AddSingleton<IHttpClientFactory>(new TestHttpClientFactory(
+                _ => new HttpResponseMessage(HttpStatusCode.NotFound)));
+        });
+    }
+
+    /// <summary>Creates a test HTTP client that does not follow redirects.</summary>
+    /// <returns>A configured <see cref="HttpClient"/> that does not follow redirects.</returns>
+    public HttpClient CreateTestClient() =>
+        CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+    /// <summary>Authentication handler that never authenticates (unauthenticated requests).</summary>
+    /// <param name="options">The options monitor for authentication scheme options.</param>
+    /// <param name="logger">The logger factory.</param>
+    /// <param name="encoder">The URL encoder.</param>
+    public class TestAuthHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        System.Text.Encodings.Web.UrlEncoder encoder)
+        : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+    {
+        public const string Scheme = "TestScheme";
+
+        /// <inheritdoc/>
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync() =>
+            Task.FromResult(AuthenticateResult.NoResult());
+    }
+
+    /// <summary>Minimal IHttpClientFactory that routes all calls through a single handler.</summary>
+    /// <param name="handler">The request dispatch function.</param>
+    sealed class TestHttpClientFactory(Func<string, HttpResponseMessage> handler) : IHttpClientFactory
+    {
+        /// <inheritdoc/>
+        public HttpClient CreateClient(string name) =>
+            new(new DispatchingHandler(handler)) { Timeout = TimeSpan.FromSeconds(10) };
+
+        sealed class DispatchingHandler(Func<string, HttpResponseMessage> handler) : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+                Task.FromResult(handler(request.RequestUri?.ToString() ?? string.Empty));
+        }
+    }
+}

--- a/Source/AuthProxy.Specs/Scenarios/when_anonymous_paths_are_configured/UnresolvedTenantAuthProxyFactory.cs
+++ b/Source/AuthProxy.Specs/Scenarios/when_anonymous_paths_are_configured/UnresolvedTenantAuthProxyFactory.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Scenarios.when_anonymous_paths_are_configured;
+
+/// <summary>
+/// The same host, but with a tenant-resolution strategy that cannot resolve anything for a caller with no
+/// session — which is the only configuration in which <c>TenancyMiddleware</c>'s refusal branch is reached
+/// at all.
+/// <para>
+/// This exists because the default factory resolves a fixed tenant for every request, so
+/// <c>TenancyMiddleware</c> never gets to refuse and the scenario would stay green with that enforcement
+/// point removed. An anonymous path only works if all three points agree, so each has to be able to fail
+/// the suite on its own.
+/// </para>
+/// </summary>
+public class UnresolvedTenantAuthProxyFactory : AuthProxyFactory
+{
+    /// <inheritdoc/>
+    protected override IEnumerable<KeyValuePair<string, string?>> TenantResolutionSettings =>
+    [
+        new($"{C.AuthProxy.SectionKey}:TenantResolutions:0:Strategy", nameof(C.TenantSourceIdentifierResolverType.Selection)),
+    ];
+}

--- a/Source/AuthProxy.Specs/Scenarios/when_anonymous_paths_are_configured/and_the_tenant_cannot_be_resolved.cs
+++ b/Source/AuthProxy.Specs/Scenarios/when_anonymous_paths_are_configured/and_the_tenant_cannot_be_resolved.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net;
+
+namespace Cratis.AuthProxy.Scenarios.when_anonymous_paths_are_configured;
+
+/// <summary>
+/// End-to-end scenario with tenant resolutions configured that cannot resolve for a caller with no
+/// session: the declared anonymous paths must still be forwarded rather than refused for having no tenant.
+/// <para>
+/// The test destinations do not exist, so reaching the forwarder surfaces as <c>502 Bad Gateway</c> — a
+/// status only a forwarded request can produce. Without <c>TenancyMiddleware</c>'s anonymous skip these
+/// would be <c>401</c> instead: the same closed door as before the feature, one middleware later.
+/// </para>
+/// </summary>
+/// <param name="factory">The shared application factory.</param>
+public class and_the_tenant_cannot_be_resolved(UnresolvedTenantAuthProxyFactory factory)
+    : IClassFixture<UnresolvedTenantAuthProxyFactory>, IAsyncLifetime
+{
+    HttpResponseMessage? _declaredFrontend;
+    HttpResponseMessage? _declaredFrontendChild;
+    HttpResponseMessage? _declaredBackend;
+    HttpResponseMessage? _undeclared;
+    string? _undeclaredBody;
+
+    public async Task InitializeAsync()
+    {
+        using var client = factory.CreateTestClient();
+
+        _declaredFrontend = await client.GetAsync(AuthProxyFactory.AnonymousFrontendPath);
+        _declaredFrontendChild = await client.GetAsync($"{AuthProxyFactory.AnonymousFrontendPath}/some-token");
+        _declaredBackend = await client.GetAsync(AuthProxyFactory.AnonymousBackendPath);
+
+        _undeclared = await client.GetAsync("/dashboard");
+        _undeclaredBody = await _undeclared.Content.ReadAsStringAsync();
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact] public void should_forward_the_declared_frontend_path() => Assert.Equal(HttpStatusCode.BadGateway, _declaredFrontend!.StatusCode);
+    [Fact] public void should_forward_below_the_declared_frontend_path() => Assert.Equal(HttpStatusCode.BadGateway, _declaredFrontendChild!.StatusCode);
+    [Fact] public void should_forward_the_declared_backend_path() => Assert.Equal(HttpStatusCode.BadGateway, _declaredBackend!.StatusCode);
+
+    [Fact] public void should_still_select_provider_for_an_undeclared_path() => Assert.Contains("Select Provider", _undeclaredBody);
+}

--- a/Source/AuthProxy.Specs/Scenarios/when_anonymous_paths_are_configured/and_unauthenticated_user_requests_them.cs
+++ b/Source/AuthProxy.Specs/Scenarios/when_anonymous_paths_are_configured/and_unauthenticated_user_requests_them.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net;
+
+namespace Cratis.AuthProxy.Scenarios.when_anonymous_paths_are_configured;
+
+/// <summary>
+/// End-to-end scenario: an unauthenticated user requests the declared anonymous paths, and an
+/// undeclared one, with two providers configured.
+/// <para>
+/// The declared paths must get all the way to the reverse proxy — past
+/// <see cref="Authentication.SelectProviderMiddleware"/> and past the authorization policy on the
+/// generated route. The test destinations do not exist, so reaching the forwarder surfaces as a
+/// <c>502 Bad Gateway</c>; that is the assertion's whole point — it can only be produced by a request
+/// that was forwarded. An undeclared path must be unaffected and still receive the selection page, which
+/// is what proves the prefixes do not over-match.
+/// </para>
+/// <para>
+/// This factory resolves a fixed tenant for every request, so <c>TenancyMiddleware</c>'s refusal branch is
+/// never entered here — that third enforcement point is covered by
+/// <see cref="and_the_tenant_cannot_be_resolved"/>.
+/// </para>
+/// </summary>
+/// <param name="factory">The shared application factory.</param>
+public class and_unauthenticated_user_requests_them(AuthProxyFactory factory) : IClassFixture<AuthProxyFactory>, IAsyncLifetime
+{
+    HttpResponseMessage? _declaredFrontend;
+    HttpResponseMessage? _declaredFrontendChild;
+    HttpResponseMessage? _declaredFrontendInDifferentCasing;
+    HttpResponseMessage? _declaredBackend;
+    HttpResponseMessage? _undeclared;
+    HttpResponseMessage? _undeclaredSibling;
+    HttpResponseMessage? _undeclaredLongerFirstSegment;
+    string? _undeclaredBody;
+    string? _undeclaredSiblingBody;
+    string? _undeclaredLongerFirstSegmentBody;
+
+    public async Task InitializeAsync()
+    {
+        using var client = factory.CreateTestClient();
+
+        _declaredFrontend = await client.GetAsync(AuthProxyFactory.AnonymousFrontendPath);
+        _declaredFrontendChild = await client.GetAsync($"{AuthProxyFactory.AnonymousFrontendPath}/some-token");
+        _declaredBackend = await client.GetAsync(AuthProxyFactory.AnonymousBackendPath);
+
+        // The route table matches literal segments case-insensitively whatever the middlewares decide,
+        // so the middlewares have to agree — this is the request that would split them if they did not.
+        _declaredFrontendInDifferentCasing = await client.GetAsync(AuthProxyFactory.AnonymousFrontendPath.ToUpperInvariant());
+
+        _undeclared = await client.GetAsync("/dashboard");
+        _undeclaredBody = await _undeclared.Content.ReadAsStringAsync();
+
+        // A sibling under the same parent as the declared leaf: /api/portal/report is anonymous,
+        // /api/portal/admin must not be.
+        _undeclaredSibling = await client.GetAsync("/api/portal/admin");
+        _undeclaredSiblingBody = await _undeclaredSibling.Content.ReadAsStringAsync();
+
+        _undeclaredLongerFirstSegment = await client.GetAsync($"{AuthProxyFactory.AnonymousFrontendPath}x/token");
+        _undeclaredLongerFirstSegmentBody = await _undeclaredLongerFirstSegment.Content.ReadAsStringAsync();
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact] public void should_forward_the_declared_frontend_path() => Assert.Equal(HttpStatusCode.BadGateway, _declaredFrontend!.StatusCode);
+    [Fact] public void should_forward_below_the_declared_frontend_path() => Assert.Equal(HttpStatusCode.BadGateway, _declaredFrontendChild!.StatusCode);
+    [Fact] public void should_forward_the_declared_backend_path() => Assert.Equal(HttpStatusCode.BadGateway, _declaredBackend!.StatusCode);
+    [Fact] public void should_forward_the_declared_path_in_a_different_casing() => Assert.Equal(HttpStatusCode.BadGateway, _declaredFrontendInDifferentCasing!.StatusCode);
+
+    [Fact] public void should_still_select_provider_for_an_undeclared_path() => Assert.Contains("Select Provider", _undeclaredBody);
+    [Fact] public void should_still_select_provider_for_an_undeclared_sibling() => Assert.Contains("Select Provider", _undeclaredSiblingBody);
+    [Fact] public void should_still_select_provider_for_a_longer_first_segment() => Assert.Contains("Select Provider", _undeclaredLongerFirstSegmentBody);
+}

--- a/Source/AuthProxy.Specs/for_AnonymousPaths/when_configuration_carries_unusable_entries.cs
+++ b/Source/AuthProxy.Specs/for_AnonymousPaths/when_configuration_carries_unusable_entries.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.for_AnonymousPaths;
+
+/// <summary>
+/// Entries that cannot express a path prefix must be discarded rather than matched.
+/// <para>
+/// The empty entry is the one that matters: <c>PathString.StartsWithSegments(string.Empty)</c> is true
+/// for every request, so a stray blank value — an env var set but never given a value, a trailing index
+/// in a configuration array — would otherwise turn the entire service anonymous, silently and globally.
+/// That is the worst possible failure for this feature, so it is pinned here rather than left to review.
+/// The bare <c>/</c> is the same failure spelled differently.
+/// </para>
+/// <para>
+/// The route-template characters are the second class. A prefix is interpolated into an ASP.NET route
+/// template, so <c>/a{x}</c> would become a route <em>parameter</em> and make the router match
+/// <c>/anything/…</c> while the middlewares matched only the literal — the two components disagreeing
+/// about the same prefix, which is the failure the shared matcher exists to prevent.
+/// </para>
+/// </summary>
+public class when_configuration_carries_unusable_entries : Specification
+{
+    C.AuthProxy _configuration;
+
+    void Establish() => _configuration = new C.AuthProxy
+    {
+        Services = new Dictionary<string, C.Service>
+        {
+            ["test"] = new()
+            {
+                AnonymousPaths =
+                [
+                    string.Empty,
+                    "   ",
+                    "/",
+                    "///",
+                    "no-leading-slash",
+                    "/double//segment",
+                    "/with space",
+                    "/route{parameter}",
+                    "/catch/{**all}",
+                    "/query?token=1",
+                    "/star*",
+                    "/percent%20encoded",
+                    "  /portal/  ",
+                ],
+            },
+        },
+    };
+
+    [Fact] void should_keep_only_the_usable_entry() => AnonymousPaths.All(_configuration).ShouldContainOnly("/portal");
+    [Fact] void should_not_match_an_unrelated_path() => AnonymousPaths.Matches("/dashboard", _configuration).ShouldBeFalse();
+    [Fact] void should_not_match_the_root_path() => AnonymousPaths.Matches("/", _configuration).ShouldBeFalse();
+    [Fact] void should_not_match_an_arbitrary_first_segment() => AnonymousPaths.Matches("/anything", _configuration).ShouldBeFalse();
+    [Fact] void should_not_match_the_route_parameter_entry_literally() => AnonymousPaths.Matches("/route{parameter}", _configuration).ShouldBeFalse();
+    [Fact] void should_not_match_below_the_catch_all_entry() => AnonymousPaths.Matches("/catch/anything", _configuration).ShouldBeFalse();
+    [Fact] void should_match_the_trimmed_entry() => AnonymousPaths.Matches("/portal", _configuration).ShouldBeTrue();
+    [Fact] void should_match_below_the_trimmed_entry() => AnonymousPaths.Matches("/portal/report", _configuration).ShouldBeTrue();
+    [Fact] void should_not_match_a_path_sharing_only_a_string_prefix() => AnonymousPaths.Matches("/portalx", _configuration).ShouldBeFalse();
+}

--- a/Source/AuthProxy.Specs/for_AnonymousPaths/when_matching_a_declared_prefix.cs
+++ b/Source/AuthProxy.Specs/for_AnonymousPaths/when_matching_a_declared_prefix.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.for_AnonymousPaths;
+
+/// <summary>
+/// A declared prefix must match on segment boundaries, case-insensitively, and nowhere else.
+/// <para>
+/// Case-insensitivity is not an accident: ASP.NET route templates match literal segments
+/// case-insensitively, so the route table would serve <c>/PORTAL</c> anonymously whatever the middlewares
+/// decided. The two have to agree, and this pins which way.
+/// </para>
+/// </summary>
+public class when_matching_a_declared_prefix : Specification
+{
+    C.AuthProxy _configuration;
+
+    void Establish() => _configuration = new C.AuthProxy
+    {
+        Services = new Dictionary<string, C.Service>
+        {
+            ["test"] = new() { AnonymousPaths = ["/portal", "/api/reports/public"] },
+        },
+    };
+
+    [Fact] void should_match_the_prefix_itself() => AnonymousPaths.Matches("/portal", _configuration).ShouldBeTrue();
+    [Fact] void should_match_a_child_segment() => AnonymousPaths.Matches("/portal/token", _configuration).ShouldBeTrue();
+    [Fact] void should_match_a_deeply_nested_child() => AnonymousPaths.Matches("/portal/a/b/c", _configuration).ShouldBeTrue();
+    [Fact] void should_match_the_prefix_with_a_trailing_slash() => AnonymousPaths.Matches("/portal/", _configuration).ShouldBeTrue();
+    [Fact] void should_match_regardless_of_casing() => AnonymousPaths.Matches("/PORTAL/Token", _configuration).ShouldBeTrue();
+    [Fact] void should_match_a_declared_leaf_below_an_undeclared_parent() => AnonymousPaths.Matches("/api/reports/public", _configuration).ShouldBeTrue();
+
+    [Fact] void should_not_match_a_longer_first_segment() => AnonymousPaths.Matches("/portalx", _configuration).ShouldBeFalse();
+    [Fact] void should_not_match_a_longer_first_segment_with_children() => AnonymousPaths.Matches("/portalx/token", _configuration).ShouldBeFalse();
+    [Fact] void should_not_match_the_undeclared_parent_of_a_declared_leaf() => AnonymousPaths.Matches("/api/reports", _configuration).ShouldBeFalse();
+    [Fact] void should_not_match_a_sibling_of_a_declared_leaf() => AnonymousPaths.Matches("/api/reports/private", _configuration).ShouldBeFalse();
+    [Fact] void should_not_match_a_prefix_appearing_below_the_root() => AnonymousPaths.Matches("/app/portal", _configuration).ShouldBeFalse();
+    [Fact] void should_not_match_the_root_path() => AnonymousPaths.Matches("/", _configuration).ShouldBeFalse();
+    [Fact] void should_not_match_an_empty_path() => AnonymousPaths.Matches(PathString.Empty, _configuration).ShouldBeFalse();
+}

--- a/Source/AuthProxy.Specs/for_AnonymousPaths/when_nothing_is_declared.cs
+++ b/Source/AuthProxy.Specs/for_AnonymousPaths/when_nothing_is_declared.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.for_AnonymousPaths;
+
+/// <summary>
+/// A configuration that declares no anonymous paths must behave exactly as it did before the feature
+/// existed — nothing anonymous, for any path.
+/// <para>
+/// This is the compatibility guarantee every existing consumer depends on, so it is pinned rather than
+/// argued: it is the one property that must hold for a deployment that never opts in.
+/// </para>
+/// </summary>
+public class when_nothing_is_declared : Specification
+{
+    C.AuthProxy _emptyConfiguration;
+    C.AuthProxy _configurationWithServices;
+
+    void Establish()
+    {
+        _emptyConfiguration = new C.AuthProxy();
+        _configurationWithServices = new C.AuthProxy
+        {
+            Services = new Dictionary<string, C.Service>
+            {
+                ["test"] = new()
+                {
+                    Backend = new C.ServiceEndpoint { BaseUrl = "http://backend.test/" },
+                    Frontend = new C.ServiceEndpoint { BaseUrl = "http://frontend.test/" },
+                },
+            },
+        };
+    }
+
+    [Fact] void should_resolve_no_paths_without_services() => AnonymousPaths.All(_emptyConfiguration).ShouldBeEmpty();
+    [Fact] void should_resolve_no_paths_with_services() => AnonymousPaths.All(_configurationWithServices).ShouldBeEmpty();
+    [Fact] void should_not_match_the_root_path() => AnonymousPaths.Matches("/", _configurationWithServices).ShouldBeFalse();
+    [Fact] void should_not_match_an_application_path() => AnonymousPaths.Matches("/dashboard", _configurationWithServices).ShouldBeFalse();
+    [Fact] void should_not_match_an_api_path() => AnonymousPaths.Matches("/api/anything", _configurationWithServices).ShouldBeFalse();
+}

--- a/Source/AuthProxy.Specs/for_TenancyMiddleware/when_path_is_anonymous.cs
+++ b/Source/AuthProxy.Specs/for_TenancyMiddleware/when_path_is_anonymous.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.for_TenancyMiddleware;
+
+/// <summary>
+/// An unauthenticated request to a declared anonymous path must still have its inbound identity headers
+/// removed, and must be forwarded rather than refused for having no resolvable tenant.
+/// <para>
+/// The header strip is the property that makes declaring a path anonymous safe. A caller reaching an
+/// anonymous path has no session, so anything it sends in <c>x-ms-client-principal*</c> or
+/// <c>Tenant-ID</c> is unverified — the application's identity handler would build a principal straight
+/// out of it. Because the request still travels through AuthProxy, the strip that runs for every other
+/// request runs for this one too; that is the whole reason to solve this inside the proxy instead of
+/// routing around it at the ingress, where those headers would arrive untouched.
+/// </para>
+/// </summary>
+public class when_path_is_anonymous : Specification
+{
+    const string AnonymousPath = "/portal";
+
+    TenancyMiddleware _middleware;
+    DefaultHttpContext _context;
+    bool _nextCalled;
+
+    void Establish()
+    {
+        var configuration = new C.AuthProxy
+        {
+            Services = new Dictionary<string, C.Service>
+            {
+                ["test"] = new()
+                {
+                    Backend = new C.ServiceEndpoint { BaseUrl = "http://backend.test/" },
+                    AnonymousPaths = [AnonymousPath],
+                },
+            },
+            TenantResolutions = [new C.TenantResolution { Strategy = C.TenantSourceIdentifierResolverType.Selection }],
+        };
+
+        var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        config.CurrentValue.Returns(configuration);
+
+        var tenantResolver = Substitute.For<ITenantResolver>();
+        tenantResolver.TryResolve(Arg.Any<HttpContext>(), out Arg.Any<string>())
+            .Returns(callInfo =>
+            {
+                callInfo[1] = string.Empty;
+                return false;
+            });
+
+        _middleware = new TenancyMiddleware(
+            _ =>
+            {
+                _nextCalled = true;
+                return Task.CompletedTask;
+            },
+            config,
+            tenantResolver,
+            Substitute.For<ITenantVerifier>(),
+            Substitute.For<IErrorPageProvider>(),
+            Substitute.For<ILogger<TenancyMiddleware>>());
+
+        _context = new DefaultHttpContext();
+        _context.Request.Path = AnonymousPath;
+        _context.Request.Headers[Headers.Principal] = "forged-principal";
+        _context.Request.Headers[Headers.PrincipalId] = "forged-id";
+        _context.Request.Headers[Headers.PrincipalName] = "forged-name";
+        _context.Request.Headers[Headers.TenantId] = "forged-tenant";
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_strip_the_inbound_principal() => _context.Request.Headers.ContainsKey(Headers.Principal).ShouldBeFalse();
+    [Fact] void should_strip_the_inbound_principal_id() => _context.Request.Headers.ContainsKey(Headers.PrincipalId).ShouldBeFalse();
+    [Fact] void should_strip_the_inbound_principal_name() => _context.Request.Headers.ContainsKey(Headers.PrincipalName).ShouldBeFalse();
+    [Fact] void should_strip_the_inbound_tenant_id() => _context.Request.Headers.ContainsKey(Headers.TenantId).ShouldBeFalse();
+    [Fact] void should_not_refuse_the_request_for_having_no_tenant() => _nextCalled.ShouldBeTrue();
+}

--- a/Source/AuthProxy/AnonymousPaths.cs
+++ b/Source/AuthProxy/AnonymousPaths.cs
@@ -1,0 +1,130 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Buffers;
+using C = Cratis.AuthProxy.Configuration;
+
+namespace Cratis.AuthProxy;
+
+/// <summary>
+/// Resolves the anonymous path prefixes declared in <see cref="C.Service.AnonymousPaths"/>.
+/// </summary>
+/// <remarks>
+/// Three components have to agree on what counts as an anonymous path — <c>SelectProviderMiddleware</c>
+/// (do not serve the provider-selection page), <c>TenancyMiddleware</c> (do not refuse a caller with no
+/// resolvable tenant), and the reverse-proxy route table (do not apply the authenticated-user
+/// authorization policy). If one disagreed the path would still be unreachable and the disagreement would
+/// be silent, so they all resolve through here.
+/// <para>
+/// The middlewares match with <see cref="PathString.StartsWithSegments(PathString)"/> while the route
+/// table matches an ASP.NET route template built from the same prefix. Those two agree only for a prefix
+/// made of plain literal segments, which is what <see cref="TryNormalize"/> enforces: anything else is
+/// discarded rather than matched, so a prefix can never mean one thing to a middleware and another to the
+/// router.
+/// </para>
+/// </remarks>
+public static class AnonymousPaths
+{
+    /// <summary>
+    /// Characters that either carry meaning in an ASP.NET route template or change how a path is
+    /// segmented, and therefore cannot appear in a declared prefix.
+    /// </summary>
+    static readonly SearchValues<char> _reservedCharacters = SearchValues.Create("{}?#*[]\\% \t\r\n");
+
+    /// <summary>
+    /// Gets the usable, de-duplicated anonymous path prefixes across every configured service.
+    /// </summary>
+    /// <param name="config">The auth proxy configuration to read.</param>
+    /// <returns>The declared anonymous path prefixes.</returns>
+    public static IEnumerable<string> All(C.AuthProxy config) =>
+        config.Services.Values
+            .SelectMany(For)
+            .Distinct(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Gets the usable, de-duplicated anonymous path prefixes declared by a single service.
+    /// </summary>
+    /// <param name="service">The service to read.</param>
+    /// <returns>The service's anonymous path prefixes.</returns>
+    public static IEnumerable<string> For(C.Service service) =>
+        Normalize(service.AnonymousPaths).Distinct(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Determines whether the given request path is covered by a declared anonymous path prefix.
+    /// </summary>
+    /// <param name="path">The request path to evaluate.</param>
+    /// <param name="config">The auth proxy configuration to read.</param>
+    /// <returns><see langword="true"/> when the path is anonymous; otherwise <see langword="false"/>.</returns>
+    /// <remarks>
+    /// This runs on every request through two middlewares, so it walks the configuration directly and
+    /// short-circuits rather than materializing <see cref="All"/>. With nothing declared it returns
+    /// immediately without allocating.
+    /// </remarks>
+    public static bool Matches(PathString path, C.AuthProxy config)
+    {
+        foreach (var service in config.Services.Values)
+        {
+            foreach (var candidate in service.AnonymousPaths)
+            {
+                if (TryNormalize(candidate, out var prefix) && path.StartsWithSegments(prefix))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Normalizes a declared entry into a usable path prefix.
+    /// </summary>
+    /// <param name="candidate">The declared entry.</param>
+    /// <param name="prefix">The normalized prefix when the entry is usable.</param>
+    /// <returns><see langword="true"/> when the entry is usable; otherwise <see langword="false"/>.</returns>
+    /// <remarks>
+    /// Every rejection here is fail-closed — a discarded entry leaves the path authenticated, never the
+    /// other way around. The empty entry is the one that matters most:
+    /// <c>PathString.StartsWithSegments(string.Empty)</c> is true for every request, so a blank value
+    /// would otherwise turn an entire service anonymous. The bare <c>/</c> is rejected for the same
+    /// reason. The remaining rejections keep the prefix safe to interpolate into a route template:
+    /// <c>/a{x}</c> would become a route <em>parameter</em>, making the router match <c>/aANYTHING/…</c>
+    /// where the middlewares match only the literal, and <c>//a</c> or <c>/a/{**b}</c> is not a legal
+    /// template at all, so it would fail the proxy's configuration load at startup. The rest are rejected
+    /// because a prefix whose meaning depends on encoding cannot be reasoned about from configuration.
+    /// </remarks>
+    public static bool TryNormalize(string? candidate, out string prefix)
+    {
+        prefix = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(candidate))
+        {
+            return false;
+        }
+
+        var normalized = candidate.Trim().TrimEnd('/');
+
+        if (normalized.Length < 2
+            || normalized[0] != '/'
+            || normalized.Contains("//", StringComparison.Ordinal)
+            || normalized.AsSpan().IndexOfAny(_reservedCharacters) >= 0)
+        {
+            return false;
+        }
+
+        prefix = normalized;
+
+        return true;
+    }
+
+    static IEnumerable<string> Normalize(IEnumerable<string> candidates)
+    {
+        foreach (var candidate in candidates)
+        {
+            if (TryNormalize(candidate, out var prefix))
+            {
+                yield return prefix;
+            }
+        }
+    }
+}

--- a/Source/AuthProxy/Authentication/SelectProviderMiddleware.cs
+++ b/Source/AuthProxy/Authentication/SelectProviderMiddleware.cs
@@ -16,7 +16,8 @@ namespace Cratis.AuthProxy.Authentication;
 /// enabled and a lobby URL is configured), unauthenticated requests without an invite token or
 /// pending invite cookie are immediately answered with the <c>invitation-required.html</c> page
 /// instead of being redirected to a login provider.
-/// Skips invite paths, authentication paths, and requests with a pending invite cookie.
+/// Skips invite paths, authentication paths, paths a service declares in
+/// <see cref="C.Service.AnonymousPaths"/>, and requests with a pending invite cookie.
 /// </summary>
 /// <param name="next">The next middleware in the pipeline.</param>
 /// <param name="proxyConfig">The auth proxy configuration monitor.</param>
@@ -43,6 +44,7 @@ public class SelectProviderMiddleware(
             || context.IsInvitation()
             || context.IsRegistration()
             || context.IsAuthenticationUI()
+            || context.IsAnonymousPath(proxyConfig.CurrentValue)
             || context.HasPendingInvitation())
         {
             await next(context);

--- a/Source/AuthProxy/Configuration/Service.cs
+++ b/Source/AuthProxy/Configuration/Service.cs
@@ -26,6 +26,35 @@ public class Service
     public ServiceEndpoint? Registration { get; set; }
 
     /// <summary>
+    /// Gets or sets the request paths on this service that are served to unauthenticated callers.
+    /// </summary>
+    /// <remarks>
+    /// Without this, every path behind the proxy requires a session: an unauthenticated request is
+    /// answered by <c>SelectProviderMiddleware</c> with the provider-selection page — at <c>HTTP 200</c>,
+    /// so a non-browser caller records success and never retries — and any request that does reach the
+    /// reverse proxy is refused by the default authorization policy. An application that legitimately
+    /// serves some paths anonymously (a magic-link landing page, a signed-token report, a public webhook
+    /// receiver) has no way to express that. Listing those paths here does.
+    /// <para>
+    /// Each entry is a path prefix, matched case-insensitively on segment boundaries exactly like the
+    /// built-in invite / registration / authentication-UI paths: <c>/portal</c> matches <c>/portal</c> and
+    /// <c>/portal/anything</c>, but not <c>/portalx</c>. Because it is a prefix, an entry covers
+    /// everything below it, so name the specific leaf path whenever a sibling under the same parent is not
+    /// public. An entry that is not a plain rooted path of literal segments — blank, unrooted, the bare
+    /// <c>/</c>, or carrying a route-template character — is discarded, leaving that path authenticated.
+    /// See <see cref="AnonymousPaths.TryNormalize"/> for the exact rule.
+    /// </para>
+    /// <para>
+    /// This does not weaken the identity boundary. Requests still flow through AuthProxy, so
+    /// <c>TenancyMiddleware</c> strips inbound <c>x-ms-client-principal*</c> and <c>Tenant-ID</c> headers
+    /// as it does for every request, and no principal headers are injected for a caller with no session.
+    /// The application stays responsible for authorizing these paths — this only stops the proxy from
+    /// demanding a login before the application is ever reached.
+    /// </para>
+    /// </remarks>
+    public IList<string> AnonymousPaths { get; set; } = [];
+
+    /// <summary>
     /// Gets or sets whether to call the <c>/.cratis/me</c> identity endpoint on this service
     /// to enrich the identity details cookie. Defaults to <see langword="true"/> when a Backend is configured.
     /// </summary>

--- a/Source/AuthProxy/HttpContextExtensions.cs
+++ b/Source/AuthProxy/HttpContextExtensions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using C = Cratis.AuthProxy.Configuration;
+
 namespace Cratis.AuthProxy;
 
 /// <summary>
@@ -74,6 +76,15 @@ public static class HttpContextExtensions
     /// <param name="context">The <see cref="HttpContext"/> to evaluate.</param>
     /// <returns><see langword="true"/> if the request is part of the authentication UI; otherwise <see langword="false"/>.</returns>
     public static bool IsAuthenticationUI(this HttpContext context) => context.IsLogin() || context.IsProviders() || context.IsToken();
+
+    /// <summary>
+    /// Determines whether the request targets a path a service declares as anonymous.
+    /// </summary>
+    /// <param name="context">The <see cref="HttpContext"/> to evaluate.</param>
+    /// <param name="config">The auth proxy configuration declaring the anonymous paths.</param>
+    /// <returns><see langword="true"/> if the request targets an anonymous path; otherwise <see langword="false"/>.</returns>
+    public static bool IsAnonymousPath(this HttpContext context, C.AuthProxy config) =>
+        AnonymousPaths.Matches(context.Request.Path, config);
 
     /// <summary>
     /// Determines whether the request targets any authentication bootstrap endpoint.

--- a/Source/AuthProxy/ReverseProxy/MicroserviceReverseProxyConfigProvider.cs
+++ b/Source/AuthProxy/ReverseProxy/MicroserviceReverseProxyConfigProvider.cs
@@ -28,6 +28,16 @@ namespace Cratis.AuthProxy.ReverseProxy;
 public class MicroserviceReverseProxyConfigProvider(
     IOptionsMonitor<C.AuthProxy> config) : IProxyConfigProvider
 {
+    /// <summary>
+    /// The YARP well-known authorization policy name that disables authorization for a route.
+    /// </summary>
+    const string AnonymousAuthorizationPolicy = "anonymous";
+
+    /// <summary>
+    /// The path prefix served by a service's backend rather than its frontend.
+    /// </summary>
+    const string ApiPathPrefix = "/api";
+
     static readonly ClusterConfig _baseCluster = new()
     {
         HttpRequest = new() { ActivityTimeout = TimeSpan.FromMinutes(5) },
@@ -49,6 +59,8 @@ public class MicroserviceReverseProxyConfigProvider(
         foreach (var (name, ms) in services)
         {
             var key = name.ToLowerInvariant();
+
+            routes.AddRange(AnonymousRoutes(key, ms));
 
             if (ms.Backend is not null)
             {
@@ -93,6 +105,69 @@ public class MicroserviceReverseProxyConfigProvider(
         }
 
         return routes;
+    }
+
+    /// <summary>
+    /// Builds the routes for the paths a service declares in <see cref="C.Service.AnonymousPaths"/>.
+    /// </summary>
+    /// <param name="microserviceKey">The lower-cased service key.</param>
+    /// <param name="service">The service configuration.</param>
+    /// <returns>One route per declared anonymous path prefix.</returns>
+    /// <remarks>
+    /// These are the only routes not generated with <c>AuthorizationPolicy = "default"</c>. That default is
+    /// <c>RequireAuthenticatedUser()</c>, so without this a declared anonymous path would clear
+    /// <c>SelectProviderMiddleware</c> and then be refused by authorization instead — the same closed door,
+    /// one middleware later. None of the built-in skip-list paths (invite, registration, authentication UI,
+    /// <c>/_pages</c>) is ever proxied to a service, so this is the first case where an unauthenticated
+    /// request is meant to reach a backend, and the first that needs the policy relaxed.
+    /// <para>
+    /// The relaxation is scoped to exactly the declared prefixes and nothing else: with no
+    /// <c>AnonymousPaths</c> declared this yields no routes and the table is what it was before. Each
+    /// prefix is emitted as a catch-all so it covers the prefix itself and everything under it, which
+    /// matches the segment-prefix semantics the middlewares apply because
+    /// <see cref="AnonymousPaths.TryNormalize"/> only admits prefixes made of literal segments.
+    /// </para>
+    /// <para>
+    /// Order 0 puts these ahead of the header- and query-selected routes, which is what relaxes the policy
+    /// but also claims the prefix for the whole proxy: an anonymous caller cannot be expected to send a
+    /// service-selection header, so the declared path is necessarily what identifies the service. In a
+    /// multi-service deployment no other service can serve anything under a declared prefix.
+    /// </para>
+    /// </remarks>
+    static IEnumerable<RouteConfig> AnonymousRoutes(string microserviceKey, C.Service service)
+    {
+        var index = 0;
+
+        foreach (var path in AnonymousPaths.For(service))
+        {
+            // Mirror the authenticated split: /api goes to the backend, anything else to the frontend,
+            // falling back to whichever endpoint the service actually declares.
+            var prefersBackend = new PathString(path).StartsWithSegments(ApiPathPrefix);
+            var clusterId = (prefersBackend, service.Backend, service.Frontend) switch
+            {
+                (true, not null, _) => BackendClusterId(microserviceKey),
+                (false, _, not null) => FrontendClusterId(microserviceKey),
+                (_, not null, null) => BackendClusterId(microserviceKey),
+                (_, null, not null) => FrontendClusterId(microserviceKey),
+                _ => null,
+            };
+
+            if (clusterId is null)
+            {
+                continue;
+            }
+
+            yield return new RouteConfig
+            {
+                RouteId = $"{microserviceKey}-anonymous-{index}",
+                ClusterId = clusterId,
+                AuthorizationPolicy = AnonymousAuthorizationPolicy,
+                Match = new RouteMatch { Path = $"{path}/{{**catch-all}}" },
+                Order = 0,
+            };
+
+            index++;
+        }
     }
 
     static IEnumerable<RouteConfig> BackendRoutes(string microserviceKey, bool isSingle)

--- a/Source/AuthProxy/TenancyMiddleware.cs
+++ b/Source/AuthProxy/TenancyMiddleware.cs
@@ -65,11 +65,18 @@ public class TenancyMiddleware(
             var hasPendingInviteCookie = context.HasPendingInvitation();
             var hasPendingRegistrationCookie = context.HasPendingRegistration();
             var isAuthPath = context.IsAuthenticationUI();
+
+            // A caller on a declared anonymous path has no session to resolve a tenant from, so treat it
+            // like the other tenant-less paths below. Without this, declaring a path anonymous would move
+            // the refusal from SelectProviderMiddleware to here instead of removing it.
+            var isAnonymousPath = context.IsAnonymousPath(config.CurrentValue);
+
             if (shouldRedirectToLobby
                 && !string.IsNullOrWhiteSpace(lobbyUrl)
                 && !isInvitePath
                 && !isRegistrationPath
                 && !isAuthPath
+                && !isAnonymousPath
                 && !hasPendingInviteCookie
                 && !hasPendingRegistrationCookie)
             {
@@ -82,6 +89,7 @@ public class TenancyMiddleware(
                 && !isAuthPath
                 && !isInvitePath
                 && !isRegistrationPath
+                && !isAnonymousPath
                 && !hasPendingInviteCookie
                 && !hasPendingRegistrationCookie)
             {


### PR DESCRIPTION
### Added
- A service can declare AnonymousPaths — path prefixes reachable without authentication — configurable through 
   Cratis__AuthProxy__Services__{key}__AnonymousPaths__{i} or the Aspire WithAnonymousPaths extension.
- Documentation for the new property in Documentation/configuration/services.md, including the matching rules and what it does not change.  

### Changed
  
- Generated YARP routes for a declared anonymous prefix carry an anonymous authorization policy instead of the default RequireAuthenticatedUser. All other routes are unchanged.
- SelectProviderMiddleware and TenancyMiddleware skip their refusal branches for a declared anonymous path. Identity-header stripping still runs first, so an anonymous path never crosses the trust boundary.
  
### Fixed
- WithAnonymousPaths discarded earlier calls for the same service — the configuration index restarted at zero on each invocation.
- Declared prefixes are validated to literal path segments. A value that would parse as an ASP.NET route template previously either hijacked unrelated paths (the router matched a parameter where the middlewares matched a literal) or threw RoutePatternException and prevented startup.