### PR TITLE
Document serving a public application surface

### DIFF
--- a/Documentation/configuration/public-surfaces.md
+++ b/Documentation/configuration/public-surfaces.md
@@ -1,0 +1,96 @@
+# Public Application Surfaces
+
+Some parts of an application are served to someone who has no account and never will: a magic-link
+landing page, a report reached by a signed URL, a public status page. The visitor is not anonymous to the
+*application* — the token in their link identifies them — but they are anonymous to the **proxy**, which
+has no session to check.
+
+Declaring those paths is what [`AnonymousPaths`](services.md#anonymous-paths) is for.
+
+---
+
+## Declaring the surface
+
+Name the specific paths the application serves without a session — the landing route that exchanges the
+token, and the API routes it calls:
+
+```json
+{
+  "Cratis": {
+    "AuthProxy": {
+      "Services": {
+        "core": {
+          "Frontend": { "BaseUrl": "http://core-web:3000/" },
+          "Backend": { "BaseUrl": "http://core:8080/" },
+          "AnonymousPaths": [
+            "/customer-portal",
+            "/api/customer-portal"
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+`/customer-portal` is served by the frontend, `/api/customer-portal` by the backend — the split follows
+the same `/api` rule the authenticated routes use.
+
+### Declare the narrowest prefix that works
+
+Entries are prefixes and cover everything beneath them. `/api/customer-portal` opens every route under it,
+including ones added later by someone who does not know the prefix is public. If only some of those routes
+are public, name them individually instead.
+
+---
+
+## What still protects the surface
+
+The token in the link. AuthProxy does not check it — it cannot, because only the application knows how it
+was minted. The application validates it on every request, exactly as it would if the proxy were not
+there.
+
+What the proxy still does:
+
+- Strips inbound `x-ms-client-principal`, `x-ms-client-principal-id`, `x-ms-client-principal-name` and
+  `Tenant-ID` headers, so a caller cannot assert an identity on the way in.
+- Injects no principal headers, because there is no session.
+- Leaves an authenticated visitor authenticated. A declared path is identity-*optional*, not
+  identity-free: someone who happens to be signed in still arrives with their identity headers, though
+  **without** a `Tenant-ID` if they have not selected a tenant. Handle a declared path as tenant-optional.
+
+---
+
+## Why declare it in the proxy rather than route around it
+
+The alternative is an ingress rule above AuthProxy sending those paths straight to the service. It works,
+and it costs two things worth understanding before choosing it.
+
+**It moves the identity-trust boundary.** Bypassing the proxy makes the service directly reachable, so the
+ingress rule must strip inbound `x-ms-client-principal*` and `Tenant-ID` headers itself. Stripping and
+re-injecting those headers is precisely AuthProxy's job; a carve-out that forwards them unfiltered is an
+authentication bypass. The rule now has to be as correct as the proxy, and it is maintained somewhere
+else, by someone else.
+
+**It weakens what you can say about the deployment.** "Public traffic reaches AuthProxy only" becomes
+"public traffic reaches AuthProxy except for this list", and the list has to be re-audited whenever it
+changes.
+
+Declaring the paths inside the proxy has neither cost. Traffic still flows through AuthProxy, so the
+header boundary holds and the invariant stays whole.
+
+---
+
+## Checking it works
+
+An unauthenticated request to a declared path should reach the application. If it comes back as the
+sign-in chooser, the declaration was not accepted — an entry that is not a rooted path of literal segments
+is discarded silently, so check its spelling first. See
+[Anonymous paths](services.md#anonymous-paths) for the exact rule.
+
+If the request comes back as `401` rather than the application's response, the caller was not treated as a
+browser navigating to a page. That is expected for a `fetch()` or a command-line client against an
+*undeclared* path — see [Unauthenticated responses](unauthenticated-responses.md).
+
+For the sibling case, an inbound request from a system rather than a person, see
+[Receiving webhooks](webhooks.md).

--- a/Documentation/configuration/services.md
+++ b/Documentation/configuration/services.md
@@ -91,7 +91,10 @@ page, a signed-token report, a public webhook receiver.
 
 A declared path is reachable by anyone who knows the URL — AuthProxy stops demanding a login, it does not
 authenticate the caller. The application remains responsible for deciding whether to trust the request.
-For inbound webhooks specifically, see [Receiving webhooks](webhooks.md).
+
+Two how-to guides cover the cases in detail: [Public application surfaces](public-surfaces.md) for a page
+or API a person reaches without an account, and [Receiving webhooks](webhooks.md) for a request from
+another system.
 
 ```json
 {

--- a/Documentation/configuration/toc.yml
+++ b/Documentation/configuration/toc.yml
@@ -16,6 +16,8 @@
   href: sign-in.md
 - name: Services
   href: services.md
+- name: Public Application Surfaces
+  href: public-surfaces.md
 - name: Receiving Webhooks
   href: webhooks.md
 - name: Lobby

--- a/Documentation/configuration/webhooks.md
+++ b/Documentation/configuration/webhooks.md
@@ -79,3 +79,6 @@ Not an omission — a deliberate boundary:
 - **Treat the payload as untrusted until verified**, including any identifiers used to look up records.
 - **Re-read the declared paths when reviewing the deployment.** They are the surface reachable without a
   session, and they are the shortest list worth auditing.
+
+For the sibling case — a page or API a *person* reaches without an account, such as a magic-link landing
+page — see [Public application surfaces](public-surfaces.md).


### PR DESCRIPTION
# Summary

Guidance for the case `AnonymousPaths` was reported for — a page or API a person reaches without an account.

## Added

- Documentation for serving a public application surface: how to declare the paths, what still protects them, and why declaring them in the proxy is preferable to routing around it at the ingress
