### PR TITLE
Sanitize anonymous paths and add a security spec suite

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -10,6 +10,7 @@ on:
       - "**"
     paths:
       - "Source/**"
+      - ".github/workflows/**"
 
 jobs:
   dotnet-build:
@@ -26,5 +27,27 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Build
+      # Debug and Release are not the same gate: the spec projects and several analyzer paths only compile
+      # under Debug, so a Release-only build can go green over code that does not compile for anyone
+      # working on it locally.
+      - name: Build (Debug)
+        run: dotnet build --configuration Debug
+
+      - name: Build (Release)
         run: dotnet build --configuration Release
+
+      - name: Test
+        run: >
+          dotnet test
+          --configuration Debug
+          --no-build
+          --logger "trx;LogFileName=specs.trx"
+          --results-directory TestResults
+
+      - name: Upload spec results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: spec-results
+          path: TestResults
+          retention-days: 14

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,97 @@
+name: Security
+
+# Runs on every pull request, deliberately without a `paths:` filter.
+#
+# AuthProxy is the component that decides who reaches everything behind it, so the security specs are not
+# gated on which files a change happens to touch: a workflow edit, a dependency bump, or a configuration
+# default can all move the security posture without any file under Source/ changing. The suite is fast
+# enough to run unconditionally, and a gate that only sometimes runs is not a gate.
+
+env:
+  DOTNET_VERSION: "10.0.x"
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - "**"
+  push:
+    branches:
+      - main
+
+jobs:
+  security-specs:
+    name: Security specs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Build security specs
+        run: dotnet build Source/AuthProxy.Security.Specs/AuthProxy.Security.Specs.csproj --configuration Release
+
+      - name: Run security specs
+        run: >
+          dotnet test Source/AuthProxy.Security.Specs/AuthProxy.Security.Specs.csproj
+          --configuration Release
+          --no-build
+          --logger "trx;LogFileName=security-specs.trx"
+          --results-directory TestResults
+
+      - name: Upload security spec results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: security-spec-results
+          path: TestResults
+          retention-days: 14
+
+  vulnerable-dependencies:
+    name: Vulnerable dependencies
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore
+        run: dotnet restore
+
+      # OWASP A06 — Vulnerable and Outdated Components. `dotnet list package` reports advisories but always
+      # exits 0, so the output is inspected and the job failed explicitly; otherwise a known-vulnerable
+      # dependency would be reported into a green check that nobody reads.
+      - name: Check for known vulnerable packages
+        run: |
+          set -euo pipefail
+
+          dotnet list package --vulnerable --include-transitive 2>&1 | tee vulnerable.txt
+
+          if grep -qE '^\s*>\s' vulnerable.txt; then
+            echo "::error::One or more packages have known vulnerabilities. See the report above."
+            exit 1
+          fi
+
+          echo "No known vulnerable packages."
+
+      - name: Upload dependency report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vulnerable-dependency-report
+          path: vulnerable.txt
+          retention-days: 14

--- a/AuthProxy.slnx
+++ b/AuthProxy.slnx
@@ -5,6 +5,7 @@
     <Project Path="Source/Aspire.Specs/Aspire.Specs.csproj" />
     <Project Path="Source/Composition/Composition.csproj" />
     <Project Path="Source/AuthProxy.Specs/AuthProxy.Specs.csproj" />
+    <Project Path="Source/AuthProxy.Security.Specs/AuthProxy.Security.Specs.csproj" />
     <Project Path="Source/TestApp/TestApp.csproj" />
   </Folder>
 </Solution>

--- a/Documentation/configuration/authentication.md
+++ b/Documentation/configuration/authentication.md
@@ -133,13 +133,34 @@ context is **session-scoped or short-lived** — closing the browser ends them. 
 |----------|---------|-------------|
 | `Lifetime` | `12:00:00` | Absolute lifetime of the authentication ticket. When it elapses the user must re-authenticate with the identity provider, even in a browser session that never closed. |
 | `SlidingExpiration` | `false` | Whether activity extends the ticket lifetime. Disabled by default so `Lifetime` is a hard bound. |
-| `IdentityRevalidationInterval` | `00:10:00` | How long the `.cratis-identity` cookie is trusted before the identity details — and the authorization they represent — are re-resolved against the services. Zero or negative disables the bound. |
+| `IdentityRevalidationInterval` | `00:10:00` | How long a resolved authorization is remembered before the identity details — and the authorization they represent — are re-resolved against the services. Zero or negative falls back to ten minutes. |
 | `TenantRevalidationInterval` | `00:10:00` | How long a tenant selected through the [tenant-selection flow](tenant-selection.md) is trusted before it is re-validated against `TenantsEndpoint`, so revoked tenant access takes effect without per-request backend calls. Zero or negative disables re-validation. |
 
 The authentication cookie itself carries no persistent `Expires` — the browser drops it when the session
 ends — and is `HttpOnly`, `SameSite=Lax`, and marked `Secure` whenever the site is served over HTTPS.
 Re-validation is cached in memory per instance, so within an interval no extra backend calls are made;
 when the interval lapses, a single backend round-trip refreshes the cached identity or tenant context.
+
+### The two identity cookies
+
+The resolved identity is written to two cookies, and the split is a security boundary rather than an
+implementation detail:
+
+| Cookie | Readable by script | Contents | Role |
+|--------|--------------------|----------|------|
+| `.cratis-identity` | Yes | Base64 JSON identity details | Lets a frontend render the signed-in user without a round-trip. **Never** treated by AuthProxy as evidence of anything. |
+| `.cratis-identity-authorization` | No (`HttpOnly`) | A sealed, unforgeable record | Carries the authorization decision that is allowed to skip the `/.cratis/me` call on later requests. |
+
+Because `.cratis-identity` is deliberately script-readable, anything a client can write must not decide
+authorization — so the decision lives in the sealed cookie instead. It is protected with ASP.NET data
+protection and bound to the user and tenant it was issued for, and its expiry is carried *inside* the
+sealed value rather than left to the cookie's `Max-Age`, which a non-browser client is free to ignore. A
+record that cannot be unsealed (for example after a data-protection key rotation) is not a failure: the
+caller is simply re-authorized against the services.
+
+Deployments running more than one AuthProxy instance should configure a shared
+`DataProtectionKeysPath` so a record sealed by one instance can be read by the others; without it each
+instance re-resolves identity for callers whose record it did not issue.
 
 ---
 

--- a/Documentation/configuration/services.md
+++ b/Documentation/configuration/services.md
@@ -128,11 +128,31 @@ as the built-in invite, registration and authentication-UI paths.
 Because an entry covers everything below it, name the specific leaf path whenever a sibling under the
 same parent is not public.
 
-An entry must be a rooted path of literal segments. Anything else — blank, unrooted, the bare `/`, a
-doubled `//`, or a value containing `{`, `}`, `?`, `#`, `*`, `[`, `]`, `\`, `%` or whitespace — is
-**discarded**, leaving that path authenticated. Discarding is deliberate: a blank value would otherwise
-match every request and turn the whole service anonymous. A discarded entry is silent, so if a declared
-path still returns the selection page, check its spelling first.
+### What a valid entry looks like
+
+An entry must be a rooted path whose segments are made only of the characters `A–Z`, `a–z`, `0–9`, `-`,
+`.`, `_` and `~`. Anything else is **refused**, leaving that path authenticated.
+
+Refusing rather than interpreting is deliberate, and every rule below is a case where a declared prefix
+would otherwise have meant one thing to the reader and another to the proxy:
+
+| Refused | Example | Why |
+|---------|---------|-----|
+| Blank, whitespace, or the bare `/` | `""`, `"/"`, `"///"` | An empty prefix matches *every* request and would turn the whole service anonymous — the worst outcome this feature can produce. |
+| Unrooted | `welcome` | Not a path prefix. |
+| An empty segment | `/a//b` | Not a legal route template. |
+| A `.` or `..` segment | `/public/../admin` | Reads as scoped to `/public` while naming `/admin`. Refused rather than resolved, so a prefix always means what it spells. |
+| Any character outside the permitted set | `/a{x}`, `/a*`, `/a?b`, `/a;b`, `/a:b`, `/a@b`, `/a\b` | `{`, `}` and `*` would make the router match `/aANYTHING/…` where the middlewares match only the literal. The rest are separators or delimiters to some parsers and literals to others. |
+| Percent-encoding | `/public%2fadmin`, `/public/%2e%2e/admin` | A prefix whose meaning depends on encoding cannot be reasoned about — and these are the classic separator-smuggling and traversal forms. |
+| Control characters or whitespace | `/a b`, `/a\tb` | Invisible differences between two entries that read identically, and the raw material of log and header injection. |
+| Non-ASCII characters | `/públic` | The same path has more than one Unicode spelling (`NFC` vs `NFD`), so which one is anonymous would depend on how the configuration file was saved. |
+| A path AuthProxy answers itself | `/.cratis`, `/.cratis/token`, `/_pages`, `/invite`, `/register`, `/signin-microsoft` | These do not become "more public" — they take the endpoint *away* from AuthProxy and hand it to a backend. |
+
+A dot *inside* a segment is fine, so `/.well-known/acme-challenge` and `/public/health.json` are both
+valid. Only a segment that is exactly `.` or `..` is refused.
+
+A refused entry is reported at startup as a warning naming the entry and the reason, so a declared path
+that still returns the selection page can be diagnosed from the log rather than by inspection.
 
 `/api` chooses the endpoint the same way the authenticated routes do: a prefix under `/api` is served by
 the service's `Backend`, anything else by its `Frontend`, falling back to whichever endpoint the service

--- a/Source/AuthProxy.Security.Specs/AuthProxy.Security.Specs.csproj
+++ b/Source/AuthProxy.Security.Specs/AuthProxy.Security.Specs.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Cratis.AuthProxy.Security</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591;MA0176</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Cratis.Specifications.XUnit" />
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Microsoft.NET.Test.SDK" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../AuthProxy/AuthProxy.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Source/AuthProxy.Security.Specs/GlobalUsings.cs
+++ b/Source/AuthProxy.Security.Specs/GlobalUsings.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+global using System.Net;
+global using Cratis.AuthProxy.Security.given;
+global using Xunit;
+global using C = Cratis.AuthProxy.Configuration;

--- a/Source/AuthProxy.Security.Specs/for_AccessControl/when_a_caller_forges_the_identity_cookies.cs
+++ b/Source/AuthProxy.Security.Specs/for_AccessControl/when_a_caller_forges_the_identity_cookies.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Security.for_AccessControl;
+
+/// <summary>
+/// OWASP A01 / A08 — the decision that a caller is authorized must not be something the caller can write.
+/// <para>
+/// AuthProxy asks every configured service's <c>/.cratis/me</c> endpoint whether a signed-in user is
+/// authorized at all, and remembers the answer so the question is not re-asked on every proxied request.
+/// Where that memory lives is the whole security question. The readable <c>.cratis-identity</c> cookie
+/// cannot be it: it is written non-HTTP-only on purpose, so a frontend can render the signed-in user from
+/// it, which means script on any proxied origin can rewrite it and any non-browser client can simply send
+/// one. Treating its presence as proof meant <c>Cookie: .cratis-identity=x</c> alongside a valid session
+/// skipped the authorization call entirely — a user whose access had been revoked stayed authorized for as
+/// long as they chose to keep sending it, and no expiry could stop them, because a cookie's
+/// <c>Max-Age</c> is a request to the browser rather than a rule.
+/// </para>
+/// <para>
+/// So the authorization answer is remembered in a separate HTTP-only cookie sealed with data protection
+/// and bound to the principal and tenant it was issued for. These specs assert the negative that matters:
+/// no value a caller can invent for either cookie skips the backend authorization call.
+/// </para>
+/// </summary>
+/// <param name="harness">The running proxy and its origin.</param>
+[Collection(SecuritySpecCollection.Name)]
+public class when_a_caller_forges_the_identity_cookies(SecurityHarness harness) : IAsyncLifetime
+{
+    bool _resolvedWithForgedIdentityCookie;
+    bool _resolvedWithForgedAuthorizationCookie;
+    bool _resolvedWithBothForged;
+    bool _resolvedWithNoCookies;
+
+    public async Task InitializeAsync()
+    {
+        _resolvedWithNoCookies = await IdentityWasResolved("clean", cookies: null);
+
+        _resolvedWithForgedIdentityCookie = await IdentityWasResolved(
+            "forged-identity",
+            $"{Cookies.Identity}=eyJ1c2VySWQiOiJhdHRhY2tlciJ9");
+
+        _resolvedWithForgedAuthorizationCookie = await IdentityWasResolved(
+            "forged-authorization",
+            $"{Cookies.IdentityAuthorization}=not-a-real-sealed-record");
+
+        _resolvedWithBothForged = await IdentityWasResolved(
+            "forged-both",
+            $"{Cookies.Identity}=eyJ1c2VySWQiOiJhdHRhY2tlciJ9; {Cookies.IdentityAuthorization}=AAAAAAAAAAAAAAAAAAAAAA");
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public void should_resolve_identity_for_a_caller_presenting_no_cookies() =>
+        Assert.True(_resolvedWithNoCookies, "The identity endpoint must be called when nothing is remembered.");
+
+    [Fact]
+    public void should_still_resolve_identity_despite_a_forged_readable_cookie() =>
+        Assert.True(_resolvedWithForgedIdentityCookie, "A caller-writable cookie must not skip the authorization call.");
+
+    [Fact]
+    public void should_still_resolve_identity_despite_a_forged_authorization_cookie() =>
+        Assert.True(_resolvedWithForgedAuthorizationCookie, "An unsealable record must not skip the authorization call.");
+
+    [Fact]
+    public void should_still_resolve_identity_despite_both_cookies_being_forged() =>
+        Assert.True(_resolvedWithBothForged, "No combination of forged cookies may skip the authorization call.");
+
+    /// <summary>
+    /// Makes one authenticated request as a brand-new user and reports whether AuthProxy asked the origin
+    /// to authorize them.
+    /// </summary>
+    /// <param name="hint">A label making the user recognizable in a failure.</param>
+    /// <param name="cookies">The raw <c>Cookie</c> header to present, if any.</param>
+    /// <returns><see langword="true"/> when the origin was asked; otherwise <see langword="false"/>.</returns>
+    /// <remarks>
+    /// A fresh user each time, because the resolver also keeps a short-lived server-side cache keyed by
+    /// user and tenant — a shared identity would let an earlier request's answer stand in for this one and
+    /// the spec would pass without proving anything.
+    /// </remarks>
+    async Task<bool> IdentityWasResolved(string hint, string? cookies)
+    {
+        using var client = harness.CreateSecurityClient();
+
+        var request = SecurityHarness.Authenticated(
+            HttpMethod.Get,
+            SecurityHarness.ProtectedPath,
+            SecurityHarness.UniqueUser(hint));
+
+        if (cookies is not null)
+        {
+            request.Headers.TryAddWithoutValidation("Cookie", cookies);
+        }
+
+        harness.Origin.Clear();
+        await client.SendAsync(request);
+
+        return harness.Origin.ReceivedAnythingFor(WellKnownPaths.IdentityDetails);
+    }
+}

--- a/Source/AuthProxy.Security.Specs/for_AccessControl/when_identity_headers_are_spoofed.cs
+++ b/Source/AuthProxy.Security.Specs/for_AccessControl/when_identity_headers_are_spoofed.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Security.for_AccessControl;
+
+/// <summary>
+/// OWASP A01 — Broken Access Control. A caller must not be able to tell the origin who they are.
+/// <para>
+/// AuthProxy's entire value is that a backend can trust <c>x-ms-client-principal</c>,
+/// <c>x-ms-client-principal-id</c>, <c>x-ms-client-principal-name</c> and <c>Tenant-ID</c> as proof of
+/// identity, because the proxy is the only thing that writes them. If an inbound copy survived to the
+/// origin, every backend behind the proxy would be authenticating whoever asked — the single worst failure
+/// this component can have, and one no client-facing response would reveal. So the assertion is made
+/// against a real origin that records what it actually received.
+/// </para>
+/// <para>
+/// Asserted on both an anonymous and an authenticated caller, and on the declared anonymous path as well
+/// as the ordinary one: the anonymous path is the route that skips the authorization policy, so it is the
+/// one where a spoofed header would most plausibly be carried through.
+/// </para>
+/// </summary>
+/// <param name="harness">The running proxy and its origin.</param>
+[Collection(SecuritySpecCollection.Name)]
+public class when_identity_headers_are_spoofed(SecurityHarness harness) : IAsyncLifetime
+{
+    ForwardedRequest? _anonymousOnAnonymousPath;
+    ForwardedRequest? _authenticatedOnProtectedPath;
+    string _injectedPrincipal = string.Empty;
+
+    public async Task InitializeAsync()
+    {
+        using var client = harness.CreateSecurityClient();
+
+        _injectedPrincipal = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(
+            /*lang=json,strict*/ """{"userId":"attacker","userRoles":["Administrator"]}"""));
+
+        harness.Origin.Clear();
+        await client.SendAsync(Spoofed(SecurityHarness.Anonymous(HttpMethod.Get, SecurityHarness.AnonymousPath)));
+        _anonymousOnAnonymousPath = harness.Origin.LastRequestTo(SecurityHarness.AnonymousPath);
+
+        harness.Origin.Clear();
+        await client.SendAsync(Spoofed(SecurityHarness.Authenticated(HttpMethod.Get, SecurityHarness.ProtectedPath)));
+        _authenticatedOnProtectedPath = harness.Origin.LastRequestTo(SecurityHarness.ProtectedPath);
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact] public void should_forward_the_anonymous_request() => Assert.NotNull(_anonymousOnAnonymousPath);
+    [Fact] public void should_forward_the_authenticated_request() => Assert.NotNull(_authenticatedOnProtectedPath);
+
+    [Fact]
+    public void should_not_carry_a_spoofed_principal_to_the_origin_for_an_anonymous_caller() =>
+        Assert.DoesNotContain(_injectedPrincipal, _anonymousOnAnonymousPath!.Value(Headers.Principal), StringComparison.Ordinal);
+
+    [Fact]
+    public void should_not_carry_a_spoofed_principal_to_the_origin_for_an_authenticated_caller() =>
+        Assert.DoesNotContain(_injectedPrincipal, _authenticatedOnProtectedPath!.Value(Headers.Principal), StringComparison.Ordinal);
+
+    [Fact]
+    public void should_not_carry_a_spoofed_principal_id_for_an_anonymous_caller() =>
+        Assert.NotEqual("attacker", _anonymousOnAnonymousPath!.Value(Headers.PrincipalId), StringComparer.OrdinalIgnoreCase);
+
+    [Fact]
+    public void should_not_carry_a_spoofed_principal_id_for_an_authenticated_caller() =>
+        Assert.NotEqual("attacker", _authenticatedOnProtectedPath!.Value(Headers.PrincipalId), StringComparer.OrdinalIgnoreCase);
+
+    [Fact]
+    public void should_not_carry_a_spoofed_principal_name_for_an_anonymous_caller() =>
+        Assert.NotEqual("attacker", _anonymousOnAnonymousPath!.Value(Headers.PrincipalName), StringComparer.OrdinalIgnoreCase);
+
+    [Fact]
+    public void should_not_carry_a_spoofed_tenant_for_an_anonymous_caller() =>
+        Assert.NotEqual("victim-tenant", _anonymousOnAnonymousPath!.Value(Headers.TenantId), StringComparer.OrdinalIgnoreCase);
+
+    [Fact]
+    public void should_not_carry_a_spoofed_tenant_for_an_authenticated_caller() =>
+        Assert.NotEqual("victim-tenant", _authenticatedOnProtectedPath!.Value(Headers.TenantId), StringComparer.OrdinalIgnoreCase);
+
+    [Fact]
+    public void should_give_an_anonymous_caller_no_principal_at_all() =>
+        Assert.False(_anonymousOnAnonymousPath!.Has(Headers.Principal));
+
+    static HttpRequestMessage Spoofed(HttpRequestMessage request)
+    {
+        var forgedPrincipal = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(
+            /*lang=json,strict*/ """{"userId":"attacker","userRoles":["Administrator"]}"""));
+
+        request.Headers.TryAddWithoutValidation(Headers.Principal, forgedPrincipal);
+        request.Headers.TryAddWithoutValidation(Headers.PrincipalId, "attacker");
+        request.Headers.TryAddWithoutValidation(Headers.PrincipalName, "attacker");
+        request.Headers.TryAddWithoutValidation(Headers.TenantId, "victim-tenant");
+
+        return request;
+    }
+}

--- a/Source/AuthProxy.Security.Specs/for_Injection/when_a_path_traverses_out_of_the_pages_root.cs
+++ b/Source/AuthProxy.Security.Specs/for_Injection/when_a_path_traverses_out_of_the_pages_root.cs
@@ -1,0 +1,180 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Security.for_Injection;
+
+/// <summary>
+/// OWASP A03 — Injection. A caller must not be able to name a file outside the pages directory.
+/// <para>
+/// The <c>/_pages</c> branch is the one place AuthProxy reads the disk on behalf of an unauthenticated
+/// caller, and by design it answers before authentication so a login or error page stays reachable without
+/// a session. Anonymous, pre-auth and file-backed is the highest-value path-traversal combination the
+/// component has: a deployment's configuration, its data-protection keys and its mounted secrets all live
+/// near the directories this branch reads from, so a single escape turns the login page into an arbitrary
+/// file read for anyone who can reach the host.
+/// </para>
+/// <para>
+/// That risk is concrete rather than theoretical here, because the proxy's own <c>appsettings.json</c> sits
+/// directly beside its <c>Pages</c> directory — one <c>../</c> is the entire distance between serving a
+/// login page and serving the deployment's configuration. So the payloads walk the evasion ladder instead
+/// of repeating one canonical <c>../</c>: percent-encoded dots, an encoded separator, doubled dots that
+/// survive a naive strip, double encoding, Windows-style backslashes, and a rooted path.
+/// </para>
+/// <para>
+/// The payloads do not all arrive intact, and the spec is written so that this is visible rather than
+/// papered over. Two layers below AuthProxy defuse most of them, and neither is this component's code:
+/// <see cref="Uri"/> collapses dot segments and rewrites backslashes as the request is built, so the three
+/// plain <c>../</c> forms are already ordinary paths before the proxy sees them and are then refused by the
+/// authentication gate; and the request path never decodes <c>%2f</c> into a separator, so the
+/// encoded-separator forms arrive as one long literal file name inside the pages directory rather than as a
+/// walk out of it. What is left reaches the pages handler and is refused there for want of a file.
+/// </para>
+/// <para>
+/// That ordering is worth stating plainly, because it means the explicit containment check in
+/// <c>ResolvePageAssetPath</c> — resolving the full path and requiring it to stay under the directory — is
+/// never the thing that says no in these runs. It is the backstop for the day a layer above stops
+/// normalizing, which is exactly how traversal bugs have historically appeared. So the assertions are made
+/// on the outcome (nothing from outside the page directories is ever returned, and no payload comes back
+/// with a body at all) rather than on the mechanism, and a status is demanded only of the payloads that
+/// genuinely reached the handler.
+/// </para>
+/// <para>
+/// A branch that answered 404 to everything would satisfy an outcome assertion while protecting nothing, so
+/// three requests prove the surface is live alongside the attacks: <c>select-provider.html</c> from the
+/// configured directory, <c>403.html</c> from the content-root directory that is the actual sibling of
+/// <c>appsettings.json</c>, and the same file addressed with an encoded separator, which must fail — it is
+/// what establishes that <c>%2f</c> is inert here and that the encoded-separator payloads were therefore
+/// never a traversal in the first place.
+/// </para>
+/// </summary>
+/// <param name="harness">The running proxy and its origin.</param>
+[Collection(SecuritySpecCollection.Name)]
+public class when_a_path_traverses_out_of_the_pages_root(SecurityHarness harness) : IAsyncLifetime
+{
+    const string ConfiguredPage = "/_pages/select-provider.html";
+    const string ConfiguredPageContent = "Select Provider";
+    const string ContentRootPage = "/_pages/403.html";
+    const string EncodedSeparatorPage = "/_pages/sub%2f..%2f403.html";
+    const string ConfigurationMarker = "AllowedHosts";
+    const string PasswordFileMarker = "root:";
+
+    static readonly string[] _payloads =
+    [
+        "/_pages/../appsettings.json",
+        "/_pages/%2e%2e/appsettings.json",
+        "/_pages/..%2f..%2fappsettings.json",
+        "/_pages/..%2fappsettings.json",
+        "/_pages/....//appsettings.json",
+        "/_pages/%252e%252e/appsettings.json",
+        "/_pages/..\\..\\appsettings.json",
+        "/_pages/....\\\\/appsettings.json",
+        "/_pages//etc/passwd",
+    ];
+
+    readonly List<Attempt> _attempts = [];
+    Attempt? _configuredPage;
+    Attempt? _contentRootPage;
+    Attempt? _encodedSeparator;
+
+    public async Task InitializeAsync()
+    {
+        using var client = harness.CreateSecurityClient();
+
+        harness.Origin.Clear();
+
+        foreach (var payload in _payloads)
+        {
+            _attempts.Add(await Request(client, payload));
+        }
+
+        _configuredPage = await Request(client, ConfiguredPage);
+        _contentRootPage = await Request(client, ContentRootPage);
+        _encodedSeparator = await Request(client, EncodedSeparatorPage);
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public void should_still_serve_a_page_from_the_configured_directory() =>
+        Assert.Equal(HttpStatusCode.OK, _configuredPage!.Status);
+
+    [Fact]
+    public void should_serve_the_content_of_the_configured_page() =>
+        Assert.Contains(ConfiguredPageContent, _configuredPage!.Body, StringComparison.Ordinal);
+
+    [Fact]
+    public void should_still_serve_a_page_from_the_directory_beside_the_configuration() =>
+        Assert.Equal(HttpStatusCode.OK, _contentRootPage!.Status);
+
+    [Fact]
+    public void should_not_resolve_an_encoded_separator_as_a_path_separator() =>
+        Assert.Equal(HttpStatusCode.NotFound, _encodedSeparator!.Status);
+
+    [Fact]
+    public void should_never_return_the_proxy_configuration() =>
+        Assert.DoesNotContain(_attempts, attempt => attempt.Body.Contains(ConfigurationMarker, StringComparison.Ordinal));
+
+    [Fact]
+    public void should_never_return_an_operating_system_account_file() =>
+        Assert.DoesNotContain(_attempts, attempt => attempt.Body.Contains(PasswordFileMarker, StringComparison.Ordinal));
+
+    [Fact]
+    public void should_never_answer_a_traversal_with_a_page_body() =>
+        Assert.DoesNotContain(_attempts, attempt => attempt.Body.Contains(ConfiguredPageContent, StringComparison.Ordinal));
+
+    [Fact]
+    public void should_never_answer_a_traversal_with_any_content_at_all() =>
+        Assert.All(_attempts, attempt => Assert.Empty(attempt.Body));
+
+    [Fact]
+    public void should_have_had_a_payload_reach_the_pages_handler() =>
+        Assert.Contains(_attempts, attempt => attempt.ReachedPagesHandler);
+
+    [Fact]
+    public void should_have_had_a_payload_reach_the_pages_handler_aimed_at_the_configuration() =>
+        Assert.Contains(
+            _attempts,
+            attempt => attempt.ReachedPagesHandler && attempt.Payload.Contains("..%2fappsettings.json", StringComparison.Ordinal));
+
+    [Fact]
+    public void should_refuse_every_payload_that_reaches_the_pages_handler() =>
+        Assert.All(
+            _attempts.Where(attempt => attempt.ReachedPagesHandler),
+            attempt => Assert.Equal(HttpStatusCode.NotFound, attempt.Status));
+
+    [Fact]
+    public void should_refuse_every_payload_normalized_away_from_the_pages_handler() =>
+        Assert.All(
+            _attempts.Where(attempt => !attempt.ReachedPagesHandler),
+            attempt => Assert.NotEqual(HttpStatusCode.OK, attempt.Status));
+
+    static async Task<Attempt> Request(HttpClient client, string pathAndQuery)
+    {
+        using var request = SecurityHarness.Anonymous(HttpMethod.Get, pathAndQuery);
+        using var response = await client.SendAsync(request);
+
+        return new Attempt(
+            pathAndQuery,
+            response.RequestMessage?.RequestUri?.AbsolutePath ?? string.Empty,
+            response.StatusCode,
+            await response.Content.ReadAsStringAsync());
+    }
+
+    /// <summary>
+    /// Records what one path produced, and whether it was still addressed at the pages branch by the time
+    /// the proxy saw it.
+    /// </summary>
+    /// <param name="Payload">The path as the attacker wrote it.</param>
+    /// <param name="EffectivePath">The path the request carried once <see cref="Uri"/> was done with it.</param>
+    /// <param name="Status">The status the proxy answered with.</param>
+    /// <param name="Body">The response body.</param>
+    sealed record Attempt(string Payload, string EffectivePath, HttpStatusCode Status, string Body)
+    {
+        /// <summary>
+        /// Gets whether the request still targeted the pages branch after client-side normalization, and
+        /// therefore says something about AuthProxy rather than about <see cref="Uri"/>.
+        /// </summary>
+        public bool ReachedPagesHandler =>
+            EffectivePath.StartsWith(WellKnownPaths.Pages, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/Source/AuthProxy.Security.Specs/for_Injection/when_request_values_carry_crlf.cs
+++ b/Source/AuthProxy.Security.Specs/for_Injection/when_request_values_carry_crlf.cs
@@ -1,0 +1,193 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Security.for_Injection;
+
+/// <summary>
+/// OWASP A03 — Injection. A caller must not be able to write a header by putting a line break in a value.
+/// <para>
+/// CR/LF injection is header forgery through the back door. AuthProxy copies caller-supplied values into
+/// two places where a line break would be catastrophic: the request it forwards to the origin, and the
+/// <c>Location</c> it hands the browser. A newline surviving into the forwarded request means the attacker
+/// is writing headers the backend trusts — the same identity forgery the proxy exists to prevent, only
+/// smuggled inside a value nobody thought to sanitize. A newline surviving into a response splits the
+/// response itself: the attacker appends headers, or a second body the browser accepts as a legitimate
+/// answer from this origin, which is how cache poisoning and reflected scripting are staged against a
+/// domain the victim already trusts.
+/// </para>
+/// <para>
+/// The payloads travel in URLs rather than in headers, because a header attempt would test the client
+/// instead of the proxy — <see cref="System.Net.Http.HttpClient"/> will not put a control character on the
+/// wire. Both forms are sent, and both arrive: <see cref="Uri"/> percent-escapes the raw
+/// <c>CR</c>/<c>LF</c> as it builds the request, so the raw and the pre-encoded payload reach AuthProxy as
+/// the same bytes — and ASP.NET Core hands both back as genuine control characters once the query value is
+/// decoded. Nothing is normalized away here; every payload reaches the code under test intact.
+/// </para>
+/// <para>
+/// Three sinks are probed. The query string of a proxied request lands in the request the backend sees, so
+/// that assertion is made against what the origin actually recorded rather than against the client-facing
+/// response. The <c>returnUrl</c> of <c>/.cratis/login/{scheme}</c> is the value AuthProxy normalizes and
+/// round-trips through the identity provider; the endpoint runs and consumes it, but this harness replaces
+/// the authentication schemes to present a session as a header, which leaves the configured provider with
+/// no handler to challenge with, so that probe cannot produce a redirect to read. The <c>redirect</c> of
+/// <c>/.cratis/logout</c> is therefore probed as well — it is the sink in this harness that does reach a
+/// real <c>Location</c> header, and without it the response-splitting assertions would pass by never
+/// having a redirect to inspect.
+/// </para>
+/// <para>
+/// That third probe is written to leave the redirect policy only one thing to object to. A payload that
+/// does not begin with <c>/</c> is refused for not looking same-site at all, which would prove nothing
+/// about line breaks, so the redirect variants keep a real same-site path in front and drop the space out
+/// of the forged header. What remains that a policy could refuse is the <c>CR</c> and the <c>LF</c>. A
+/// clean target is sent through the same endpoint as a control, so the payloads falling back to <c>/</c>
+/// reads as a refusal rather than as an endpoint that ignores the parameter.
+/// </para>
+/// </summary>
+/// <param name="harness">The running proxy and its origin.</param>
+[Collection(SecuritySpecCollection.Name)]
+public class when_request_values_carry_crlf(SecurityHarness harness) : IAsyncLifetime
+{
+    const string InjectedHeader = "X-Injected";
+    const string LoginPath = $"{WellKnownPaths.LoginPrefix}/provider-one";
+    const string LegitimateRedirect = "/dashboard";
+
+    /// <summary>
+    /// The forged header in raw and percent-encoded form, each paired with the variant used against a
+    /// redirect target — same-site prefix kept and the space dropped, so the only thing a redirect policy
+    /// can object to is the line break itself.
+    /// </summary>
+    static readonly (string Value, string Redirect)[] _payloads =
+    [
+        ("\r\nX-Injected: yes", $"{LegitimateRedirect}\r\nX-Injected:yes"),
+        ("%0d%0aX-Injected:%20yes", $"{LegitimateRedirect}%0d%0aX-Injected:yes"),
+    ];
+
+    readonly List<Exchange> _exchanges = [];
+    readonly List<Exchange> _logouts = [];
+    readonly List<ForwardedRequest?> _forwarded = [];
+    Exchange? _legitimateLogout;
+
+    public async Task InitializeAsync()
+    {
+        using var client = harness.CreateSecurityClient();
+
+        foreach (var (value, redirect) in _payloads)
+        {
+            harness.Origin.Clear();
+            _exchanges.Add(await Send(client, SecurityHarness.Authenticated(HttpMethod.Get, $"{SecurityHarness.ProtectedPath}?next={value}")));
+            _forwarded.Add(harness.Origin.LastRequestTo(SecurityHarness.ProtectedPath));
+
+            harness.Origin.Clear();
+            _exchanges.Add(await Send(client, SecurityHarness.Anonymous(HttpMethod.Get, $"{LoginPath}?returnUrl={value}")));
+
+            harness.Origin.Clear();
+            var logout = await Send(client, SecurityHarness.Authenticated(HttpMethod.Get, $"{WellKnownPaths.Logout}?redirect={redirect}"));
+            _logouts.Add(logout);
+            _exchanges.Add(logout);
+        }
+
+        harness.Origin.Clear();
+        _legitimateLogout = await Send(client, SecurityHarness.Authenticated(HttpMethod.Get, $"{WellKnownPaths.Logout}?redirect={LegitimateRedirect}"));
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public void should_still_honor_a_redirect_target_that_carries_no_line_break() =>
+        Assert.Equal(LegitimateRedirect, _legitimateLogout!.Location);
+
+    [Fact]
+    public void should_have_delivered_the_payload_to_every_probed_sink() =>
+        Assert.All(_exchanges, exchange => Assert.True(exchange.Reached || exchange.FailedOnlyAtSchemeDispatch));
+
+    [Fact]
+    public void should_have_forwarded_the_payload_to_the_origin() =>
+        Assert.All(_forwarded, Assert.NotNull);
+
+    [Fact]
+    public void should_have_produced_a_redirect_to_inspect() =>
+        Assert.All(_logouts, logout => Assert.NotEmpty(logout.Location));
+
+    [Fact]
+    public void should_fall_back_to_the_application_root_for_a_redirect_target_carrying_a_line_break() =>
+        Assert.All(_logouts, logout => Assert.Equal("/", logout.Location));
+
+    [Fact]
+    public void should_never_write_the_injected_header_on_a_response() =>
+        Assert.DoesNotContain(_exchanges, exchange => exchange.HeaderNames.Contains(InjectedHeader, StringComparer.OrdinalIgnoreCase));
+
+    [Fact]
+    public void should_never_carry_the_injected_header_to_the_origin() =>
+        Assert.All(_forwarded, forwarded => Assert.False(forwarded!.Has(InjectedHeader)));
+
+    [Fact]
+    public void should_never_name_the_injected_header_in_what_the_origin_received() =>
+        Assert.DoesNotContain(_forwarded, forwarded => forwarded!.Headers.Values.Any(value => value.Contains(InjectedHeader, StringComparison.OrdinalIgnoreCase)));
+
+    [Fact]
+    public void should_never_put_a_raw_carriage_return_in_a_redirect_target() =>
+        Assert.All(_exchanges, exchange => Assert.DoesNotContain('\r', exchange.Location));
+
+    [Fact]
+    public void should_never_put_a_raw_line_feed_in_a_redirect_target() =>
+        Assert.All(_exchanges, exchange => Assert.DoesNotContain('\n', exchange.Location));
+
+    [Fact]
+    public void should_never_put_a_raw_carriage_return_in_any_response_header() =>
+        Assert.All(_exchanges, exchange => Assert.DoesNotContain('\r', exchange.HeaderValues));
+
+    [Fact]
+    public void should_never_put_a_raw_line_feed_in_any_response_header() =>
+        Assert.All(_exchanges, exchange => Assert.DoesNotContain('\n', exchange.HeaderValues));
+
+    static async Task<Exchange> Send(HttpClient client, HttpRequestMessage request)
+    {
+        try
+        {
+            using var response = await client.SendAsync(request);
+
+            var headers = response.Headers.Concat(response.Content.Headers).ToArray();
+
+            return new Exchange(
+                true,
+                string.Empty,
+                [.. headers.Select(header => header.Key)],
+                string.Concat(headers.SelectMany(header => header.Value)),
+                string.Concat(response.Headers.TryGetValues("Location", out var location) ? location : []));
+        }
+        catch (Exception ex)
+        {
+            // The proxy never answered. What failed matters: a rejection the payload caused is a result,
+            // while the harness being unable to dispatch a challenge is not, and the two must not be
+            // allowed to look alike.
+            return new Exchange(false, $"{ex.GetType().Name}: {ex.Message}", [], string.Empty, string.Empty);
+        }
+    }
+
+    /// <summary>
+    /// Records what one payload produced on the client-facing response.
+    /// </summary>
+    /// <param name="Reached">Whether the proxy answered at all.</param>
+    /// <param name="Failure">The failure that replaced an answer, or an empty string when there was one.</param>
+    /// <param name="HeaderNames">Every response header name.</param>
+    /// <param name="HeaderValues">Every response header value, concatenated.</param>
+    /// <param name="Location">The raw <c>Location</c> header, or an empty string when there was none.</param>
+    sealed record Exchange(bool Reached, string Failure, IReadOnlyCollection<string> HeaderNames, string HeaderValues, string Location)
+    {
+        /// <summary>
+        /// Gets whether the only thing that stopped this exchange was the harness having no handler
+        /// registered for the configured provider scheme.
+        /// </summary>
+        /// <remarks>
+        /// The harness replaces the authentication schemes so a spec can present a session as a header, and
+        /// that leaves the configured OIDC provider without a handler to challenge with. The endpoint still
+        /// runs — it parses and normalizes the caller's <c>returnUrl</c> before it ever asks for a
+        /// challenge, so the payload does reach the code under test — but dispatch then fails and there is
+        /// no response to read a header from. Recognizing that exact failure keeps it from silently
+        /// standing in for a genuine refusal, and makes this spec fail the day the scheme becomes
+        /// challengeable and a real <c>Location</c> needs asserting on.
+        /// </remarks>
+        public bool FailedOnlyAtSchemeDispatch =>
+            Failure.Contains("No authentication handler is registered", StringComparison.Ordinal);
+    }
+}

--- a/Source/AuthProxy.Security.Specs/for_OpenRedirect/when_the_logout_endpoint_is_given_a_hostile_target.cs
+++ b/Source/AuthProxy.Security.Specs/for_OpenRedirect/when_the_logout_endpoint_is_given_a_hostile_target.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Security.for_OpenRedirect;
+
+/// <summary>
+/// OWASP A01 — an authentication proxy must never redirect a caller off-site on request.
+/// <para>
+/// An open redirect here is worth more to an attacker than almost anywhere else: the victim is handed a
+/// link on the real domain, watches a real sign-out complete, and only then lands on the attacker's page —
+/// so every signal a careful person is taught to check says the page is genuine. That is why the target is
+/// validated against an allow-list rather than merely being made to "look relative".
+/// </para>
+/// <para>
+/// A single leading slash is not what makes a URL same-site, and the payloads below are the ways that
+/// assumption fails. <c>//evil.test</c> is protocol-relative. <c>/\evil.test</c> is the same URL to every
+/// major browser, which normalize a backslash to a slash in the authority position. A slash followed by a
+/// tab, carriage return or newline is also the same URL, because browsers strip those characters before
+/// parsing — so the string the server checked and the URL the browser fetched are different strings. Every
+/// one of them must come back as the application root.
+/// </para>
+/// </summary>
+/// <param name="harness">The running proxy and its origin.</param>
+[Collection(SecuritySpecCollection.Name)]
+public class when_the_logout_endpoint_is_given_a_hostile_target(SecurityHarness harness) : IAsyncLifetime
+{
+    static readonly string[] _hostileTargets =
+    [
+        "//evil.test",
+        "//evil.test/phish",
+        "///evil.test",
+        "/\\evil.test",
+        "/\\/evil.test",
+        "/\\\\evil.test",
+        "\\\\evil.test",
+        "https://evil.test",
+        "http://evil.test/phish",
+        "//evil.test:8080/phish",
+        "/\tevil.test",
+        "/\t//evil.test",
+        "/\r\n//evil.test",
+        "/ /evil.test",
+        "javascript:alert(1)",
+        "//user:pass@evil.test",
+    ];
+
+    static readonly string[] _safeTargets =
+    [
+        "/",
+        "/dashboard",
+        "/dashboard/reports",
+        "/dashboard?tab=overview",
+        "/a-b_c~d.e",
+    ];
+
+    readonly Dictionary<string, string> _locations = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Gets the redirect targets that must never be honored, in the raw form a caller would put in the
+    /// query string.
+    /// </summary>
+    public static TheoryData<string> HostileTargets => new(_hostileTargets);
+
+    /// <summary>
+    /// Gets the targets that are genuinely same-site and must keep working, so the guard is not simply
+    /// refusing everything.
+    /// </summary>
+    public static TheoryData<string> SafeTargets => new(_safeTargets);
+
+    public async Task InitializeAsync()
+    {
+        using var client = harness.CreateSecurityClient();
+
+        foreach (var target in _hostileTargets.Concat(_safeTargets))
+        {
+            var response = await client.SendAsync(SecurityHarness.Authenticated(
+                HttpMethod.Get,
+                $"{WellKnownPaths.Logout}?redirect={Uri.EscapeDataString(target)}"));
+
+            _locations[target] = response.Headers.Location?.OriginalString ?? string.Empty;
+        }
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Theory]
+    [MemberData(nameof(HostileTargets))]
+    public void should_send_a_hostile_target_to_the_application_root(string target) =>
+        Assert.Equal(RelativeRedirect.ApplicationRoot, _locations[target]);
+
+    [Theory]
+    [MemberData(nameof(SafeTargets))]
+    public void should_honor_a_same_site_target(string target) =>
+        Assert.Equal(target, _locations[target]);
+
+    [Theory]
+    [MemberData(nameof(HostileTargets))]
+    public void should_never_name_the_attacker_host_in_the_location(string target) =>
+        Assert.DoesNotContain("evil.test", _locations[target], StringComparison.OrdinalIgnoreCase);
+}

--- a/Source/AuthProxy.Security.Specs/for_RequestSmuggling/when_hop_by_hop_headers_are_sent.cs
+++ b/Source/AuthProxy.Security.Specs/for_RequestSmuggling/when_hop_by_hop_headers_are_sent.cs
@@ -1,0 +1,93 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Security.for_RequestSmuggling;
+
+/// <summary>
+/// A proxy must end the client's connection and start a new one, not extend the client's connection to the
+/// origin. Hop-by-hop headers are the difference.
+/// <para>
+/// <c>Connection</c>, <c>Keep-Alive</c>, <c>Proxy-Connection</c>, <c>Upgrade</c>, <c>TE</c> and
+/// <c>Transfer-Encoding</c> describe a single hop — how these two endpoints agreed to frame and hold this
+/// one connection. Relaying them makes the origin negotiate a connection with a client it is not connected
+/// to. That is where request smuggling lives: an attacker who can get <c>Transfer-Encoding</c> past the
+/// proxy makes the proxy and the origin disagree about where one request ends and the next begins, and
+/// then owns the front of somebody else's request — every access-control decision the proxy just made gets
+/// applied to a body the attacker wrote. <c>Upgrade</c> is the same failure in one step: an origin that
+/// accepts a relayed upgrade leaves a raw tunnel behind the proxy that no later request ever passes through
+/// it again.
+/// </para>
+/// <para>
+/// None of this is visible from the client-facing response — a smuggled request looks like a perfectly
+/// ordinary one until it lands on a different victim's connection. So the assertion is made against a real
+/// origin that records what it actually received, on the declared anonymous path, which is the one route
+/// an unauthenticated attacker can reach without any credential at all.
+/// </para>
+/// </summary>
+/// <param name="harness">The running proxy and its origin.</param>
+[Collection(SecuritySpecCollection.Name)]
+public class when_hop_by_hop_headers_are_sent(SecurityHarness harness) : IAsyncLifetime
+{
+    ForwardedRequest? _forwarded;
+
+    public async Task InitializeAsync()
+    {
+        using var client = harness.CreateSecurityClient();
+
+        harness.Origin.Clear();
+        await client.SendAsync(HopByHop(SecurityHarness.Anonymous(HttpMethod.Get, SecurityHarness.AnonymousPath)));
+        _forwarded = harness.Origin.LastRequestTo(SecurityHarness.AnonymousPath);
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact] public void should_forward_the_request() => Assert.NotNull(_forwarded);
+
+    [Fact]
+    public void should_not_relay_the_connection_header() => Assert.False(_forwarded!.Has("Connection"));
+
+    [Fact]
+    public void should_not_relay_the_keep_alive_header() => Assert.False(_forwarded!.Has("Keep-Alive"));
+
+    [Fact]
+    public void should_not_relay_the_proxy_connection_header() => Assert.False(_forwarded!.Has("Proxy-Connection"));
+
+    [Fact]
+    public void should_not_relay_the_upgrade_header() => Assert.False(_forwarded!.Has("Upgrade"));
+
+    [Fact]
+    public void should_not_relay_the_te_header() => Assert.False(_forwarded!.Has("TE"));
+
+    [Fact]
+    public void should_not_relay_the_transfer_encoding_header() => Assert.False(_forwarded!.Has("Transfer-Encoding"));
+
+    /// <summary>
+    /// Records the one deviation: RFC 9110 section 7.6.1 also asks an intermediary to drop every field the
+    /// <c>Connection</c> header <em>names</em>, and this one survives — the connection-token list is not
+    /// parsed, only the standard hop-by-hop set is stripped.
+    /// </summary>
+    /// <remarks>
+    /// Pinned rather than left unasserted, because it is a real deviation and a change in either direction
+    /// should be a deliberate one. It is not exploitable: the mechanism only ever <em>removes</em> headers,
+    /// so ignoring it forwards more than was asked rather than less, and the surviving header is one the
+    /// same attacker already chose to send. The direction that would matter — naming a trusted hop's
+    /// identity headers in <c>Connection</c> to have them stripped — is closed by the <c>Connection</c>
+    /// header itself never being relayed.
+    /// </remarks>
+    [Fact]
+    public void should_not_honor_the_connection_token_list_for_a_named_custom_header() =>
+        Assert.Equal("leaked", _forwarded!.Value("X-Custom-Hop"));
+
+    static HttpRequestMessage HopByHop(HttpRequestMessage request)
+    {
+        request.Headers.TryAddWithoutValidation("Connection", "close, X-Custom-Hop");
+        request.Headers.TryAddWithoutValidation("Keep-Alive", "timeout=5");
+        request.Headers.TryAddWithoutValidation("Proxy-Connection", "keep-alive");
+        request.Headers.TryAddWithoutValidation("Upgrade", "websocket");
+        request.Headers.TryAddWithoutValidation("TE", "trailers");
+        request.Headers.TryAddWithoutValidation("Transfer-Encoding", "chunked");
+        request.Headers.TryAddWithoutValidation("X-Custom-Hop", "leaked");
+
+        return request;
+    }
+}

--- a/Source/AuthProxy.Security.Specs/for_SecurityMisconfiguration/when_the_proxy_answers_an_error.cs
+++ b/Source/AuthProxy.Security.Specs/for_SecurityMisconfiguration/when_the_proxy_answers_an_error.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Security.for_SecurityMisconfiguration;
+
+/// <summary>
+/// OWASP A05 — Security Misconfiguration. What a proxy says when it refuses is itself a disclosure.
+/// <para>
+/// An attacker's first move against an unfamiliar deployment is to make it fail, because a failing system
+/// describes itself. A .NET stack trace names the exact types, methods and source files behind the door, so
+/// the attacker stops guessing which product and version is running and starts reading its published
+/// advisories. A configured backend address in a refusal body is worse: AuthProxy exists so that the origin
+/// is only ever reachable through it, and naming that origin to a caller who was just refused hands over
+/// the one thing they needed to try reaching it directly.
+/// </para>
+/// <para>
+/// The most dangerous version of this is an error that fires <em>before</em> the request is authenticated.
+/// Endpoint selection runs ahead of authentication, so a caller who can make route matching itself fail
+/// gets that failure — and in a misconfigured environment its stack trace — without presenting a
+/// credential. That is what a request satisfying two routes at once used to do here: sending both the
+/// <c>Service-ID</c> header and the <c>?service=</c> query parameter matched two candidate routes with the
+/// same template and the same order, which ASP.NET reports as an ambiguity and surfaces as a bare 500 to
+/// anyone at all. Both shapes are exercised below, authenticated and not, so a reordering that reopens the
+/// ambiguity is caught rather than shipped.
+/// </para>
+/// </summary>
+/// <param name="harness">The running proxy and its origin.</param>
+[Collection(SecuritySpecCollection.Name)]
+public class when_the_proxy_answers_an_error(SecurityHarness harness) : IAsyncLifetime
+{
+    const string BothRoutesSameService = "/api/thing?service=app";
+    const string BothRoutesCrossService = "/api/thing?service=other";
+
+    readonly List<Answer> _answers = [];
+    string _everyBody = string.Empty;
+
+    public async Task InitializeAsync()
+    {
+        using var client = harness.CreateSecurityClient();
+
+        // A refusal, plus every shape that satisfies both the header route and the query route at once.
+        await Capture(client, "anonymous-protected", SecurityHarness.Anonymous(HttpMethod.Get, SecurityHarness.ProtectedPath));
+        await Capture(client, "authenticated-same-service", ServiceHeader(SecurityHarness.Authenticated(HttpMethod.Get, BothRoutesSameService)));
+        await Capture(client, "authenticated-cross-service", ServiceHeader(SecurityHarness.Authenticated(HttpMethod.Get, BothRoutesCrossService)));
+        await Capture(client, "anonymous-same-service", ServiceHeader(SecurityHarness.Anonymous(HttpMethod.Get, BothRoutesSameService)));
+        await Capture(client, "anonymous-cross-service", ServiceHeader(SecurityHarness.Anonymous(HttpMethod.Get, BothRoutesCrossService)));
+
+        _everyBody = string.Join('\n', _answers.Select(answer => answer.Body));
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public void should_not_disclose_a_stack_frame_in_any_response() =>
+        Assert.DoesNotContain("at Cratis.AuthProxy.", _everyBody, StringComparison.Ordinal);
+
+    [Fact]
+    public void should_not_disclose_an_exception_type_in_any_response() =>
+        Assert.DoesNotContain("System.Exception", _everyBody, StringComparison.Ordinal);
+
+    [Fact]
+    public void should_not_disclose_a_stack_trace_in_any_response() =>
+        Assert.DoesNotContain("StackTrace", _everyBody, StringComparison.Ordinal);
+
+    [Fact]
+    public void should_not_disclose_a_source_file_and_line_in_any_response() =>
+        Assert.DoesNotContain(".cs:line ", _everyBody, StringComparison.Ordinal);
+
+    [Fact]
+    public void should_not_fail_an_authenticated_request_matching_the_header_and_query_routes() =>
+        Assert.NotEqual(HttpStatusCode.InternalServerError, StatusOf("authenticated-same-service"));
+
+    [Fact]
+    public void should_not_fail_an_authenticated_request_naming_another_service_in_the_query() =>
+        Assert.NotEqual(HttpStatusCode.InternalServerError, StatusOf("authenticated-cross-service"));
+
+    [Fact]
+    public void should_not_fail_an_unauthenticated_request_matching_the_header_and_query_routes() =>
+        Assert.NotEqual(HttpStatusCode.InternalServerError, StatusOf("anonymous-same-service"));
+
+    [Fact]
+    public void should_not_fail_an_unauthenticated_request_naming_another_service_in_the_query() =>
+        Assert.NotEqual(HttpStatusCode.InternalServerError, StatusOf("anonymous-cross-service"));
+
+    [Fact]
+    public void should_refuse_an_unauthenticated_request_for_a_protected_path() =>
+        Assert.Equal(HttpStatusCode.Unauthorized, StatusOf("anonymous-protected"));
+
+    [Fact]
+    public void should_not_disclose_the_backend_origin_to_an_unauthenticated_caller() =>
+        Assert.DoesNotContain("127.0.0.1", BodyOf("anonymous-protected"), StringComparison.Ordinal);
+
+    static HttpRequestMessage ServiceHeader(HttpRequestMessage request)
+    {
+        request.Headers.TryAddWithoutValidation(Headers.ServiceId, "app");
+
+        return request;
+    }
+
+    async Task Capture(HttpClient client, string label, HttpRequestMessage request)
+    {
+        harness.Origin.Clear();
+
+        var response = await client.SendAsync(request);
+        _answers.Add(new Answer(label, response.StatusCode, await response.Content.ReadAsStringAsync()));
+    }
+
+    Answer Answered(string label) => _answers.Single(answer => string.Equals(answer.Label, label, StringComparison.Ordinal));
+
+    HttpStatusCode StatusOf(string label) => Answered(label).Status;
+
+    string BodyOf(string label) => Answered(label).Body;
+
+    /// <summary>
+    /// Represents one answer the proxy gave, kept so every spec reads the same recorded exchange.
+    /// </summary>
+    /// <param name="Label">The name the spec refers to this exchange by.</param>
+    /// <param name="Status">The status code the proxy answered with.</param>
+    /// <param name="Body">The response body, as a caller would read it.</param>
+    sealed record Answer(string Label, HttpStatusCode Status, string Body);
+}

--- a/Source/AuthProxy.Security.Specs/given/ForwardedRequest.cs
+++ b/Source/AuthProxy.Security.Specs/given/ForwardedRequest.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Security.given;
+
+/// <summary>
+/// Represents a request as the origin behind AuthProxy received it.
+/// </summary>
+/// <param name="Method">The HTTP method.</param>
+/// <param name="Path">The request path.</param>
+/// <param name="QueryString">The query string, including the leading <c>?</c> when present.</param>
+/// <param name="Headers">Every header the origin received, keyed case-insensitively.</param>
+public sealed record ForwardedRequest(
+    string Method,
+    string Path,
+    string QueryString,
+    IReadOnlyDictionary<string, string> Headers)
+{
+    /// <summary>
+    /// Gets whether the origin received the named header.
+    /// </summary>
+    /// <param name="name">The header name.</param>
+    /// <returns><see langword="true"/> when the header was present; otherwise <see langword="false"/>.</returns>
+    public bool Has(string name) => Headers.ContainsKey(name);
+
+    /// <summary>
+    /// Gets the value the origin received for a header, or an empty string when it was absent.
+    /// </summary>
+    /// <param name="name">The header name.</param>
+    /// <returns>The header value.</returns>
+    public string Value(string name) => Headers.TryGetValue(name, out var value) ? value : string.Empty;
+}

--- a/Source/AuthProxy.Security.Specs/given/HeaderAuthenticationHandler.cs
+++ b/Source/AuthProxy.Security.Specs/given/HeaderAuthenticationHandler.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Cratis.AuthProxy.Security.given;
+
+/// <summary>
+/// Authenticates a request that carries <see cref="SecurityHarness.AuthenticatedUserHeader"/>, standing in
+/// for a valid session cookie.
+/// </summary>
+/// <remarks>
+/// A header rather than a fixed always-authenticate scheme, so a single harness can serve both the specs
+/// that ask what an anonymous caller can reach and the specs that ask what an authenticated caller can
+/// escalate to. It is not the mechanism under test — every spec here treats "has a session" as given and
+/// asks what else the caller can obtain by shaping the rest of the request.
+/// </remarks>
+/// <param name="options">The options monitor for authentication scheme options.</param>
+/// <param name="logger">The logger factory.</param>
+/// <param name="encoder">The URL encoder.</param>
+public class HeaderAuthenticationHandler(
+    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder)
+    : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+    /// <summary>The scheme name the harness registers this under.</summary>
+    public const string Scheme = "SecuritySpecScheme";
+
+    /// <inheritdoc/>
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        var user = Request.Headers[SecurityHarness.AuthenticatedUserHeader].ToString();
+
+        if (string.IsNullOrEmpty(user))
+        {
+            return Task.FromResult(AuthenticateResult.NoResult());
+        }
+
+        var identity = new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, user),
+                new Claim("oid", user),
+                new Claim(ClaimTypes.Name, user),
+            ],
+            Scheme);
+
+        return Task.FromResult(AuthenticateResult.Success(
+            new AuthenticationTicket(new ClaimsPrincipal(identity), Scheme)));
+    }
+}

--- a/Source/AuthProxy.Security.Specs/given/RecordingBackend.cs
+++ b/Source/AuthProxy.Security.Specs/given/RecordingBackend.cs
@@ -1,0 +1,148 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.AuthProxy.Security.given;
+
+/// <summary>
+/// A real HTTP origin on loopback that records every request AuthProxy forwards to it.
+/// </summary>
+/// <remarks>
+/// The security question that matters most for a reverse proxy is not what it answers the client, but what
+/// it hands the origin — a spoofed <c>x-ms-client-principal</c> that reaches a backend is a full identity
+/// forgery, and no amount of inspecting the client-facing response would reveal it. Asserting on that
+/// requires an origin that actually exists, so this listens on a real socket: YARP forwards over the
+/// network stack rather than through the in-memory test server, and what arrives here is exactly what a
+/// deployed backend would see.
+/// <para>
+/// It also answers <c>/.cratis/me</c>, because AuthProxy calls it on every authenticated request to
+/// resolve identity details, and a backend that refused would make every authenticated spec a 403 about
+/// something else.
+/// </para>
+/// </remarks>
+public sealed class RecordingBackend : IAsyncDisposable
+{
+    readonly WebApplication _app;
+
+    RecordingBackend(WebApplication app, string baseUrl)
+    {
+        _app = app;
+        BaseUrl = baseUrl;
+    }
+
+    /// <summary>
+    /// Gets the origin's base URL, on an ephemeral loopback port.
+    /// </summary>
+    public string BaseUrl { get; }
+
+    /// <summary>
+    /// Gets every request the proxy has forwarded, most recent last.
+    /// </summary>
+    public ConcurrentQueue<ForwardedRequest> Received { get; } = new();
+
+    /// <summary>
+    /// Starts a new recording origin.
+    /// </summary>
+    /// <returns>The started origin.</returns>
+    public static async Task<RecordingBackend> Start()
+    {
+        var builder = WebApplication.CreateSlimBuilder();
+        builder.Logging.ClearProviders();
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+        builder.Services.AddSingleton<RecordingState>();
+
+        var app = builder.Build();
+        var state = app.Services.GetRequiredService<RecordingState>();
+
+        app.Use(async (context, next) =>
+        {
+            state.Record(context);
+            await next();
+        });
+
+        // AuthProxy calls this on every authenticated request to resolve identity details. Answering an
+        // empty object means "authorized, nothing to add", which keeps a spec's 403 attributable to the
+        // behavior under test rather than to the origin refusing.
+        app.MapGet(WellKnownPaths.IdentityDetails, () => Results.Json(new { }));
+
+        app.MapFallback(() => Results.Text("origin", "text/plain"));
+
+        await app.StartAsync();
+
+        var address = app.Services.GetRequiredService<IServer>().Features
+            .Get<IServerAddressesFeature>()!
+            .Addresses
+            .First();
+
+        var backend = new RecordingBackend(app, address);
+        state.Attach(backend.Received);
+
+        return backend;
+    }
+
+    /// <summary>
+    /// Gets the most recently forwarded request, or <see langword="null"/> when nothing was forwarded.
+    /// </summary>
+    /// <returns>The last forwarded request.</returns>
+    public ForwardedRequest? LastRequest() => Received.LastOrDefault();
+
+    /// <summary>
+    /// Gets the most recent request forwarded to a specific path.
+    /// </summary>
+    /// <param name="path">The path to look for.</param>
+    /// <returns>The last request to that path, or <see langword="null"/> when there was none.</returns>
+    /// <remarks>
+    /// An authenticated request produces two calls here — the proxy's own <c>/.cratis/me</c> identity
+    /// resolution and then the forwarded request itself — so a spec that means "the request I sent" has to
+    /// say which one, rather than trusting the order they happen to arrive in.
+    /// </remarks>
+    public ForwardedRequest? LastRequestTo(string path) =>
+        Received.LastOrDefault(request => string.Equals(request.Path, path, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// Gets whether anything at all was forwarded to a path.
+    /// </summary>
+    /// <param name="path">The path to look for.</param>
+    /// <returns><see langword="true"/> when the origin saw that path; otherwise <see langword="false"/>.</returns>
+    public bool ReceivedAnythingFor(string path) => LastRequestTo(path) is not null;
+
+    /// <summary>
+    /// Forgets every recorded request, so one spec's traffic cannot be read as another's.
+    /// </summary>
+    public void Clear() => Received.Clear();
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        await _app.StopAsync();
+        await _app.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Records requests into whichever queue the owning origin exposes.
+    /// </summary>
+    sealed class RecordingState
+    {
+        ConcurrentQueue<ForwardedRequest>? _target;
+
+        public void Attach(ConcurrentQueue<ForwardedRequest> target) => _target = target;
+
+        public void Record(HttpContext context) =>
+            _target?.Enqueue(new ForwardedRequest(
+                context.Request.Method,
+                context.Request.Path.Value ?? string.Empty,
+                context.Request.QueryString.Value ?? string.Empty,
+                context.Request.Headers.ToDictionary(
+                    header => header.Key,
+                    header => header.Value.ToString(),
+                    StringComparer.OrdinalIgnoreCase)));
+    }
+}

--- a/Source/AuthProxy.Security.Specs/given/SecurityHarness.cs
+++ b/Source/AuthProxy.Security.Specs/given/SecurityHarness.cs
@@ -1,0 +1,160 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.AuthProxy.Security.given;
+
+/// <summary>
+/// A running AuthProxy in front of a real recording origin, shared by every security spec.
+/// </summary>
+/// <remarks>
+/// Deliberately configured the way a real deployment is rather than the way that makes assertions easy: a
+/// single service so the catch-all route exists and carries the authenticated-user policy, providers
+/// configured so an unauthenticated caller is genuinely refused, a tenant that always resolves so a
+/// refusal is attributable to the check under test, and one declared anonymous path so the one route that
+/// legitimately skips authorization is present and can be probed for over-reach.
+/// <para>
+/// A caller becomes authenticated by sending <see cref="AuthenticatedUserHeader"/>, which stands in for
+/// presenting a valid session cookie. Everything else about a request is left to the spec, because the
+/// point of these specs is what an attacker can put on the wire.
+/// </para>
+/// </remarks>
+public class SecurityHarness : WebApplicationFactory<Program>
+{
+    /// <summary>The header a spec sends to act as an authenticated user.</summary>
+    public const string AuthenticatedUserHeader = "X-Security-Spec-User";
+
+    /// <summary>The tenant every request resolves to.</summary>
+    public const string TenantId = "11111111-1111-1111-1111-111111111111";
+
+    /// <summary>The one path this deployment declares anonymous.</summary>
+    public const string AnonymousPath = "/public";
+
+    /// <summary>A path that is not anonymous and therefore requires a session.</summary>
+    public const string ProtectedPath = "/private";
+
+    readonly string _pagesPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SecurityHarness"/> class.
+    /// </summary>
+    /// <remarks>
+    /// The origin has to exist before the proxy is configured, because its address is what the proxy is
+    /// configured to forward to. A fixture constructor cannot be async, so the start is awaited here.
+    /// </remarks>
+    public SecurityHarness()
+    {
+        Directory.CreateDirectory(_pagesPath);
+        File.WriteAllText(Path.Combine(_pagesPath, "select-provider.html"), "<html><body>Select Provider</body></html>");
+        File.WriteAllText(Path.Combine(_pagesPath, "forbidden.html"), "<html><body>Forbidden</body></html>");
+
+        Origin = RecordingBackend.Start().GetAwaiter().GetResult();
+    }
+
+    /// <summary>
+    /// Gets the origin AuthProxy forwards to, and the record of what reached it.
+    /// </summary>
+    public RecordingBackend Origin { get; }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+
+        if (!disposing)
+        {
+            return;
+        }
+
+        Origin.DisposeAsync().AsTask().GetAwaiter().GetResult();
+
+        if (Directory.Exists(_pagesPath))
+        {
+            Directory.Delete(_pagesPath, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Creates a client that surfaces redirects as responses rather than following them, and that sends
+    /// only the cookies a spec puts on a request.
+    /// </summary>
+    /// <returns>A configured <see cref="HttpClient"/>.</returns>
+    /// <remarks>
+    /// Redirects are not followed because the redirect itself is what the open-redirect specs are about.
+    /// Cookies are not carried between requests because these specs are about what an attacker can present:
+    /// a client that helpfully replayed a cookie AuthProxy had just issued would answer a different
+    /// question — whether the legitimate flow works — and would quietly hand a spec the very sealed record
+    /// it is trying to prove cannot be forged.
+    /// </remarks>
+    public HttpClient CreateSecurityClient() =>
+        CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false, HandleCookies = false });
+
+    /// <summary>
+    /// Builds a request from an authenticated caller.
+    /// </summary>
+    /// <param name="method">The HTTP method.</param>
+    /// <param name="pathAndQuery">The path and query to request.</param>
+    /// <param name="user">The user to act as. Defaults to a shared one.</param>
+    /// <returns>A request carrying the harness's stand-in for a valid session.</returns>
+    /// <remarks>
+    /// A spec that needs to observe the identity resolution actually happening must pass a
+    /// <paramref name="user"/> nobody else has used: the resolver holds a short-lived in-memory cache per
+    /// user and tenant, so a shared identity would let an earlier spec's answer satisfy a later spec's
+    /// request and the backend call being asserted on would never be made.
+    /// </remarks>
+    public static HttpRequestMessage Authenticated(HttpMethod method, string pathAndQuery, string? user = null)
+    {
+        var request = new HttpRequestMessage(method, pathAndQuery);
+        request.Headers.TryAddWithoutValidation(AuthenticatedUserHeader, user ?? "security-spec-user");
+
+        return request;
+    }
+
+    /// <summary>
+    /// Creates a user identity no other spec shares.
+    /// </summary>
+    /// <param name="hint">A short label making the identity recognizable in a failure.</param>
+    /// <returns>A unique user identity.</returns>
+    public static string UniqueUser(string hint) => $"{hint}-{Guid.NewGuid():N}";
+
+    /// <summary>
+    /// Builds a request from an anonymous caller.
+    /// </summary>
+    /// <param name="method">The HTTP method.</param>
+    /// <param name="pathAndQuery">The path and query to request.</param>
+    /// <returns>A request carrying no session.</returns>
+    public static HttpRequestMessage Anonymous(HttpMethod method, string pathAndQuery) => new(method, pathAndQuery);
+
+    /// <inheritdoc/>
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder
+            .UseEnvironment("Production")
+            .ConfigureAppConfiguration((_, config) => config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"{C.AuthProxy.SectionKey}:Services:app:Backend:BaseUrl"] = Origin.BaseUrl,
+                [$"{C.AuthProxy.SectionKey}:Services:app:Frontend:BaseUrl"] = Origin.BaseUrl,
+                [$"{C.AuthProxy.SectionKey}:Services:app:AnonymousPaths:0"] = AnonymousPath,
+
+                [$"{C.AuthProxy.SectionKey}:PagesPath"] = _pagesPath,
+
+                [$"{C.AuthProxy.SectionKey}:TenantResolutions:0:Strategy"] = nameof(C.TenantSourceIdentifierResolverType.Specified),
+                [$"{C.AuthProxy.SectionKey}:TenantResolutions:0:Options:TenantId"] = TenantId,
+
+                [$"{C.Authentication.SectionKey}:OidcProviders:0:Name"] = "Provider One",
+                [$"{C.Authentication.SectionKey}:OidcProviders:0:Authority"] = "https://login.example.test/one",
+                [$"{C.Authentication.SectionKey}:OidcProviders:0:ClientId"] = "client-one",
+            }))
+            .ConfigureTestServices(services => services
+                .AddAuthentication(HeaderAuthenticationHandler.Scheme)
+                .AddScheme<AuthenticationSchemeOptions, HeaderAuthenticationHandler>(
+                    HeaderAuthenticationHandler.Scheme,
+                    _ => { }));
+    }
+}

--- a/Source/AuthProxy.Security.Specs/given/SecuritySpecCollection.cs
+++ b/Source/AuthProxy.Security.Specs/given/SecuritySpecCollection.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Security.given;
+
+/// <summary>
+/// Runs every security spec against one shared proxy and origin, in sequence.
+/// </summary>
+/// <remarks>
+/// The origin records what it received, and a spec reads that record to decide whether an attack got
+/// through. Two specs running concurrently against one recorder would read each other's traffic, so the
+/// collection serializes them. It also means the proxy host and the origin are started once rather than
+/// per spec class, which is what keeps a suite this size fast enough to sit on every pull request.
+/// </remarks>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public class SecuritySpecCollection : ICollectionFixture<SecurityHarness>
+{
+    /// <summary>The collection name every security spec joins.</summary>
+    public const string Name = "Security";
+}

--- a/Source/AuthProxy.Specs/Authentication/for_TenantAuthenticationState/when_the_return_url_is_hostile.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_TenantAuthenticationState/when_the_return_url_is_hostile.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authentication.for_TenantAuthenticationState;
+
+/// <summary>
+/// The <c>returnUrl</c> the login endpoint accepts must never survive as an off-site redirect.
+/// <para>
+/// This is the most exposed redirect sink in AuthProxy and the most valuable one to an attacker. The
+/// endpoint that feeds it — <c>/.cratis/login/{scheme}</c> — is <c>AllowAnonymous</c>, so the value is
+/// attacker-supplied by default. What it becomes is the challenge's <c>RedirectUri</c>,
+/// which ASP.NET's remote authentication handler hands straight to <c>Response.Redirect</c> once the
+/// identity provider returns, without validating it. The victim therefore sees a link on the real domain,
+/// completes a genuine sign-in at the genuine provider, and only then lands wherever the link said —
+/// every signal a careful person is taught to check having already passed.
+/// </para>
+/// <para>
+/// The check that used to guard it was <c>returnUrl.StartsWith('/')</c>, which <c>//evil.test</c> and
+/// <c>/\evil.test</c> both satisfy while navigating off-site. An absolute URL is reduced to its path and
+/// query rather than refused, so a caller that sends its own origin keeps working — the host is dropped,
+/// never honored.
+/// </para>
+/// </summary>
+public class when_the_return_url_is_hostile : Specification
+{
+    ITenantResolver _tenantResolver;
+    DefaultHttpContext _context;
+
+    void Establish()
+    {
+        _tenantResolver = Substitute.For<ITenantResolver>();
+        _tenantResolver
+            .TryResolve(Arg.Any<HttpContext>(), out Arg.Any<TenantResolutionResult>())
+            .Returns(false);
+
+        _context = new DefaultHttpContext();
+    }
+
+    string RedirectFor(string? returnUrl) =>
+        TenantAuthenticationState.CreateChallengeProperties(_context, _tenantResolver, returnUrl!).RedirectUri!;
+
+    [Fact] void should_refuse_a_protocol_relative_target() => RedirectFor("//evil.test").ShouldEqual("/");
+    [Fact] void should_refuse_a_protocol_relative_target_with_a_path() => RedirectFor("//evil.test/phish").ShouldEqual("/");
+    [Fact] void should_refuse_three_leading_slashes() => RedirectFor("///evil.test").ShouldEqual("/");
+    [Fact] void should_refuse_a_backslash_authority() => RedirectFor("/\\evil.test").ShouldEqual("/");
+    [Fact] void should_refuse_a_mixed_slash_authority() => RedirectFor("/\\/evil.test").ShouldEqual("/");
+    [Fact] void should_refuse_a_stripped_tab() => RedirectFor("/\t/evil.test").ShouldEqual("/");
+    [Fact] void should_refuse_a_header_injection_payload() => RedirectFor("/a\r\nSet-Cookie: x=y").ShouldEqual("/");
+    [Fact] void should_refuse_a_javascript_target() => RedirectFor("javascript:alert(1)").ShouldEqual("/");
+    [Fact] void should_refuse_an_empty_target() => RedirectFor(string.Empty).ShouldEqual("/");
+
+    [Fact] void should_reduce_an_absolute_foreign_url_to_its_path() => RedirectFor("https://evil.test/phish").ShouldEqual("/phish");
+    [Fact] void should_reduce_an_absolute_foreign_url_keeping_its_query() => RedirectFor("https://evil.test/phish?a=b").ShouldEqual("/phish?a=b");
+    [Fact] void should_root_a_bare_relative_target() => RedirectFor("dashboard").ShouldEqual("/dashboard");
+
+    [Fact] void should_keep_a_same_site_target() => RedirectFor("/dashboard").ShouldEqual("/dashboard");
+    [Fact] void should_keep_a_same_site_target_with_a_query() => RedirectFor("/dashboard?tab=overview").ShouldEqual("/dashboard?tab=overview");
+    [Fact] void should_keep_a_nested_same_site_target() => RedirectFor("/a/b/c").ShouldEqual("/a/b/c");
+}

--- a/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_identity_cookie_is_already_present.cs
+++ b/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_identity_cookie_is_already_present.cs
@@ -1,15 +1,32 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Net;
 using Cratis.Arc.Identity;
 
 namespace Cratis.AuthProxy.Identity.for_IdentityDetailsResolver;
 
+/// <summary>
+/// The readable <c>.cratis-identity</c> cookie must not, on its own, decide that a caller is authorized.
+/// <para>
+/// It is written non-HTTP-only so a frontend can render the signed-in user from it, which means script on
+/// any proxied origin can write it — and a non-browser caller can simply send it. This resolver used to
+/// short-circuit on its mere presence, without ever reading its value, so
+/// <c>Cookie: .cratis-identity=x</c> alongside a valid session was enough to skip every configured
+/// service's <c>/.cratis/me</c> authorization call, for as long as the caller kept sending it. A user
+/// whose backend authorization had been revoked stayed authorized at the proxy by choice.
+/// </para>
+/// <para>
+/// The services are called instead. What is allowed to skip them is the sealed record checked through
+/// <see cref="IIdentityAuthorizationCache"/>, which is covered by its own specs.
+/// </para>
+/// </summary>
 public class when_identity_cookie_is_already_present : Specification
 {
     IdentityDetailsResolver _resolver;
     DefaultHttpContext _context;
     IHttpClientFactory _httpClientFactory;
+    IIdentityAuthorizationCache _authorizationCache;
     IdentityProviderResult _result;
 
     void Establish()
@@ -25,15 +42,24 @@ public class when_identity_cookie_is_already_present : Specification
         optionsMonitor.CurrentValue.Returns(config);
 
         _httpClientFactory = Substitute.For<IHttpClientFactory>();
+        _httpClientFactory.CreateClient(Arg.Any<string>()).Returns(
+            new HttpClient(new FakeHttpMessageHandler(HttpStatusCode.OK, /*lang=json,strict*/ "{\"displayName\":\"John Doe\"}")));
 
-        _resolver = new IdentityDetailsResolver(optionsMonitor, _httpClientFactory, [], Substitute.For<IMemoryCache>(), Substitute.For<ILogger<IdentityDetailsResolver>>());
+        // No sealed record — which is exactly the position an attacker sending only the readable cookie
+        // is in, because they cannot produce one.
+        _authorizationCache = Substitute.For<IIdentityAuthorizationCache>();
+        _authorizationCache.IsAuthorized(Arg.Any<HttpContext>(), Arg.Any<ClientPrincipal>(), Arg.Any<string>()).Returns(false);
+
+        _resolver = new IdentityDetailsResolver(optionsMonitor, _httpClientFactory, [], Substitute.For<IMemoryCache>(), _authorizationCache, Substitute.For<ILogger<IdentityDetailsResolver>>());
 
         _context = new DefaultHttpContext();
-        _context.Request.Headers.Cookie = $"{Cookies.Identity}=existing-value";
+        _context.Request.Headers.Cookie = $"{Cookies.Identity}=forged-value";
     }
 
     async Task Because() => _result = await _resolver.Resolve(_context, new ClientPrincipal { UserId = "user-1" }, Guid.NewGuid().ToString());
 
-    [Fact] void should_be_authorized() => Assert.True(_result.IsAuthorized);
-    [Fact] void should_not_call_the_http_client() => _httpClientFactory.DidNotReceive().CreateClient(Arg.Any<string>());
+    [Fact] void should_still_call_the_identity_endpoint() => _httpClientFactory.Received().CreateClient(Arg.Any<string>());
+    [Fact] void should_authorize_on_what_the_service_answered() => Assert.True(_result.IsAuthorized);
+    [Fact] void should_record_the_authorization_it_resolved() =>
+        _authorizationCache.Received(1).Record(_context, Arg.Any<ClientPrincipal>(), Arg.Any<string>());
 }

--- a/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_identity_revalidation_is_disabled.cs
+++ b/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_identity_revalidation_is_disabled.cs
@@ -29,7 +29,7 @@ public class when_identity_revalidation_is_disabled : Specification
         httpClientFactory.CreateClient(Arg.Any<string>()).Returns(
             new HttpClient(new FakeHttpMessageHandler(HttpStatusCode.OK, /*lang=json,strict*/ "{\"displayName\":\"John Doe\"}")));
 
-        _resolver = new IdentityDetailsResolver(optionsMonitor, httpClientFactory, [], Substitute.For<IMemoryCache>(), Substitute.For<ILogger<IdentityDetailsResolver>>());
+        _resolver = new IdentityDetailsResolver(optionsMonitor, httpClientFactory, [], Substitute.For<IMemoryCache>(), Substitute.For<IIdentityAuthorizationCache>(), Substitute.For<ILogger<IdentityDetailsResolver>>());
         _context = new DefaultHttpContext();
     }
 

--- a/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_invite_claim_forwarding_is_configured.cs
+++ b/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_invite_claim_forwarding_is_configured.cs
@@ -65,6 +65,7 @@ public class when_invite_claim_forwarding_is_configured : Specification
             httpClientFactory,
             enrichers,
             Substitute.For<IMemoryCache>(),
+            Substitute.For<IIdentityAuthorizationCache>(),
             Substitute.For<ILogger<IdentityDetailsResolver>>());
 
         _context = new DefaultHttpContext();

--- a/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_microservice_returns_forbidden.cs
+++ b/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_microservice_returns_forbidden.cs
@@ -28,7 +28,7 @@ public class when_microservice_returns_forbidden : Specification
         httpClientFactory.CreateClient(Arg.Any<string>()).Returns(
             new HttpClient(new FakeHttpMessageHandler(HttpStatusCode.Forbidden)));
 
-        _resolver = new IdentityDetailsResolver(optionsMonitor, httpClientFactory, [], Substitute.For<IMemoryCache>(), Substitute.For<ILogger<IdentityDetailsResolver>>());
+        _resolver = new IdentityDetailsResolver(optionsMonitor, httpClientFactory, [], Substitute.For<IMemoryCache>(), Substitute.For<IIdentityAuthorizationCache>(), Substitute.For<ILogger<IdentityDetailsResolver>>());
         _context = new DefaultHttpContext();
     }
 

--- a/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_microservice_returns_identity_details.cs
+++ b/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_microservice_returns_identity_details.cs
@@ -28,7 +28,7 @@ public class when_microservice_returns_identity_details : Specification
         httpClientFactory.CreateClient(Arg.Any<string>()).Returns(
             new HttpClient(new FakeHttpMessageHandler(HttpStatusCode.OK, /*lang=json,strict*/ "{\"displayName\":\"John Doe\"}")));
 
-        _resolver = new IdentityDetailsResolver(optionsMonitor, httpClientFactory, [], Substitute.For<IMemoryCache>(), Substitute.For<ILogger<IdentityDetailsResolver>>());
+        _resolver = new IdentityDetailsResolver(optionsMonitor, httpClientFactory, [], Substitute.For<IMemoryCache>(), Substitute.For<IIdentityAuthorizationCache>(), Substitute.For<ILogger<IdentityDetailsResolver>>());
         _context = new DefaultHttpContext();
     }
 

--- a/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_microservice_returns_invalid_json.cs
+++ b/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_microservice_returns_invalid_json.cs
@@ -28,7 +28,7 @@ public class when_microservice_returns_invalid_json : Specification
         httpClientFactory.CreateClient(Arg.Any<string>()).Returns(
             new HttpClient(new FakeHttpMessageHandler(HttpStatusCode.OK, "{not-json")));
 
-        _resolver = new IdentityDetailsResolver(optionsMonitor, httpClientFactory, [], Substitute.For<IMemoryCache>(), Substitute.For<ILogger<IdentityDetailsResolver>>());
+        _resolver = new IdentityDetailsResolver(optionsMonitor, httpClientFactory, [], Substitute.For<IMemoryCache>(), Substitute.For<IIdentityAuthorizationCache>(), Substitute.For<ILogger<IdentityDetailsResolver>>());
         _context = new DefaultHttpContext();
     }
 

--- a/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_microservice_returns_non_success_status_code.cs
+++ b/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_microservice_returns_non_success_status_code.cs
@@ -28,7 +28,7 @@ public class when_microservice_returns_non_success_status_code : Specification
         httpClientFactory.CreateClient(Arg.Any<string>()).Returns(
             new HttpClient(new FakeHttpMessageHandler(HttpStatusCode.BadRequest, "bad request")));
 
-        _resolver = new IdentityDetailsResolver(optionsMonitor, httpClientFactory, [], Substitute.For<IMemoryCache>(), Substitute.For<ILogger<IdentityDetailsResolver>>());
+        _resolver = new IdentityDetailsResolver(optionsMonitor, httpClientFactory, [], Substitute.For<IMemoryCache>(), Substitute.For<IIdentityAuthorizationCache>(), Substitute.For<ILogger<IdentityDetailsResolver>>());
         _context = new DefaultHttpContext();
     }
 

--- a/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_multiple_microservices_return_details.cs
+++ b/Source/AuthProxy.Specs/Identity/for_IdentityDetailsResolver/when_multiple_microservices_return_details.cs
@@ -29,7 +29,7 @@ public class when_multiple_microservices_return_details : Specification
         httpClientFactory.CreateClient(Arg.Any<string>()).Returns(
             new HttpClient(new FakeHttpMessageHandler(HttpStatusCode.OK, /*lang=json,strict*/ "{\"propA\":\"valueA\",\"propB\":\"valueB\"}")));
 
-        _resolver = new IdentityDetailsResolver(optionsMonitor, httpClientFactory, [], Substitute.For<IMemoryCache>(), Substitute.For<ILogger<IdentityDetailsResolver>>());
+        _resolver = new IdentityDetailsResolver(optionsMonitor, httpClientFactory, [], Substitute.For<IMemoryCache>(), Substitute.For<IIdentityAuthorizationCache>(), Substitute.For<ILogger<IdentityDetailsResolver>>());
         _context = new DefaultHttpContext();
     }
 

--- a/Source/AuthProxy.Specs/for_AnonymousPathPolicy/when_an_entry_attempts_traversal.cs
+++ b/Source/AuthProxy.Specs/for_AnonymousPathPolicy/when_an_entry_attempts_traversal.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.for_AnonymousPathPolicy;
+
+/// <summary>
+/// A declared prefix must mean exactly what it spells. Every traversal form is refused rather than
+/// resolved, so a prefix can never open a path the operator did not name.
+/// <para>
+/// Resolving would be the more forgiving choice and the wrong one: <c>/public/../admin</c> reads as scoped
+/// to <c>/public</c> while meaning <c>/admin</c>, so accepting it as <c>/admin</c> would hand an
+/// unauthenticated caller a surface nobody typed. The encoded spellings — <c>%2e%2e%2f</c>, <c>%2f</c>,
+/// <c>%00</c> — are refused one step earlier, by the character allow-list, which is why they are pinned
+/// here alongside the literal form: they are the same attack and must not survive by taking a different
+/// route through the check.
+/// </para>
+/// </summary>
+public class when_an_entry_attempts_traversal : Specification
+{
+    static AnonymousPathRejection Evaluate(string candidate) => AnonymousPathPolicy.Evaluate(candidate, out _);
+
+    [Fact] void should_refuse_a_parent_segment() => Evaluate("/public/../admin").ShouldEqual(AnonymousPathRejection.DotSegment);
+    [Fact] void should_refuse_a_trailing_parent_segment() => Evaluate("/public/..").ShouldEqual(AnonymousPathRejection.DotSegment);
+    [Fact] void should_refuse_a_leading_parent_segment() => Evaluate("/../admin").ShouldEqual(AnonymousPathRejection.DotSegment);
+    [Fact] void should_refuse_a_current_segment() => Evaluate("/public/./admin").ShouldEqual(AnonymousPathRejection.DotSegment);
+    [Fact] void should_refuse_a_bare_current_segment() => Evaluate("/.").ShouldEqual(AnonymousPathRejection.DotSegment);
+    [Fact] void should_refuse_stacked_parent_segments() => Evaluate("/a/../../..").ShouldEqual(AnonymousPathRejection.DotSegment);
+
+    [Fact] void should_refuse_an_encoded_parent_segment() => Evaluate("/public/%2e%2e/admin").ShouldEqual(AnonymousPathRejection.DisallowedCharacter);
+    [Fact] void should_refuse_an_encoded_separator() => Evaluate("/public%2fadmin").ShouldEqual(AnonymousPathRejection.DisallowedCharacter);
+    [Fact] void should_refuse_a_double_encoded_parent_segment() => Evaluate("/public/%252e%252e/admin").ShouldEqual(AnonymousPathRejection.DisallowedCharacter);
+    [Fact] void should_refuse_an_encoded_null_byte() => Evaluate("/public%00.png").ShouldEqual(AnonymousPathRejection.DisallowedCharacter);
+    [Fact] void should_refuse_a_backslash_separator() => Evaluate("/public\\..\\admin").ShouldEqual(AnonymousPathRejection.DisallowedCharacter);
+    [Fact] void should_refuse_an_overlong_encoded_separator() => Evaluate("/public%c0%afadmin").ShouldEqual(AnonymousPathRejection.DisallowedCharacter);
+
+    [Fact] void should_keep_a_dot_inside_a_segment() => Evaluate("/.well-known/acme-challenge").ShouldEqual(AnonymousPathRejection.None);
+    [Fact] void should_keep_a_file_extension() => Evaluate("/public/health.json").ShouldEqual(AnonymousPathRejection.None);
+}

--- a/Source/AuthProxy.Specs/for_AnonymousPathPolicy/when_an_entry_cannot_name_a_prefix.cs
+++ b/Source/AuthProxy.Specs/for_AnonymousPathPolicy/when_an_entry_cannot_name_a_prefix.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.for_AnonymousPathPolicy;
+
+/// <summary>
+/// An entry that does not name a path prefix at all is refused, and refused with the reason that says
+/// which failure it was.
+/// <para>
+/// The entries that resolve to the application root are the ones that matter most:
+/// <c>PathString.StartsWithSegments(string.Empty)</c> is true for every request, so a blank value — an
+/// environment variable set but never given one, a trailing index in a configuration array — would turn an
+/// entire service anonymous, silently and globally. That is the worst outcome this feature can produce, so
+/// every spelling of it is pinned here rather than left to review.
+/// </para>
+/// </summary>
+public class when_an_entry_cannot_name_a_prefix : Specification
+{
+    static AnonymousPathRejection Evaluate(string? candidate) => AnonymousPathPolicy.Evaluate(candidate, out _);
+
+    [Fact] void should_refuse_a_null_entry() => Evaluate(null).ShouldEqual(AnonymousPathRejection.Empty);
+    [Fact] void should_refuse_an_empty_entry() => Evaluate(string.Empty).ShouldEqual(AnonymousPathRejection.Empty);
+    [Fact] void should_refuse_a_whitespace_entry() => Evaluate("   ").ShouldEqual(AnonymousPathRejection.Empty);
+    [Fact] void should_refuse_the_root() => Evaluate("/").ShouldEqual(AnonymousPathRejection.Root);
+    [Fact] void should_refuse_repeated_separators_that_trim_to_the_root() => Evaluate("///").ShouldEqual(AnonymousPathRejection.Root);
+    [Fact] void should_refuse_a_root_with_surrounding_whitespace() => Evaluate("  /  ").ShouldEqual(AnonymousPathRejection.Root);
+    [Fact] void should_refuse_an_unrooted_entry() => Evaluate("portal").ShouldEqual(AnonymousPathRejection.NotRooted);
+    [Fact] void should_refuse_a_protocol_relative_entry() => Evaluate("//evil.test/portal").ShouldEqual(AnonymousPathRejection.EmptySegment);
+    [Fact] void should_refuse_a_repeated_inner_separator() => Evaluate("/double//segment").ShouldEqual(AnonymousPathRejection.EmptySegment);
+
+    [Fact] void should_accept_a_trimmed_entry() => Evaluate("  /portal/  ").ShouldEqual(AnonymousPathRejection.None);
+
+    [Fact] void should_normalize_a_trimmed_entry_to_its_prefix()
+    {
+        AnonymousPathPolicy.Evaluate("  /portal/  ", out var prefix);
+        prefix.ShouldEqual("/portal");
+    }
+
+    [Fact] void should_yield_no_prefix_for_a_refused_entry()
+    {
+        AnonymousPathPolicy.Evaluate("/route{parameter}", out var prefix);
+        prefix.ShouldBeEmpty();
+    }
+}

--- a/Source/AuthProxy.Specs/for_AnonymousPathPolicy/when_an_entry_carries_a_disallowed_character.cs
+++ b/Source/AuthProxy.Specs/for_AnonymousPathPolicy/when_an_entry_carries_a_disallowed_character.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.for_AnonymousPathPolicy;
+
+/// <summary>
+/// The permitted characters are an allow-list — RFC 3986 unreserved plus the separator — so a character
+/// that carries meaning to either matcher is refused by construction rather than by having been
+/// anticipated.
+/// <para>
+/// The failure this prevents is a prefix that means one thing to the middlewares, which match a literal
+/// with <see cref="PathString.StartsWithSegments(PathString)"/>, and another to the router, which matches
+/// an ASP.NET route template built from the same string. <c>/a{x}</c> is the sharpest example: as a
+/// template it is a route <em>parameter</em>, so the router would serve <c>/aANYTHING/…</c> anonymously
+/// while the middlewares matched only <c>/a{x}</c> — an unauthenticated surface far wider than anything
+/// declared.
+/// </para>
+/// </summary>
+public class when_an_entry_carries_a_disallowed_character : Specification
+{
+    static AnonymousPathRejection Evaluate(string candidate) => AnonymousPathPolicy.Evaluate(candidate, out _);
+
+    [Fact] void should_refuse_a_route_parameter() => Evaluate("/route{parameter}").ShouldEqual(AnonymousPathRejection.DisallowedCharacter);
+    [Fact] void should_refuse_a_catch_all() => Evaluate("/catch/{**all}").ShouldEqual(AnonymousPathRejection.DisallowedCharacter);
+    [Fact] void should_refuse_a_wildcard() => Evaluate("/star*").ShouldEqual(AnonymousPathRejection.DisallowedCharacter);
+    [Fact] void should_refuse_a_query_string() => Evaluate("/query?token=1").ShouldEqual(AnonymousPathRejection.DisallowedCharacter);
+    [Fact] void should_refuse_a_fragment() => Evaluate("/page#section").ShouldEqual(AnonymousPathRejection.DisallowedCharacter);
+    [Fact] void should_refuse_a_path_parameter() => Evaluate("/public;/admin").ShouldEqual(AnonymousPathRejection.DisallowedCharacter);
+    [Fact] void should_refuse_an_authority_separator() => Evaluate("/public@evil.test").ShouldEqual(AnonymousPathRejection.DisallowedCharacter);
+    [Fact] void should_refuse_a_scheme_separator() => Evaluate("/http://evil.test").ShouldEqual(AnonymousPathRejection.DisallowedCharacter);
+    [Fact] void should_refuse_an_inner_space() => Evaluate("/with space").ShouldEqual(AnonymousPathRejection.DisallowedCharacter);
+    [Fact] void should_refuse_a_carriage_return() => Evaluate("/public\r\nSet-Cookie: a=b").ShouldEqual(AnonymousPathRejection.DisallowedCharacter);
+    [Fact] void should_refuse_a_tab() => Evaluate("/public\tadmin").ShouldEqual(AnonymousPathRejection.DisallowedCharacter);
+    [Fact] void should_refuse_a_raw_null_byte() => Evaluate("/public\0").ShouldEqual(AnonymousPathRejection.DisallowedCharacter);
+    [Fact] void should_refuse_a_non_ascii_character() => Evaluate("/públic").ShouldEqual(AnonymousPathRejection.DisallowedCharacter);
+    [Fact] void should_refuse_a_homoglyph() => Evaluate("/publiс").ShouldEqual(AnonymousPathRejection.DisallowedCharacter);
+    [Fact] void should_refuse_a_zero_width_joiner() => Evaluate("/pub‍lic").ShouldEqual(AnonymousPathRejection.DisallowedCharacter);
+
+    [Fact] void should_keep_letters_digits_and_unreserved_punctuation() =>
+        Evaluate("/api/reports-v2/public_data~1").ShouldEqual(AnonymousPathRejection.None);
+}

--- a/Source/AuthProxy.Specs/for_AnonymousPathPolicy/when_an_entry_targets_a_path_the_proxy_owns.cs
+++ b/Source/AuthProxy.Specs/for_AnonymousPathPolicy/when_an_entry_targets_a_path_the_proxy_owns.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.for_AnonymousPathPolicy;
+
+/// <summary>
+/// AuthProxy answers some paths itself, and a declared prefix cannot take them away from it.
+/// <para>
+/// An anonymous route is emitted at order 0, ahead of every service-selected route, and the three
+/// middlewares stop applying their checks below a declared prefix. So pointing one at AuthProxy's own
+/// namespace does not make an endpoint public — those endpoints already admit anonymous callers where they
+/// are meant to. It <em>removes</em> the endpoint from AuthProxy: a declared <c>/.cratis</c> hands the
+/// logout, token, tenant-selection and login endpoints to a backend, and a declared <c>/invite</c> or
+/// <c>/register</c> puts those flow middlewares behind a proxied route. Both are configuration mistakes
+/// with no legitimate spelling, so they are refused outright.
+/// </para>
+/// </summary>
+public class when_an_entry_targets_a_path_the_proxy_owns : Specification
+{
+    static AnonymousPathRejection Evaluate(string candidate) => AnonymousPathPolicy.Evaluate(candidate, out _);
+
+    [Fact] void should_refuse_the_proxy_namespace() => Evaluate("/.cratis").ShouldEqual(AnonymousPathRejection.ProxyOwnedPath);
+    [Fact] void should_refuse_the_token_endpoint() => Evaluate("/.cratis/token").ShouldEqual(AnonymousPathRejection.ProxyOwnedPath);
+    [Fact] void should_refuse_the_logout_endpoint() => Evaluate("/.cratis/logout").ShouldEqual(AnonymousPathRejection.ProxyOwnedPath);
+    [Fact] void should_refuse_the_tenant_selection_endpoint() => Evaluate("/.cratis/select-tenant").ShouldEqual(AnonymousPathRejection.ProxyOwnedPath);
+    [Fact] void should_refuse_an_unclaimed_path_in_the_proxy_namespace() => Evaluate("/.cratis/anything").ShouldEqual(AnonymousPathRejection.ProxyOwnedPath);
+    [Fact] void should_refuse_the_proxy_namespace_regardless_of_casing() => Evaluate("/.CRATIS/Token").ShouldEqual(AnonymousPathRejection.ProxyOwnedPath);
+    [Fact] void should_refuse_the_pages_prefix() => Evaluate("/_pages").ShouldEqual(AnonymousPathRejection.ProxyOwnedPath);
+    [Fact] void should_refuse_below_the_pages_prefix() => Evaluate("/_pages/error").ShouldEqual(AnonymousPathRejection.ProxyOwnedPath);
+    [Fact] void should_refuse_the_invite_prefix() => Evaluate("/invite").ShouldEqual(AnonymousPathRejection.ProxyOwnedPath);
+    [Fact] void should_refuse_below_the_invite_prefix() => Evaluate("/invite/token").ShouldEqual(AnonymousPathRejection.ProxyOwnedPath);
+    [Fact] void should_refuse_the_registration_path() => Evaluate("/register").ShouldEqual(AnonymousPathRejection.ProxyOwnedPath);
+    [Fact] void should_refuse_a_provider_callback() => Evaluate("/signin-microsoft").ShouldEqual(AnonymousPathRejection.ProxyOwnedPath);
+
+    [Fact] void should_keep_a_path_that_only_shares_a_string_prefix_with_the_proxy_namespace() =>
+        Evaluate("/.cratisfiles").ShouldEqual(AnonymousPathRejection.None);
+
+    [Fact] void should_keep_a_path_that_only_shares_a_string_prefix_with_the_invite_prefix() =>
+        Evaluate("/invites").ShouldEqual(AnonymousPathRejection.None);
+
+    [Fact] void should_keep_a_path_that_merely_contains_a_reserved_name_below_the_root() =>
+        Evaluate("/app/invite").ShouldEqual(AnonymousPathRejection.None);
+}

--- a/Source/AuthProxy.Specs/for_RelativeRedirect/when_deciding_whether_a_target_is_same_site.cs
+++ b/Source/AuthProxy.Specs/for_RelativeRedirect/when_deciding_whether_a_target_is_same_site.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.for_RelativeRedirect;
+
+/// <summary>
+/// The single check that decides whether a caller-supplied redirect target can navigate off-site.
+/// <para>
+/// Four endpoints hand the browser a target the caller chose — the login <c>returnUrl</c>, the link
+/// <c>returnUrl</c>, tenant selection's <c>returnUrl</c>, and logout's <c>redirect</c> — and each used to
+/// carry its own version of this check. They disagreed, which is the whole reason the check moved here: one
+/// accepted <c>//evil.test</c> outright, and the two that rejected it still accepted <c>/\evil.test</c>.
+/// </para>
+/// <para>
+/// What every disagreement had in common was treating a leading <c>/</c> as proof of same-site. It is not,
+/// because the browser decides what a <c>Location</c> means. <c>//host</c> is protocol-relative;
+/// <c>/\host</c> is the same URL to every major browser, which normalize a backslash to a slash in the
+/// authority position; and a slash followed by a tab, carriage return or newline is also the same URL,
+/// because browsers strip those characters before parsing — so the string checked here and the URL actually
+/// fetched would be different strings.
+/// </para>
+/// </summary>
+public class when_deciding_whether_a_target_is_same_site : Specification
+{
+    [Fact] void should_reject_nothing_at_all() => RelativeRedirect.IsSameSiteRelative(null).ShouldBeFalse();
+    [Fact] void should_reject_an_empty_target() => RelativeRedirect.IsSameSiteRelative(string.Empty).ShouldBeFalse();
+    [Fact] void should_reject_an_unrooted_target() => RelativeRedirect.IsSameSiteRelative("dashboard").ShouldBeFalse();
+
+    [Fact] void should_reject_a_protocol_relative_target() => RelativeRedirect.IsSameSiteRelative("//evil.test").ShouldBeFalse();
+    [Fact] void should_reject_a_protocol_relative_target_with_a_path() => RelativeRedirect.IsSameSiteRelative("//evil.test/phish").ShouldBeFalse();
+    [Fact] void should_reject_three_leading_slashes() => RelativeRedirect.IsSameSiteRelative("///evil.test").ShouldBeFalse();
+    [Fact] void should_reject_a_protocol_relative_target_carrying_userinfo() => RelativeRedirect.IsSameSiteRelative("//user:pass@evil.test").ShouldBeFalse();
+
+    [Fact] void should_reject_a_backslash_authority() => RelativeRedirect.IsSameSiteRelative("/\\evil.test").ShouldBeFalse();
+    [Fact] void should_reject_a_mixed_slash_authority() => RelativeRedirect.IsSameSiteRelative("/\\/evil.test").ShouldBeFalse();
+    [Fact] void should_reject_a_double_backslash_authority() => RelativeRedirect.IsSameSiteRelative("/\\\\evil.test").ShouldBeFalse();
+    [Fact] void should_reject_a_leading_double_backslash() => RelativeRedirect.IsSameSiteRelative("\\\\evil.test").ShouldBeFalse();
+    [Fact] void should_reject_a_backslash_anywhere() => RelativeRedirect.IsSameSiteRelative("/dashboard\\evil.test").ShouldBeFalse();
+
+    [Fact] void should_reject_a_stripped_tab() => RelativeRedirect.IsSameSiteRelative("/\t/evil.test").ShouldBeFalse();
+    [Fact] void should_reject_a_stripped_newline() => RelativeRedirect.IsSameSiteRelative("/\n/evil.test").ShouldBeFalse();
+    [Fact] void should_reject_a_stripped_carriage_return() => RelativeRedirect.IsSameSiteRelative("/\r/evil.test").ShouldBeFalse();
+    [Fact] void should_reject_a_header_injection_payload() => RelativeRedirect.IsSameSiteRelative("/a\r\nSet-Cookie: x=y").ShouldBeFalse();
+    [Fact] void should_reject_a_null_byte() => RelativeRedirect.IsSameSiteRelative("/dashboard\0").ShouldBeFalse();
+    [Fact] void should_reject_a_space() => RelativeRedirect.IsSameSiteRelative("/ /evil.test").ShouldBeFalse();
+    [Fact] void should_reject_a_delete_character() => RelativeRedirect.IsSameSiteRelative("/dashboard").ShouldBeFalse();
+
+    [Fact] void should_reject_an_absolute_https_target() => RelativeRedirect.IsSameSiteRelative("https://evil.test").ShouldBeFalse();
+    [Fact] void should_reject_an_absolute_http_target() => RelativeRedirect.IsSameSiteRelative("http://evil.test/phish").ShouldBeFalse();
+    [Fact] void should_reject_a_javascript_target() => RelativeRedirect.IsSameSiteRelative("javascript:alert(1)").ShouldBeFalse();
+    [Fact] void should_reject_a_data_target() => RelativeRedirect.IsSameSiteRelative("data:text/html,<script>alert(1)</script>").ShouldBeFalse();
+
+    [Fact] void should_accept_the_application_root() => RelativeRedirect.IsSameSiteRelative("/").ShouldBeTrue();
+    [Fact] void should_accept_a_simple_path() => RelativeRedirect.IsSameSiteRelative("/dashboard").ShouldBeTrue();
+    [Fact] void should_accept_a_nested_path() => RelativeRedirect.IsSameSiteRelative("/dashboard/reports/2026").ShouldBeTrue();
+    [Fact] void should_accept_a_path_with_a_query() => RelativeRedirect.IsSameSiteRelative("/dashboard?tab=overview&sort=asc").ShouldBeTrue();
+    [Fact] void should_accept_a_path_with_a_fragment() => RelativeRedirect.IsSameSiteRelative("/dashboard#section").ShouldBeTrue();
+    [Fact] void should_accept_a_path_with_percent_encoding() => RelativeRedirect.IsSameSiteRelative("/search?q=a%20b").ShouldBeTrue();
+    [Fact] void should_accept_a_path_with_unreserved_punctuation() => RelativeRedirect.IsSameSiteRelative("/a-b_c~d.e").ShouldBeTrue();
+
+    [Fact] void should_resolve_a_hostile_target_to_the_application_root() =>
+        RelativeRedirect.Resolve("//evil.test").ShouldEqual(RelativeRedirect.ApplicationRoot);
+
+    [Fact] void should_resolve_a_backslash_target_to_the_application_root() =>
+        RelativeRedirect.Resolve("/\\evil.test").ShouldEqual(RelativeRedirect.ApplicationRoot);
+
+    [Fact] void should_resolve_a_missing_target_to_the_application_root() =>
+        RelativeRedirect.Resolve(null).ShouldEqual(RelativeRedirect.ApplicationRoot);
+
+    [Fact] void should_resolve_a_same_site_target_to_itself() =>
+        RelativeRedirect.Resolve("/dashboard?tab=1").ShouldEqual("/dashboard?tab=1");
+}

--- a/Source/AuthProxy/AnonymousPathEvaluation.cs
+++ b/Source/AuthProxy/AnonymousPathEvaluation.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy;
+
+/// <summary>
+/// Represents the outcome of evaluating a single declared anonymous path entry.
+/// </summary>
+/// <param name="Declared">The entry exactly as it was declared in configuration.</param>
+/// <param name="Prefix">The normalized prefix when the entry is usable; otherwise empty.</param>
+/// <param name="Rejection">Why the entry was refused, or <see cref="AnonymousPathRejection.None"/>.</param>
+/// <remarks>
+/// <paramref name="Declared"/> is kept alongside the result so a refusal can be reported in the operator's
+/// own words — the string they put in configuration — rather than in whatever it normalized to before it
+/// was thrown away.
+/// </remarks>
+public sealed record AnonymousPathEvaluation(string Declared, string Prefix, AnonymousPathRejection Rejection)
+{
+    /// <summary>
+    /// Gets a value indicating whether the entry survived evaluation and can be served anonymously.
+    /// </summary>
+    public bool IsUsable => Rejection == AnonymousPathRejection.None;
+
+    /// <summary>
+    /// Gets the declared entry rendered safe to write to a log.
+    /// </summary>
+    /// <remarks>
+    /// The entry is reported precisely because it was refused, and a control character is one of the
+    /// reasons it can be refused — so the value most in need of reporting is the one carrying a newline
+    /// that would forge a second log line, or a terminal escape sequence. Control characters are replaced
+    /// and the value truncated, so a refusal can always be reported without the refused text deciding how
+    /// it is displayed.
+    /// </remarks>
+    public string DeclaredForDisplay => Sanitize(Declared);
+
+    static string Sanitize(string value)
+    {
+        const int maxLength = 120;
+
+        var truncated = value.Length > maxLength ? value[..maxLength] : value;
+
+        return string.Create(truncated.Length, truncated, static (span, source) =>
+        {
+            for (var i = 0; i < source.Length; i++)
+            {
+                span[i] = char.IsControl(source[i]) ? '_' : source[i];
+            }
+        });
+    }
+}

--- a/Source/AuthProxy/AnonymousPathPolicy.cs
+++ b/Source/AuthProxy/AnonymousPathPolicy.cs
@@ -1,0 +1,164 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Buffers;
+
+namespace Cratis.AuthProxy;
+
+/// <summary>
+/// Decides whether a declared anonymous path entry is safe to serve without authentication.
+/// </summary>
+/// <remarks>
+/// Declaring a path anonymous is the one setting in AuthProxy that removes authentication from a surface,
+/// so the entry itself is attacker-relevant input: whoever writes the configuration may be copying a path
+/// from a bug report, a URL, or a template. Every rule here is fail-closed — a refused entry leaves that
+/// path authenticated, never the reverse — and the refusal is reported by
+/// <c>MicroserviceReverseProxyConfigProvider</c> rather than swallowed.
+/// <para>
+/// The characters are an allow-list, not a deny-list, which is the whole point: a deny-list has to
+/// anticipate every character that means something to one of the two matchers, and the cost of missing one
+/// is a prefix that means different things to the middlewares and to the router. The permitted set is RFC
+/// 3986 <em>unreserved</em> (<c>A-Z a-z 0-9 - . _ ~</c>) plus the separator, which is every character a
+/// path prefix needs and nothing that carries meaning anywhere else. It excludes, by construction rather
+/// than by enumeration: <c>%</c> (a prefix whose meaning depends on encoding cannot be reasoned about, and
+/// <c>%2e%2e%2f</c> / <c>%2f</c> are the classic traversal and separator smuggling forms), <c>{}*</c> (a
+/// route <em>parameter</em> or catch-all, which would make the router match <c>/aANYTHING/…</c> where the
+/// middlewares match only the literal), <c>\</c> (a separator to some backends and not to others),
+/// <c>?#</c> (they end the path), <c>;</c> (path parameters, which some backends strip and others do not),
+/// <c>:</c> and <c>@</c> (authority syntax), control characters and whitespace (log and header injection,
+/// and invisible differences between two entries that read identically), and every non-ASCII character
+/// (<c>NFC</c> and <c>NFD</c> spellings of the same path compare unequal, so which one is anonymous would
+/// depend on how the configuration file was saved).
+/// </para>
+/// </remarks>
+public static class AnonymousPathPolicy
+{
+    /// <summary>
+    /// The characters a declared prefix may contain: RFC 3986 unreserved, plus the segment separator.
+    /// </summary>
+    static readonly SearchValues<char> _allowedCharacters = SearchValues.Create(
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~/");
+
+    /// <summary>
+    /// The path prefixes AuthProxy answers itself and therefore cannot hand to a service.
+    /// </summary>
+    static readonly string[] _reservedPrefixes =
+    [
+        WellKnownPaths.Cratis,
+        WellKnownPaths.Pages,
+        WellKnownPaths.InvitePathPrefix,
+        WellKnownPaths.Registration,
+    ];
+
+    /// <summary>
+    /// Evaluates a declared entry, producing the normalized prefix or the reason it was refused.
+    /// </summary>
+    /// <param name="candidate">The entry exactly as declared in configuration.</param>
+    /// <param name="prefix">The normalized prefix when the entry is usable; otherwise empty.</param>
+    /// <returns><see cref="AnonymousPathRejection.None"/> when the entry is usable; otherwise the reason.</returns>
+    public static AnonymousPathRejection Evaluate(string? candidate, out string prefix)
+    {
+        prefix = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(candidate))
+        {
+            return AnonymousPathRejection.Empty;
+        }
+
+        var normalized = candidate.Trim().TrimEnd('/');
+
+        // Everything that trims away to nothing or to the bare separator is the same failure:
+        // PathString.StartsWithSegments(string.Empty) is true for every request, so either would turn an
+        // entire service anonymous — the worst outcome this feature can produce.
+        if (normalized.Length < 2)
+        {
+            return AnonymousPathRejection.Root;
+        }
+
+        if (normalized[0] != '/')
+        {
+            return AnonymousPathRejection.NotRooted;
+        }
+
+        if (normalized.AsSpan().IndexOfAnyExcept(_allowedCharacters) >= 0)
+        {
+            return AnonymousPathRejection.DisallowedCharacter;
+        }
+
+        var segmentRejection = EvaluateSegments(normalized);
+        if (segmentRejection != AnonymousPathRejection.None)
+        {
+            return segmentRejection;
+        }
+
+        if (IsReserved(normalized))
+        {
+            return AnonymousPathRejection.ProxyOwnedPath;
+        }
+
+        prefix = normalized;
+
+        return AnonymousPathRejection.None;
+    }
+
+    /// <summary>
+    /// Checks the individual segments of an already character-validated prefix.
+    /// </summary>
+    /// <param name="normalized">The trimmed, rooted prefix.</param>
+    /// <returns><see cref="AnonymousPathRejection.None"/> when every segment is usable; otherwise the reason.</returns>
+    /// <remarks>
+    /// A <c>.</c> or <c>..</c> segment is refused rather than resolved. Resolving it would be the more
+    /// forgiving choice and the wrong one: <c>/public/../admin</c> reads as scoped to <c>/public</c> while
+    /// meaning <c>/admin</c>, so silently accepting it as <c>/admin</c> would open a path the operator did
+    /// not believe they were naming. Refusing keeps a declaration's meaning the same as its spelling.
+    /// </remarks>
+    static AnonymousPathRejection EvaluateSegments(string normalized)
+    {
+        foreach (var segment in normalized[1..].Split('/'))
+        {
+            if (segment.Length == 0)
+            {
+                return AnonymousPathRejection.EmptySegment;
+            }
+
+            if (string.Equals(segment, ".", StringComparison.Ordinal)
+                || string.Equals(segment, "..", StringComparison.Ordinal))
+            {
+                return AnonymousPathRejection.DotSegment;
+            }
+        }
+
+        return AnonymousPathRejection.None;
+    }
+
+    /// <summary>
+    /// Determines whether a prefix overlaps a path AuthProxy answers itself.
+    /// </summary>
+    /// <param name="normalized">The trimmed, rooted prefix.</param>
+    /// <returns><see langword="true"/> when the prefix is reserved; otherwise <see langword="false"/>.</returns>
+    /// <remarks>
+    /// An anonymous route is emitted at order 0, ahead of every service-selected route, and the three
+    /// middlewares stop applying their checks below a declared prefix. Pointing one at AuthProxy's own
+    /// namespace therefore does not make an endpoint public — those endpoints already allow anonymous
+    /// callers where they are meant to — it takes the endpoint <em>away</em> from AuthProxy: a declared
+    /// <c>/.cratis</c> claims the logout, token, tenant-selection and login endpoints for a backend, and a
+    /// declared <c>/invite</c> or <c>/register</c> puts the flow middlewares behind a proxied route. The
+    /// prefixes are reserved so that cannot be configured by accident.
+    /// </remarks>
+    static bool IsReserved(string normalized)
+    {
+        var path = new PathString(normalized);
+
+        foreach (var reserved in _reservedPrefixes)
+        {
+            if (path.StartsWithSegments(reserved))
+            {
+                return true;
+            }
+        }
+
+        // The provider callbacks are a string prefix rather than a segment prefix — the scheme is appended
+        // directly, as in /signin-microsoft — so they are matched the same way the pipeline matches them.
+        return normalized.StartsWith(WellKnownPaths.SignInPrefix, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/Source/AuthProxy/AnonymousPathRejection.cs
+++ b/Source/AuthProxy/AnonymousPathRejection.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy;
+
+/// <summary>
+/// Represents why a declared anonymous path was refused.
+/// </summary>
+/// <remarks>
+/// A refused entry leaves its path authenticated, which is the safe outcome but an invisible one — the
+/// operator declared a path public and it silently is not. Naming the reason is what makes the refusal
+/// reportable, so <c>MicroserviceReverseProxyConfigProvider</c> can say which entry was dropped and why
+/// rather than leaving it to be discovered from a login prompt on a path that was meant to be open.
+/// </remarks>
+public enum AnonymousPathRejection
+{
+    /// <summary>The entry is usable and was not refused.</summary>
+    None = 0,
+
+    /// <summary>The entry was blank, or whitespace only.</summary>
+    Empty = 1,
+
+    /// <summary>The entry does not start with <c>/</c>.</summary>
+    NotRooted = 2,
+
+    /// <summary>The entry resolves to the application root, which would make the whole service anonymous.</summary>
+    Root = 3,
+
+    /// <summary>The entry contains an empty segment, from a repeated <c>/</c>.</summary>
+    EmptySegment = 4,
+
+    /// <summary>The entry contains a <c>.</c> or <c>..</c> segment.</summary>
+    DotSegment = 5,
+
+    /// <summary>The entry contains a character outside the permitted set.</summary>
+    DisallowedCharacter = 6,
+
+    /// <summary>The entry overlaps a path prefix AuthProxy answers itself.</summary>
+    ProxyOwnedPath = 7,
+}

--- a/Source/AuthProxy/AnonymousPaths.cs
+++ b/Source/AuthProxy/AnonymousPaths.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Buffers;
 using System.Runtime.CompilerServices;
 using C = Cratis.AuthProxy.Configuration;
 
@@ -20,19 +19,13 @@ namespace Cratis.AuthProxy;
 /// <para>
 /// The middlewares match with <see cref="PathString.StartsWithSegments(PathString)"/> while the route
 /// table matches an ASP.NET route template built from the same prefix. Those two agree only for a prefix
-/// made of plain literal segments, which is what <see cref="TryNormalize"/> enforces: anything else is
-/// discarded rather than matched, so a prefix can never mean one thing to a middleware and another to the
-/// router.
+/// made of plain literal segments, which is what <see cref="AnonymousPathPolicy"/> enforces: anything else
+/// is discarded rather than matched, so a prefix can never mean one thing to a middleware and another to
+/// the router.
 /// </para>
 /// </remarks>
 public static class AnonymousPaths
 {
-    /// <summary>
-    /// Characters that either carry meaning in an ASP.NET route template or change how a path is
-    /// segmented, and therefore cannot appear in a declared prefix.
-    /// </summary>
-    static readonly SearchValues<char> _reservedCharacters = SearchValues.Create("{}?#*[]\\% \t\r\n");
-
     /// <summary>
     /// The usable prefixes resolved for a configuration instance, so <see cref="Matches"/> does not re-parse
     /// every declared entry on every request. Weak keys, so a superseded configuration is collectable.
@@ -45,7 +38,28 @@ public static class AnonymousPaths
     /// <param name="service">The service to read.</param>
     /// <returns>The service's anonymous path prefixes.</returns>
     public static IEnumerable<string> For(C.Service service) =>
-        Normalize(service.AnonymousPaths).Distinct(StringComparer.OrdinalIgnoreCase);
+        Evaluate(service)
+            .Where(_ => _.IsUsable)
+            .Select(_ => _.Prefix)
+            .Distinct(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Evaluates every entry a service declares, keeping the refused ones and the reason for each.
+    /// </summary>
+    /// <param name="service">The service to read.</param>
+    /// <returns>One evaluation per declared entry, in declaration order.</returns>
+    /// <remarks>
+    /// <see cref="For(C.Service)"/> answers what is anonymous; this answers what was <em>asked</em> for and
+    /// refused, which is the part an operator cannot otherwise see. A refusal is fail-closed, so nothing
+    /// breaks loudly — the path simply keeps asking for a login — and without this the only symptom of a
+    /// typo in a declared prefix is a surface that was meant to be public quietly not being.
+    /// </remarks>
+    public static IEnumerable<AnonymousPathEvaluation> Evaluate(C.Service service) =>
+        service.AnonymousPaths.Select(candidate =>
+        {
+            var rejection = AnonymousPathPolicy.Evaluate(candidate, out var prefix);
+            return new AnonymousPathEvaluation(candidate ?? string.Empty, prefix, rejection);
+        });
 
     /// <summary>
     /// Determines whether the given request path is covered by a declared anonymous path prefix.
@@ -88,53 +102,15 @@ public static class AnonymousPaths
     /// <param name="prefix">The normalized prefix when the entry is usable.</param>
     /// <returns><see langword="true"/> when the entry is usable; otherwise <see langword="false"/>.</returns>
     /// <remarks>
-    /// Every rejection here is fail-closed — a discarded entry leaves the path authenticated, never the
-    /// other way around. The empty entry is the one that matters most:
-    /// <c>PathString.StartsWithSegments(string.Empty)</c> is true for every request, so a blank value
-    /// would otherwise turn an entire service anonymous. The bare <c>/</c> is rejected for the same
-    /// reason. The remaining rejections keep the prefix safe to interpolate into a route template:
-    /// <c>/a{x}</c> would become a route <em>parameter</em>, making the router match <c>/aANYTHING/…</c>
-    /// where the middlewares match only the literal, and <c>//a</c> or <c>/a/{**b}</c> is not a legal
-    /// template at all, so it would fail the proxy's configuration load at startup. The rest are rejected
-    /// because a prefix whose meaning depends on encoding cannot be reasoned about from configuration.
+    /// Every rejection is fail-closed — a discarded entry leaves the path authenticated, never the other
+    /// way around. <see cref="AnonymousPathPolicy"/> owns the rules and the reason for each; this is the
+    /// boolean form for callers that only need to know whether an entry survived.
     /// </remarks>
-    public static bool TryNormalize(string? candidate, out string prefix)
-    {
-        prefix = string.Empty;
-
-        if (string.IsNullOrWhiteSpace(candidate))
-        {
-            return false;
-        }
-
-        var normalized = candidate.Trim().TrimEnd('/');
-
-        if (normalized.Length < 2
-            || normalized[0] != '/'
-            || normalized.Contains("//", StringComparison.Ordinal)
-            || normalized.AsSpan().IndexOfAny(_reservedCharacters) >= 0)
-        {
-            return false;
-        }
-
-        prefix = normalized;
-
-        return true;
-    }
+    public static bool TryNormalize(string? candidate, out string prefix) =>
+        AnonymousPathPolicy.Evaluate(candidate, out prefix) == AnonymousPathRejection.None;
 
     static string[] Resolve(C.AuthProxy config) =>
         [.. config.Services.Values
-            .SelectMany(_ => Normalize(_.AnonymousPaths))
+            .SelectMany(For)
             .Distinct(StringComparer.OrdinalIgnoreCase)];
-
-    static IEnumerable<string> Normalize(IEnumerable<string> candidates)
-    {
-        foreach (var candidate in candidates)
-        {
-            if (TryNormalize(candidate, out var prefix))
-            {
-                yield return prefix;
-            }
-        }
-    }
 }

--- a/Source/AuthProxy/Authentication/TenantAuthenticationState.cs
+++ b/Source/AuthProxy/Authentication/TenantAuthenticationState.cs
@@ -100,24 +100,48 @@ public static class TenantAuthenticationState
         return false;
     }
 
+    /// <summary>
+    /// Reduces a caller-supplied return URL to a target that can only navigate within this site.
+    /// </summary>
+    /// <param name="returnUrl">The caller-supplied return URL.</param>
+    /// <returns>A same-site relative target, or the application root when none can be derived.</returns>
+    /// <remarks>
+    /// This value survives the round-trip to the identity provider and is handed to the browser as the
+    /// post-authentication <c>Location</c>, so it is the single most attractive open-redirect target in
+    /// AuthProxy: the victim sees the real domain and completes a real login before it is honored. It
+    /// arrives from an <c>AllowAnonymous</c> endpoint, so it is attacker-supplied by default.
+    /// <para>
+    /// An <em>http(s)</em> absolute URL is reduced to its path and query rather than refused, which keeps a
+    /// caller that sends its own origin working — the host is dropped, never honored. Any other scheme is
+    /// refused outright, and so is anything that cannot be reduced to a verified same-site relative target.
+    /// </para>
+    /// <para>
+    /// The scheme check is doing more work than it looks like. On Unix, <see cref="Uri.TryCreate(string, UriKind, out Uri)"/>
+    /// parses a rooted path as an absolute <c>file:</c> URI, so without it <c>//evil.test/phish</c> and
+    /// <c>/\t/evil.test</c> would be run through <see cref="Uri.AbsolutePath"/> — laundering a target this
+    /// method had just rejected into one that looks clean, and doing it on Linux but not on Windows.
+    /// </para>
+    /// </remarks>
     static string NormalizeReturnUrl(string? returnUrl)
     {
         if (string.IsNullOrWhiteSpace(returnUrl))
         {
-            return "/";
+            return RelativeRedirect.ApplicationRoot;
         }
 
-        if (returnUrl.StartsWith('/'))
+        if (RelativeRedirect.IsSameSiteRelative(returnUrl))
         {
             return returnUrl;
         }
 
         if (Uri.TryCreate(returnUrl, UriKind.Absolute, out var absoluteUri))
         {
-            return $"{absoluteUri.AbsolutePath}{absoluteUri.Query}";
+            return absoluteUri.Scheme == Uri.UriSchemeHttp || absoluteUri.Scheme == Uri.UriSchemeHttps
+                ? RelativeRedirect.Resolve($"{absoluteUri.AbsolutePath}{absoluteUri.Query}")
+                : RelativeRedirect.ApplicationRoot;
         }
 
-        return $"/{returnUrl}";
+        return RelativeRedirect.Resolve($"/{returnUrl}");
     }
 
     static string BuildAbsoluteRedirectUri(string scheme, string host, string returnUrl)

--- a/Source/AuthProxy/Cookies.cs
+++ b/Source/AuthProxy/Cookies.cs
@@ -10,8 +10,21 @@ public static class Cookies
 {
     /// <summary>
     /// Cookie holding the enriched identity details from the application's identity provider endpoint.
+    /// Intentionally <em>not</em> HTTP-only so client-side script can render the signed-in user, and
+    /// therefore never evidence of anything — see <see cref="IdentityAuthorization"/>.
     /// </summary>
     public const string Identity = ".cratis-identity";
+
+    /// <summary>
+    /// HTTP-only cookie holding the sealed record that a principal was authorized in a tenant, used to
+    /// skip the <c>/.cratis/me</c> authorization call on subsequent requests.
+    /// </summary>
+    /// <remarks>
+    /// Separate from <see cref="Identity"/> precisely because that one is readable and writable by the
+    /// client. This carries the authorization decision, so it is sealed with data protection and bound to
+    /// the principal and tenant it was issued for.
+    /// </remarks>
+    public const string IdentityAuthorization = ".cratis-identity-authorization";
 
     /// <summary>
     /// Short-lived HTTP-only cookie used to carry the invite token across the OIDC redirect.

--- a/Source/AuthProxy/HttpContextExtensions.cs
+++ b/Source/AuthProxy/HttpContextExtensions.cs
@@ -11,7 +11,6 @@ namespace Cratis.AuthProxy;
 /// </summary>
 public static class HttpContextExtensions
 {
-    const string SignInPathPrefix = "/signin-";
     const string FetchDestinationHeader = "Sec-Fetch-Dest";
     const string HtmlMediaType = "text/html";
 
@@ -132,7 +131,7 @@ public static class HttpContextExtensions
     /// <param name="context">The <see cref="HttpContext"/> to evaluate.</param>
     /// <returns><see langword="true"/> if the request is part of authentication bootstrap; otherwise <see langword="false"/>.</returns>
     public static bool IsAuthenticationBootstrap(this HttpContext context) =>
-        context.IsAuthenticationUI() || (context.Request.Path.Value?.StartsWith(SignInPathPrefix, StringComparison.OrdinalIgnoreCase) ?? false);
+        context.IsAuthenticationUI() || (context.Request.Path.Value?.StartsWith(WellKnownPaths.SignInPrefix, StringComparison.OrdinalIgnoreCase) ?? false);
 
     /// <summary>
     /// Attempts to extract the invitation token from the current invitation request path.

--- a/Source/AuthProxy/Identity/IIdentityAuthorizationCache.cs
+++ b/Source/AuthProxy/Identity/IIdentityAuthorizationCache.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Identity;
+
+/// <summary>
+/// Defines the contract for remembering, across requests, that a principal was authorized in a tenant.
+/// </summary>
+/// <remarks>
+/// Resolving identity details means calling <c>/.cratis/me</c> on every configured service, and the answer
+/// includes whether the caller is authorized at all. Doing that on every request would put a fan-out of
+/// backend calls in front of every proxied request, so the outcome is remembered on the client — which
+/// makes the remembered value an authorization decision travelling through the caller's own browser, and
+/// therefore something the caller must not be able to write.
+/// </remarks>
+public interface IIdentityAuthorizationCache
+{
+    /// <summary>
+    /// Records that the given principal was authorized in the given tenant.
+    /// </summary>
+    /// <param name="context">The current <see cref="HttpContext"/>, whose response the record is written to.</param>
+    /// <param name="principal">The authorized principal.</param>
+    /// <param name="tenantId">The tenant the principal was authorized in.</param>
+    void Record(HttpContext context, ClientPrincipal principal, string tenantId);
+
+    /// <summary>
+    /// Determines whether the current request carries proof that this principal was already authorized in
+    /// this tenant.
+    /// </summary>
+    /// <param name="context">The current <see cref="HttpContext"/>.</param>
+    /// <param name="principal">The principal to check.</param>
+    /// <param name="tenantId">The tenant to check.</param>
+    /// <returns><see langword="true"/> when a valid, unexpired record for this principal and tenant is present; otherwise <see langword="false"/>.</returns>
+    bool IsAuthorized(HttpContext context, ClientPrincipal principal, string tenantId);
+
+    /// <summary>
+    /// Clears any recorded authorization from the response.
+    /// </summary>
+    /// <param name="context">The current <see cref="HttpContext"/>.</param>
+    void Clear(HttpContext context);
+}

--- a/Source/AuthProxy/Identity/IdentityAuthorizationCache.cs
+++ b/Source/AuthProxy/Identity/IdentityAuthorizationCache.cs
@@ -1,0 +1,117 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Options;
+using C = Cratis.AuthProxy.Configuration;
+
+namespace Cratis.AuthProxy.Identity;
+
+/// <summary>
+/// Remembers an authorization outcome in a cookie the caller cannot forge.
+/// </summary>
+/// <remarks>
+/// The readable <c>.cratis-identity</c> cookie exists so a frontend can render the signed-in user without
+/// a round-trip, which is why it is written non-HTTP-only and in plain base64. That makes it useless as
+/// evidence: any script on a proxied origin, and any non-browser client at all, can write whatever it
+/// likes into it. This writes the <em>decision</em> to a separate HTTP-only cookie sealed with ASP.NET
+/// data protection, so the value that skips the <c>/.cratis/me</c> authorization call is one only
+/// AuthProxy can have produced.
+/// <para>
+/// The sealed payload names the principal and the tenant it was issued for, and both are compared against
+/// the current request rather than trusted. Sealing alone would not be enough: a sealed record is still a
+/// bearer value, so without the comparison a caller could keep a record issued for one tenant and present
+/// it while acting in another, or a record from an old session could authorize whoever holds the browser
+/// next. The expiry is carried inside the sealed payload rather than left to the cookie's
+/// <c>Max-Age</c>, because <c>Max-Age</c> is a request to the browser and a client that declines to honor
+/// it would otherwise hold an authorization that never lapses.
+/// </para>
+/// </remarks>
+/// <param name="dataProtectionProvider">The data protection provider used to seal the record.</param>
+/// <param name="config">The auth proxy configuration, providing the re-validation interval.</param>
+/// <param name="logger">The logger.</param>
+public class IdentityAuthorizationCache(
+    IDataProtectionProvider dataProtectionProvider,
+    IOptionsMonitor<C.AuthProxy> config,
+    ILogger<IdentityAuthorizationCache> logger) : IIdentityAuthorizationCache
+{
+    /// <summary>
+    /// The purpose string binding the protector to this use. A record sealed for one purpose cannot be
+    /// unsealed for another, so an unrelated protected value cannot be replayed here.
+    /// </summary>
+    const string ProtectorPurpose = "Cratis.AuthProxy.Identity.Authorization.v1";
+
+    /// <summary>
+    /// The lifetime used when no re-validation interval is configured.
+    /// </summary>
+    static readonly TimeSpan _defaultLifetime = TimeSpan.FromMinutes(10);
+
+    readonly IDataProtector _protector = dataProtectionProvider.CreateProtector(ProtectorPurpose);
+
+    /// <summary>
+    /// Gets how long a recorded authorization stays valid, mirroring the identity cookie's own lifetime.
+    /// </summary>
+    TimeSpan Lifetime
+    {
+        get
+        {
+            var configured = config.CurrentValue.Session.IdentityRevalidationInterval;
+
+            return configured > TimeSpan.Zero ? configured : _defaultLifetime;
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Record(HttpContext context, ClientPrincipal principal, string tenantId)
+    {
+        var lifetime = Lifetime;
+        var expires = DateTimeOffset.UtcNow.Add(lifetime);
+        var payload = $"{expires.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture)}|{principal.UserId}|{tenantId}";
+
+        context.Response.Cookies.Append(Cookies.IdentityAuthorization, _protector.Protect(payload), new CookieOptions
+        {
+            HttpOnly = true,
+            SameSite = SameSiteMode.Lax,
+            Secure = context.Request.IsHttps,
+            MaxAge = lifetime,
+            IsEssential = true,
+        });
+    }
+
+    /// <inheritdoc/>
+    public bool IsAuthorized(HttpContext context, ClientPrincipal principal, string tenantId)
+    {
+        if (!context.Request.Cookies.TryGetValue(Cookies.IdentityAuthorization, out var sealedRecord)
+            || string.IsNullOrWhiteSpace(sealedRecord))
+        {
+            return false;
+        }
+
+        string payload;
+
+        try
+        {
+            payload = _protector.Unprotect(sealedRecord);
+        }
+        catch (System.Security.Cryptography.CryptographicException)
+        {
+            // Tampered, truncated, or sealed by a key this instance no longer has. Either way it is not
+            // evidence of anything, so the caller is re-authorized against the services rather than
+            // refused — a rotated data-protection key must not lock everyone out.
+            logger.IdentityAuthorizationRecordRejected();
+            return false;
+        }
+
+        var parts = payload.Split('|', 3);
+
+        return parts.Length == 3
+            && long.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var expiresAt)
+            && DateTimeOffset.FromUnixTimeSeconds(expiresAt) > DateTimeOffset.UtcNow
+            && string.Equals(parts[1], principal.UserId, StringComparison.Ordinal)
+            && string.Equals(parts[2], tenantId, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <inheritdoc/>
+    public void Clear(HttpContext context) => context.Response.Cookies.Delete(Cookies.IdentityAuthorization);
+}

--- a/Source/AuthProxy/Identity/IdentityAuthorizationCacheLogging.cs
+++ b/Source/AuthProxy/Identity/IdentityAuthorizationCacheLogging.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Identity;
+
+internal static partial class IdentityAuthorizationCacheLogging
+{
+    [LoggerMessage(LogLevel.Debug, "A recorded identity authorization could not be unsealed and was ignored. The caller will be re-authorized against the configured services.")]
+    internal static partial void IdentityAuthorizationRecordRejected(this ILogger logger);
+}

--- a/Source/AuthProxy/Identity/IdentityDetailsResolver.cs
+++ b/Source/AuthProxy/Identity/IdentityDetailsResolver.cs
@@ -22,12 +22,14 @@ namespace Cratis.AuthProxy.Identity;
 /// <param name="httpClientFactory">The HTTP client factory.</param>
 /// <param name="principalEnrichers">Enrichers that augment the principal before it is sent to the identity endpoint.</param>
 /// <param name="memoryCache">The memory cache used to deduplicate concurrent identity resolutions.</param>
+/// <param name="authorizationCache">The tamper-proof record of a previously resolved authorization.</param>
 /// <param name="logger">The logger.</param>
 public class IdentityDetailsResolver(
     IOptionsMonitor<C.AuthProxy> config,
     IHttpClientFactory httpClientFactory,
     IEnumerable<IIdentityDetailsPrincipalEnricher> principalEnrichers,
     IMemoryCache memoryCache,
+    IIdentityAuthorizationCache authorizationCache,
     ILogger<IdentityDetailsResolver> logger) : IIdentityDetailsResolver
 {
     static readonly TimeSpan _cacheTtl = TimeSpan.FromSeconds(30);
@@ -49,7 +51,13 @@ public class IdentityDetailsResolver(
         // otherwise shadow the invite claims and cause the Lobby to return the wrong flow type.
         var hasPendingInvite = context.HasPendingInvitation();
 
-        if (!hasPendingInvite && context.Request.Cookies.ContainsKey(Cookies.Identity))
+        // Skipping the identity endpoints means skipping the authorization answer they carry, so what
+        // permits the skip has to be something the caller could not have written. The readable
+        // .cratis-identity cookie is not that — it is non-HTTP-only by design and its value was never
+        // examined here, so sending any value for it used to be enough to be treated as authorized, for as
+        // long as the caller chose to keep sending it. The sealed record is checked instead, and it is
+        // checked against this principal and this tenant.
+        if (!hasPendingInvite && authorizationCache.IsAuthorized(context, principal, tenantId))
         {
             return BuildAuthorizedResult(principal, details: null);
         }
@@ -58,7 +66,7 @@ public class IdentityDetailsResolver(
 
         if (!hasPendingInvite && memoryCache.TryGetValue(cacheKey, out IdentityProviderResult? cached) && cached is not null)
         {
-            WriteIdentityCookie(context, cached);
+            WriteIdentityState(context, cached, principal, tenantId);
             logger.IdentityDetailsCacheHit(principal.UserId);
             return cached;
         }
@@ -70,7 +78,7 @@ public class IdentityDetailsResolver(
             // Double-check inside the lock — another request may have populated the cache while we waited.
             if (!hasPendingInvite && memoryCache.TryGetValue(cacheKey, out cached) && cached is not null)
             {
-                WriteIdentityCookie(context, cached);
+                WriteIdentityState(context, cached, principal, tenantId);
                 logger.IdentityDetailsCacheHit(principal.UserId);
                 return cached;
             }
@@ -108,7 +116,7 @@ public class IdentityDetailsResolver(
             }
 
             var identityResult = BuildAuthorizedResult(principal, mergedDetails.Count > 0 ? mergedDetails : null);
-            WriteIdentityCookie(context, identityResult);
+            WriteIdentityState(context, identityResult, principal, tenantId);
             logger.IdentityDetailsCookieWritten(principal.UserId);
             memoryCache.Set(cacheKey, identityResult, _cacheTtl);
             return identityResult;
@@ -128,8 +136,13 @@ public class IdentityDetailsResolver(
             principal.UserRoles,
             details!);
 
-    void WriteIdentityCookie(HttpContext context, IdentityProviderResult result)
+    void WriteIdentityState(HttpContext context, IdentityProviderResult result, ClientPrincipal principal, string tenantId)
     {
+        // Two cookies, deliberately: the readable one the frontend renders from, and the sealed record
+        // that is allowed to skip this resolution next time. They are written together so the authorized
+        // outcome and the proof of it can never drift apart.
+        authorizationCache.Record(context, principal, tenantId);
+
         var json = JsonSerializer.Serialize(result, _cookieSerializerOptions);
         var encoded = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(json));
 

--- a/Source/AuthProxy/Identity/IdentityServiceCollectionExtensions.cs
+++ b/Source/AuthProxy/Identity/IdentityServiceCollectionExtensions.cs
@@ -18,6 +18,7 @@ public static class IdentityServiceCollectionExtensions
         builder.Services.AddHttpClient();
         builder.Services.AddMemoryCache();
         builder.Services.AddSingleton<IIdentityDetailsPrincipalEnricher, InviteTokenClaimsPrincipalEnricher>();
+        builder.Services.AddSingleton<IIdentityAuthorizationCache, IdentityAuthorizationCache>();
         builder.Services.AddSingleton<IIdentityDetailsResolver, IdentityDetailsResolver>();
 
         return builder;

--- a/Source/AuthProxy/Links/LinkMiddleware.cs
+++ b/Source/AuthProxy/Links/LinkMiddleware.cs
@@ -43,8 +43,6 @@ public class LinkMiddleware(
     /// </summary>
     public const string LinkTokenPropertyKey = "Cratis.AuthProxy.LinkToken";
 
-    const string ApplicationRoot = "/";
-
     /// <inheritdoc cref="IMiddleware.InvokeAsync"/>
     public async Task InvokeAsync(HttpContext context)
     {
@@ -88,22 +86,15 @@ public class LinkMiddleware(
         await context.ChallengeAsync(scheme, properties);
     }
 
-    static string ResolveReturnUrl(string? returnUrl)
-    {
-        // The return URL is echoed back to the browser after the link completes, so it must be a same-site
-        // relative path (a single leading slash, not '//') — anything else falls back to the application
-        // root so the endpoint can never be used as an open redirect.
-        if (string.IsNullOrWhiteSpace(returnUrl))
-        {
-            return ApplicationRoot;
-        }
-
-        var isSafeRelative = Uri.TryCreate(returnUrl, UriKind.Relative, out _)
-            && returnUrl.StartsWith('/')
-            && !returnUrl.StartsWith("//", StringComparison.Ordinal);
-
-        return isSafeRelative ? returnUrl : ApplicationRoot;
-    }
+    /// <summary>
+    /// Resolves the return URL echoed back to the browser once the link completes.
+    /// </summary>
+    /// <param name="returnUrl">The caller-supplied return URL.</param>
+    /// <returns>The requested target when it is same-site relative; otherwise the application root.</returns>
+    /// <remarks>
+    /// See <see cref="RelativeRedirect"/> for why a single leading slash is not the whole test.
+    /// </remarks>
+    static string ResolveReturnUrl(string? returnUrl) => RelativeRedirect.Resolve(returnUrl);
 
     bool SchemeExists(string scheme)
     {

--- a/Source/AuthProxy/LogoutMiddleware.cs
+++ b/Source/AuthProxy/LogoutMiddleware.cs
@@ -135,6 +135,7 @@ public class LogoutMiddleware(
     {
         await context.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
         context.Response.Cookies.Delete(Cookies.Identity);
+        context.Response.Cookies.Delete(Cookies.IdentityAuthorization);
         context.Response.Cookies.Delete(Cookies.Tenant);
         context.Response.Cookies.Delete(Cookies.Tenants);
         context.Response.Cookies.Delete(Cookies.InviteToken);

--- a/Source/AuthProxy/PostLogoutRedirectPolicy.cs
+++ b/Source/AuthProxy/PostLogoutRedirectPolicy.cs
@@ -48,8 +48,10 @@ public static class PostLogoutRedirectPolicy
             return false;
         }
 
-        // A relative, single-slash URL is always same-site and therefore safe.
-        if (Uri.TryCreate(redirect, UriKind.Relative, out _) && redirect.StartsWith('/') && !redirect.StartsWith("//", StringComparison.Ordinal))
+        // A same-site relative URL is always safe. See RelativeRedirect for why a single leading slash is
+        // not the whole test — '/\evil.test' and a slash followed by a stripped control character both
+        // navigate off-site.
+        if (RelativeRedirect.IsSameSiteRelative(redirect))
         {
             return true;
         }

--- a/Source/AuthProxy/RelativeRedirect.cs
+++ b/Source/AuthProxy/RelativeRedirect.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy;
+
+/// <summary>
+/// Decides whether a caller-supplied redirect target is a same-site relative URL, and is the single place
+/// that decision is made.
+/// </summary>
+/// <remarks>
+/// AuthProxy hands the browser a redirect target the caller supplied in four places — the login endpoint's
+/// <c>returnUrl</c>, the link flow's <c>returnUrl</c>, tenant selection's <c>returnUrl</c>, and logout's
+/// <c>redirect</c>. Each had grown its own version of "is this relative", and they disagreed: one accepted
+/// <c>//evil.test</c> outright, and the two that rejected it still accepted <c>/\evil.test</c>. An open
+/// redirect on the authentication proxy is the strongest phishing primitive a system can offer — the
+/// victim sees the real domain, completes a real login at the real identity provider, and only then lands
+/// on the attacker's page — so the check lives here once rather than being re-derived per call site.
+/// <para>
+/// A single leading <c>/</c> is not enough to be same-site, because the browser decides what a
+/// <c>Location</c> means, not the string's first character:
+/// </para>
+/// <list type="bullet">
+///   <item><c>//evil.test</c> is protocol-relative and navigates off-site.</item>
+///   <item><c>/\evil.test</c> is the same thing to every major browser, which normalize <c>\</c> to
+///     <c>/</c> in the authority position.</item>
+///   <item><c>/</c> followed by a tab, carriage return or newline is <em>also</em> the same thing:
+///     browsers strip those characters from a URL before parsing it, so <c>/\tevil.test</c> is fetched as
+///     <c>//evil.test</c>. Control characters are what make a header-injection payload too, so they are
+///     refused rather than stripped.</item>
+/// </list>
+/// </remarks>
+public static class RelativeRedirect
+{
+    /// <summary>
+    /// The application root, used as the safe destination when a requested target is not allowed.
+    /// </summary>
+    public const string ApplicationRoot = "/";
+
+    /// <summary>
+    /// Determines whether a target is a relative URL that can only navigate within this site.
+    /// </summary>
+    /// <param name="url">The caller-supplied target.</param>
+    /// <returns><see langword="true"/> when the target is same-site relative; otherwise <see langword="false"/>.</returns>
+    public static bool IsSameSiteRelative(string? url)
+    {
+        if (string.IsNullOrEmpty(url) || url[0] != '/')
+        {
+            return false;
+        }
+
+        // The second character is what turns a path into an authority. Both spellings are refused, so
+        // neither '//evil.test' nor '/\evil.test' can be handed to a browser.
+        if (url.Length > 1 && (url[1] == '/' || url[1] == '\\'))
+        {
+            return false;
+        }
+
+        // A backslash anywhere is refused rather than reasoned about: it is a separator to some parsers
+        // and a literal to others, and no legitimate return URL needs one.
+        // Anything at or below space covers every control character — including the tab, carriage return
+        // and newline a browser would strip, revealing a leading '//' that was not there in the string.
+        foreach (var character in url)
+        {
+            if (character == '\\' || character <= ' ' || character == '\u007f')
+            {
+                return false;
+            }
+        }
+
+        return Uri.TryCreate(url, UriKind.Relative, out _);
+    }
+
+    /// <summary>
+    /// Resolves the effective redirect target, returning the requested value when it is same-site relative
+    /// and the application root otherwise.
+    /// </summary>
+    /// <param name="url">The caller-supplied target.</param>
+    /// <returns>The requested target when allowed; otherwise <see cref="ApplicationRoot"/>.</returns>
+    public static string Resolve(string? url) => IsSameSiteRelative(url) ? url! : ApplicationRoot;
+}

--- a/Source/AuthProxy/ReverseProxy/MicroserviceReverseProxyConfigProvider.cs
+++ b/Source/AuthProxy/ReverseProxy/MicroserviceReverseProxyConfigProvider.cs
@@ -249,7 +249,12 @@ public class MicroserviceReverseProxyConfigProvider(
             Order = 1,
         };
 
-        // Query-parameter–matched API route (adds the header for downstream)
+        // Query-parameter–matched API route (adds the header for downstream).
+        // Ordered behind the header-matched route rather than beside it: a caller that sends both a
+        // Service-ID header and a ?service= parameter satisfies both, and two candidates at the same order
+        // with the same template are an AmbiguousMatchException. Endpoint selection runs ahead of
+        // authentication, so that surfaces to an unauthenticated caller as a bare 500 — trivially
+        // reachable, and in Development a stack trace. A distinct order makes the header win instead.
         yield return new RouteConfig
         {
             RouteId = $"{microserviceKey}-backend-query-api",
@@ -269,7 +274,7 @@ public class MicroserviceReverseProxyConfigProvider(
                     }
                 ],
             },
-            Order = 1,
+            Order = 2,
         };
 
         // Plain /api catch-all when there is only one microservice.
@@ -311,7 +316,8 @@ public class MicroserviceReverseProxyConfigProvider(
             Order = 10,
         };
 
-        // Query-parameter–matched frontend route
+        // Query-parameter–matched frontend route, ordered behind the header-matched one for the same
+        // reason as the backend pair: satisfying both must select one route, not raise an ambiguity.
         yield return new RouteConfig
         {
             RouteId = $"{microserviceKey}-frontend-query",
@@ -331,7 +337,7 @@ public class MicroserviceReverseProxyConfigProvider(
                     }
                 ],
             },
-            Order = 10,
+            Order = 11,
         };
     }
 

--- a/Source/AuthProxy/ReverseProxy/MicroserviceReverseProxyConfigProvider.cs
+++ b/Source/AuthProxy/ReverseProxy/MicroserviceReverseProxyConfigProvider.cs
@@ -69,6 +69,7 @@ public class MicroserviceReverseProxyConfigProvider(
         {
             var key = name.ToLowerInvariant();
 
+            ReportRefusedAnonymousPaths(key, ms, logger);
             routes.AddRange(AnonymousRoutes(key, ms, claimedAnonymousPaths, logger));
 
             if (ms.Backend is not null)
@@ -114,6 +115,26 @@ public class MicroserviceReverseProxyConfigProvider(
         }
 
         return routes;
+    }
+
+    /// <summary>
+    /// Reports every declared anonymous path that was refused, and why.
+    /// </summary>
+    /// <param name="microserviceKey">The lower-cased service key.</param>
+    /// <param name="service">The service configuration.</param>
+    /// <param name="logger">The logger, used to name each refused entry.</param>
+    /// <remarks>
+    /// A refusal is fail-closed, so nothing breaks loudly — the path keeps demanding a login. That is the
+    /// safe outcome and an invisible one: an operator who mistypes a prefix, or pastes one carrying an
+    /// encoded character, gets a service that behaves exactly as if they had never declared it. Startup is
+    /// the only place the two can be compared, so the refusal is named here.
+    /// </remarks>
+    static void ReportRefusedAnonymousPaths(string microserviceKey, C.Service service, ILogger logger)
+    {
+        foreach (var refused in AnonymousPaths.Evaluate(service).Where(_ => !_.IsUsable))
+        {
+            logger.AnonymousPathRefused(refused.DeclaredForDisplay, microserviceKey, refused.Rejection);
+        }
     }
 
     /// <summary>

--- a/Source/AuthProxy/ReverseProxy/MicroserviceReverseProxyConfigProviderLogging.cs
+++ b/Source/AuthProxy/ReverseProxy/MicroserviceReverseProxyConfigProviderLogging.cs
@@ -7,4 +7,7 @@ internal static partial class MicroserviceReverseProxyConfigProviderLogging
 {
     [LoggerMessage(LogLevel.Warning, "Anonymous path '{Path}' is declared by more than one service. Service '{ServingService}' serves it; the declaration on '{IgnoredService}' has no effect, and requests below that prefix will not reach it.")]
     internal static partial void AnonymousPathAlreadyClaimed(this ILogger logger, string path, string servingService, string ignoredService);
+
+    [LoggerMessage(LogLevel.Warning, "Anonymous path '{Path}' declared by service '{Service}' was refused ({Reason}) and remains authenticated. Declare a rooted path of plain literal segments, made only of letters, digits, '-', '.', '_' and '~', that does not start with one of the paths AuthProxy reserves for itself.")]
+    internal static partial void AnonymousPathRefused(this ILogger logger, string path, string service, AnonymousPathRejection reason);
 }

--- a/Source/AuthProxy/TenantSelectionMiddleware.cs
+++ b/Source/AuthProxy/TenantSelectionMiddleware.cs
@@ -251,10 +251,7 @@ public class TenantSelectionMiddleware(
         memoryCache.Set(RevalidationCacheKey(principal.UserId, tenantId), true, interval);
     }
 
-    bool IsSafeRelativeUrl(string? url) =>
-        !string.IsNullOrWhiteSpace(url)
-        && Uri.TryCreate(url, UriKind.Relative, out _)
-        && url.StartsWith('/');
+    bool IsSafeRelativeUrl(string? url) => RelativeRedirect.IsSameSiteRelative(url);
 
     bool TryGetSelectionOptions(C.AuthProxy authProxyConfig, out Tenancy.SelectionOptions selectionOptions)
     {

--- a/Source/AuthProxy/WellKnownPaths.cs
+++ b/Source/AuthProxy/WellKnownPaths.cs
@@ -9,6 +9,18 @@ namespace Cratis.AuthProxy;
 public static class WellKnownPaths
 {
     /// <summary>
+    /// The path prefix under which AuthProxy answers its own endpoints. Everything below it belongs to the
+    /// proxy rather than to a service, so it can never be routed to a backend.
+    /// </summary>
+    public const string Cratis = "/.cratis";
+
+    /// <summary>
+    /// The path prefix the authentication handlers use for provider callbacks. The provider scheme is
+    /// appended directly rather than as a segment (e.g. <c>/signin-microsoft</c>).
+    /// </summary>
+    public const string SignInPrefix = "/signin-";
+
+    /// <summary>
     /// The well-known path for the Cratis identity details endpoint on a microservice.
     /// </summary>
     public const string IdentityDetails = "/.cratis/me";


### PR DESCRIPTION
# Summary

Hardens what a deployment can declare as an anonymous path, fixes four security defects found while doing so, and adds a security spec suite that gates every pull request.

The anonymous path rules moved from a deny-list of route-template characters to an allow-list of RFC 3986 unreserved characters. A deny-list has to anticipate every character that means something to one of the two matchers — the middlewares matching a literal and the router matching a route template — and the cost of missing one is a prefix that means different things to each. Refusals stay fail-closed, leaving the path authenticated, and are now reported at startup instead of being silent.

## Added

- Security spec suite covering broken access control, injection, open redirect, request smuggling and security misconfiguration. Specs run a real AuthProxy in front of a real origin that records every forwarded request, so assertions can be made about what reached the backend rather than only what the client saw (#42)
- A Security workflow that runs the security specs and a known-vulnerable dependency check on every pull request, with no path filter (#42)
- Startup warnings naming every declared anonymous path that was refused, and why

## Changed

- Anonymous path entries are validated against an allow-list of letters, digits, `-`, `.`, `_` and `~`. Percent-encoding, backslashes, semicolons, authority syntax, control characters and non-ASCII are refused, as is any `.` or `..` segment
- Anonymous path entries may no longer target the prefixes AuthProxy answers itself (`/.cratis`, `/_pages`, `/invite`, `/register`, `/signin-*`). Declaring one never made an endpoint more public — it took the endpoint away from AuthProxy and handed it to a backend
- CI now builds Debug as well as Release and runs the specs. Previously no tests ran in CI at all

## Security

- Fixed an open redirect on the login, link, tenant-selection and logout endpoints. Each carried its own version of a same-site check and they disagreed: two accepted `//evil.test` outright, and the two that rejected it still accepted `/\evil.test`, which every major browser treats identically. The login endpoint is the most exposed of the four — its `returnUrl` is accepted anonymously and becomes the post-authentication redirect, so a victim completes a genuine sign-in before landing on the attacker's page
- Fixed authorization being granted by the presence of the script-readable `.cratis-identity` cookie, whose value was never read. Sending any value for it alongside a valid session skipped every service's `/.cratis/me` authorization call, so a user whose access had been revoked stayed authorized for as long as they kept sending it. The decision now lives in a separate HTTP-only cookie sealed with data protection and bound to the principal and tenant it was issued for
- Fixed an unauthenticated HTTP 500 reachable by sending both a `Service-ID` header and a `?service=` parameter. The two route variants shared a template and an order, and endpoint selection runs ahead of authentication
