### PR TITLE
Apply configuration reloads to the reverse proxy route table

### DIFF
--- a/Source/AuthProxy.Specs/ReverseProxy/for_MicroserviceReverseProxyConfigProvider/ReloadableOptionsMonitor.cs
+++ b/Source/AuthProxy.Specs/ReverseProxy/for_MicroserviceReverseProxyConfigProvider/ReloadableOptionsMonitor.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.ReverseProxy.for_MicroserviceReverseProxyConfigProvider;
+
+/// <summary>
+/// An <see cref="IOptionsMonitor{TOptions}"/> that can replace the configuration it serves, so a spec can
+/// drive a reload the way a file-backed configuration source does — a new instance handed out, and every
+/// registered listener notified.
+/// </summary>
+/// <param name="initial">The configuration to serve until the first reload.</param>
+public class ReloadableOptionsMonitor(C.AuthProxy initial) : IOptionsMonitor<C.AuthProxy>
+{
+    readonly List<Action<C.AuthProxy, string?>> _listeners = [];
+
+    /// <inheritdoc/>
+    public C.AuthProxy CurrentValue { get; private set; } = initial;
+
+    /// <inheritdoc/>
+    public C.AuthProxy Get(string? name) => CurrentValue;
+
+    /// <inheritdoc/>
+    public IDisposable? OnChange(Action<C.AuthProxy, string?> listener)
+    {
+        _listeners.Add(listener);
+
+        // The real monitor returns a registration to unsubscribe with; nothing here needs to.
+        return null;
+    }
+
+    /// <summary>
+    /// Serves a new configuration and notifies every listener, as a reload does.
+    /// </summary>
+    /// <param name="next">The configuration to serve from now on.</param>
+    public void Reload(C.AuthProxy next)
+    {
+        CurrentValue = next;
+
+        foreach (var listener in _listeners)
+        {
+            listener(next, Options.DefaultName);
+        }
+    }
+}

--- a/Source/AuthProxy.Specs/ReverseProxy/for_MicroserviceReverseProxyConfigProvider/when_the_configuration_reloads/and_a_declaration_changed.cs
+++ b/Source/AuthProxy.Specs/ReverseProxy/for_MicroserviceReverseProxyConfigProvider/when_the_configuration_reloads/and_a_declaration_changed.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Yarp.ReverseProxy.Configuration;
+
+namespace Cratis.AuthProxy.ReverseProxy.for_MicroserviceReverseProxyConfigProvider.when_the_configuration_reloads;
+
+/// <summary>
+/// The route table is the fourth component that has to agree on what counts as an anonymous path, and the
+/// only one not consulted per request — so it has to follow a reload rather than the process lifetime.
+/// <para>
+/// Withdrawal is the direction that matters. Three middlewares read the configuration on every request and
+/// stop treating a withdrawn prefix as anonymous the moment it reloads, while a table built once at startup
+/// would go on serving that prefix from a route carrying the relaxed authorization policy — the backstop
+/// still open under a surface an operator believes they just closed. Asserted in both directions, so a
+/// rebuild that simply dropped every anonymous route would not satisfy it.
+/// </para>
+/// </summary>
+public class and_a_declaration_changed : given.a_provider_over_a_reloadable_configuration
+{
+    IReadOnlyList<RouteConfig> _routes;
+
+    void Because()
+    {
+        _monitor.Reload(ConfigurationDeclaring("/status"));
+        _routes = _provider.GetConfig().Routes;
+    }
+
+    [Fact] void should_route_the_prefix_the_replacement_declares() =>
+        _routes.Single(_ => _.Match.Path == "/status/{**catch-all}").AuthorizationPolicy.ShouldEqual("anonymous");
+
+    [Fact] void should_no_longer_route_the_withdrawn_prefix() =>
+        _routes.Any(_ => _.Match.Path == "/portal/{**catch-all}").ShouldBeFalse();
+
+    [Fact] void should_relax_the_policy_on_nothing_but_the_declared_prefix() =>
+        _routes.Count(_ => _.AuthorizationPolicy == "anonymous").ShouldEqual(1);
+}

--- a/Source/AuthProxy.Specs/ReverseProxy/for_MicroserviceReverseProxyConfigProvider/when_the_configuration_reloads/and_a_service_endpoint_changed.cs
+++ b/Source/AuthProxy.Specs/ReverseProxy/for_MicroserviceReverseProxyConfigProvider/when_the_configuration_reloads/and_a_service_endpoint_changed.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Yarp.ReverseProxy.Configuration;
+
+namespace Cratis.AuthProxy.ReverseProxy.for_MicroserviceReverseProxyConfigProvider.when_the_configuration_reloads;
+
+/// <summary>
+/// Routes are not the only half of the table a reload can change. A service that moves to a new address is
+/// the same kind of drift as a withdrawn anonymous path — the configuration says one thing and the proxy
+/// goes on forwarding to the old destination — so the clusters are rebuilt with the routes.
+/// </summary>
+public class and_a_service_endpoint_changed : Specification
+{
+    ReloadableOptionsMonitor _monitor;
+    MicroserviceReverseProxyConfigProvider _provider;
+    IReadOnlyList<ClusterConfig> _clusters;
+
+    static C.AuthProxy ConfigurationServing(string baseUrl) =>
+        new()
+        {
+            Services = new Dictionary<string, C.Service>
+            {
+                ["App"] = new() { Frontend = new C.ServiceEndpoint { BaseUrl = baseUrl } },
+            },
+        };
+
+    void Establish()
+    {
+        _monitor = new ReloadableOptionsMonitor(ConfigurationServing("https://frontend.local/"));
+        _provider = new MicroserviceReverseProxyConfigProvider(
+            _monitor,
+            Substitute.For<ILogger<MicroserviceReverseProxyConfigProvider>>());
+    }
+
+    void Because()
+    {
+        _monitor.Reload(ConfigurationServing("https://moved.local/"));
+        _clusters = _provider.GetConfig().Clusters;
+    }
+
+    [Fact] void should_forward_to_the_destination_the_replacement_declares() =>
+        _clusters.Single(_ => _.ClusterId == "app-frontend-cluster").Destinations!.Values.Single().Address.ShouldEqual("https://moved.local/");
+}

--- a/Source/AuthProxy.Specs/ReverseProxy/for_MicroserviceReverseProxyConfigProvider/when_the_configuration_reloads/and_nothing_changed.cs
+++ b/Source/AuthProxy.Specs/ReverseProxy/for_MicroserviceReverseProxyConfigProvider/when_the_configuration_reloads/and_nothing_changed.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Yarp.ReverseProxy.Configuration;
+
+namespace Cratis.AuthProxy.ReverseProxy.for_MicroserviceReverseProxyConfigProvider.when_the_configuration_reloads;
+
+/// <summary>
+/// A file-backed configuration source commonly raises two change notifications for a single edit, and the
+/// second describes the configuration already being served.
+/// <para>
+/// A new <see cref="IProxyConfig"/> is how this provider tells YARP the table changed — YARP answers it by
+/// tearing down and rebuilding its routes — so the configuration served is the same object when the rebuild
+/// arrives at the same table. It is the same object here even though the reload supplies a separately
+/// constructed configuration declaring the same prefix, which is what a second notification for one edit
+/// actually looks like.
+/// </para>
+/// </summary>
+public class and_nothing_changed : given.a_provider_over_a_reloadable_configuration
+{
+    IProxyConfig _before;
+    IProxyConfig _after;
+
+    void Because()
+    {
+        _before = _provider.GetConfig();
+        _monitor.Reload(ConfigurationDeclaring("/portal"));
+        _after = _provider.GetConfig();
+    }
+
+    [Fact] void should_go_on_serving_the_table_it_already_built() =>
+        ReferenceEquals(_after, _before).ShouldBeTrue();
+
+    [Fact] void should_still_route_the_declared_prefix() =>
+        _after.Routes.Single(_ => _.Match.Path == "/portal/{**catch-all}").AuthorizationPolicy.ShouldEqual("anonymous");
+}

--- a/Source/AuthProxy.Specs/ReverseProxy/for_MicroserviceReverseProxyConfigProvider/when_the_configuration_reloads/given/a_provider_over_a_reloadable_configuration.cs
+++ b/Source/AuthProxy.Specs/ReverseProxy/for_MicroserviceReverseProxyConfigProvider/when_the_configuration_reloads/given/a_provider_over_a_reloadable_configuration.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.ReverseProxy.for_MicroserviceReverseProxyConfigProvider.when_the_configuration_reloads.given;
+
+/// <summary>
+/// A provider built over a configuration that can be replaced, declaring <c>/portal</c> anonymous to start
+/// with. A single service with only a frontend keeps the generated table small enough to read.
+/// </summary>
+public class a_provider_over_a_reloadable_configuration : Specification
+{
+    protected MicroserviceReverseProxyConfigProvider _provider;
+    protected ReloadableOptionsMonitor _monitor;
+
+    protected static C.AuthProxy ConfigurationDeclaring(params string[] anonymousPaths) =>
+        new()
+        {
+            Services = new Dictionary<string, C.Service>
+            {
+                ["App"] = new()
+                {
+                    Frontend = new C.ServiceEndpoint { BaseUrl = "https://frontend.local/" },
+                    AnonymousPaths = [.. anonymousPaths],
+                },
+            },
+        };
+
+    void Establish()
+    {
+        _monitor = new ReloadableOptionsMonitor(ConfigurationDeclaring("/portal"));
+        _provider = new MicroserviceReverseProxyConfigProvider(
+            _monitor,
+            Substitute.For<ILogger<MicroserviceReverseProxyConfigProvider>>());
+    }
+}

--- a/Source/AuthProxy/ReverseProxy/MicroserviceReverseProxyConfigProvider.cs
+++ b/Source/AuthProxy/ReverseProxy/MicroserviceReverseProxyConfigProvider.cs
@@ -23,12 +23,12 @@ namespace Cratis.AuthProxy.ReverseProxy;
 /// optional and a plain catch-all route is also registered so that the single
 /// microservice works without any special client configuration.
 /// </para>
+/// <para>
+/// The table is rebuilt whenever the configuration reloads, so it keeps agreeing with the middlewares that
+/// read the same configuration per request — see <see cref="Rebuild"/>.
+/// </para>
 /// </summary>
-/// <param name="config">The options monitor providing the current auth proxy configuration.</param>
-/// <param name="logger">The logger.</param>
-public class MicroserviceReverseProxyConfigProvider(
-    IOptionsMonitor<C.AuthProxy> config,
-    ILogger<MicroserviceReverseProxyConfigProvider> logger) : IProxyConfigProvider
+public class MicroserviceReverseProxyConfigProvider : IProxyConfigProvider, IDisposable
 {
     /// <summary>
     /// The YARP well-known authorization policy name that disables authorization for a route.
@@ -45,12 +45,39 @@ public class MicroserviceReverseProxyConfigProvider(
         HttpRequest = new() { ActivityTimeout = TimeSpan.FromMinutes(5) },
     };
 
-    readonly InMemoryConfigProvider _inner = new(
-        BuildRoutes(config.CurrentValue, logger),
-        BuildClusters(config.CurrentValue));
+    readonly InMemoryConfigProvider _inner;
+    readonly ILogger<MicroserviceReverseProxyConfigProvider> _logger;
+    readonly Lock _rebuilding = new();
+    IDisposable? _configurationChanged;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MicroserviceReverseProxyConfigProvider"/> class.
+    /// </summary>
+    /// <param name="config">The options monitor providing the current auth proxy configuration.</param>
+    /// <param name="logger">The logger.</param>
+    public MicroserviceReverseProxyConfigProvider(
+        IOptionsMonitor<C.AuthProxy> config,
+        ILogger<MicroserviceReverseProxyConfigProvider> logger)
+    {
+        _logger = logger;
+        _inner = new InMemoryConfigProvider(
+            BuildRoutes(config.CurrentValue, logger),
+            BuildClusters(config.CurrentValue));
+        _configurationChanged = config.OnChange(Rebuild);
+    }
 
     /// <inheritdoc/>
     public IProxyConfig GetConfig() => _inner.GetConfig();
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        // Idempotent: this instance is registered both as itself and as IProxyConfigProvider, so the
+        // container can hand the same object to two disposal registrations.
+        _configurationChanged?.Dispose();
+        _configurationChanged = null;
+        GC.SuppressFinalize(this);
+    }
 
     static List<RouteConfig> BuildRoutes(C.AuthProxy config, ILogger logger)
     {
@@ -351,4 +378,40 @@ public class MicroserviceReverseProxyConfigProvider(
 
     static string BackendClusterId(string key) => $"{key}-backend-cluster";
     static string FrontendClusterId(string key) => $"{key}-frontend-cluster";
+
+    /// <summary>
+    /// Rebuilds the route table from a reloaded configuration.
+    /// </summary>
+    /// <param name="config">The reloaded configuration.</param>
+    /// <remarks>
+    /// The route table is one of the four components that have to agree on what counts as an anonymous path
+    /// (see <see cref="AnonymousPaths"/>). The other three are middlewares reading
+    /// <see cref="IOptionsMonitor{TOptions}.CurrentValue"/> per request, so they follow a reload immediately;
+    /// a table built once at startup would not. Withdrawing a declared prefix would leave it on a route still
+    /// carrying <see cref="AnonymousAuthorizationPolicy"/> until the process restarted, and declaring a new one
+    /// would leave it matching only the authenticated catch-all — agreement at the same startup rather than at
+    /// the same instant.
+    /// <para>
+    /// A file-backed configuration source commonly raises two change notifications for a single edit, so a
+    /// rebuild that arrives at the table already being served is skipped: handing YARP an identical
+    /// configuration makes it tear down and rebuild its route table for nothing.
+    /// </para>
+    /// </remarks>
+    void Rebuild(C.AuthProxy config)
+    {
+        var routes = BuildRoutes(config, _logger);
+        var clusters = BuildClusters(config);
+
+        lock (_rebuilding)
+        {
+            var current = _inner.GetConfig();
+
+            if (current.Routes.SequenceEqual(routes) && current.Clusters.SequenceEqual(clusters))
+            {
+                return;
+            }
+
+            _inner.Update(routes, clusters);
+        }
+    }
 }


### PR DESCRIPTION
# Summary

Configuration reloads now reach the reverse proxy route table.

## Fixed

- Changes to `Cratis:AuthProxy:Services` now take effect when configuration reloads rather than at the next restart — routes and clusters are both rebuilt, so a service that moves address, or is added or removed, is routed accordingly without cycling the proxy
- Withdrawing a path from `AnonymousPaths` now removes the route that relaxed authorization for it, instead of leaving that route serving the prefix until the process restarted
- Declaring a new path in `AnonymousPaths` now opens it on reload, instead of the prefix counting as anonymous to the middlewares while still matching only the authenticated catch-all
