### PR TITLE
Add first-gate authorization driven by a claim from the identity provider

### DIFF
--- a/Documentation/configuration/authentication.md
+++ b/Documentation/configuration/authentication.md
@@ -108,6 +108,72 @@ This allows a common callback endpoint while still restoring tenant-specific beh
 
 ---
 
+## OAuth 2.0 providers
+
+Not every provider publishes an OpenID Connect discovery document. GitHub is the common one that does not,
+so it is configured under `Cratis:AuthProxy:Authentication:OAuthProviders` with its endpoints named
+explicitly instead of discovered from an authority:
+
+```json
+{
+  "Cratis": {
+    "AuthProxy": {
+      "Authentication": {
+        "OAuthProviders": [
+          {
+            "Name": "GitHub",
+            "Type": "GitHub",
+            "AuthorizationEndpoint": "https://github.com/login/oauth/authorize",
+            "TokenEndpoint": "https://github.com/login/oauth/access_token",
+            "UserInformationEndpoint": "https://api.github.com/user",
+            "ClientId": "<client-id>",
+            "ClientSecret": "<client-secret>",
+            "Scopes": [ "read:user", "user:email" ],
+            "ClaimMappings": {
+              "sub": "id",
+              "name": "name",
+              "preferred_username": "login",
+              "email": "email"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+OAuth providers sit alongside OIDC providers in every other respect: they appear on the
+provider-selection page, they get a login endpoint at `/.cratis/login/{scheme}`, and the count of both
+together decides whether an unauthenticated browser is challenged directly or offered a choice.
+
+`ClaimMappings` is what turns the provider's user-info JSON into claims — the key is the claim type to
+create, the value is the field to read it from. The mapping above produces the claims AuthProxy reads when
+it builds the forwarded principal.
+
+> [!NOTE]
+> OAuth 2.0 has no standard end-session endpoint, so signing out of an OAuth-established session clears
+> the local session only — the user stays signed in at the provider. See [Logout](logout.md).
+
+### OAuthProviderConfig properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Name` | `string` | Display name shown on the login selection page, and the source of the scheme name. |
+| `Type` | `string` | Provider brand (`GitHub`, `Microsoft`, `Google`, `Apple`, or `Custom`). Picks the logo, and for GitHub also enables [organization and team claims](authorization.md#github-organizations-and-teams). |
+| `AuthorizationEndpoint` | `string` | The OAuth 2.0 authorization endpoint URL. |
+| `TokenEndpoint` | `string` | The OAuth 2.0 token endpoint URL. |
+| `UserInformationEndpoint` | `string` | The user-information (profile) API endpoint URL. |
+| `ClientId` | `string` | OAuth 2.0 client ID. |
+| `ClientSecret` | `string` | OAuth 2.0 client secret. |
+| `Scopes` | `string[]` | Scopes to request. Adding `read:org` to a GitHub provider also adds organization and team claims to the session. |
+| `ClaimMappings` | `object` | Claim type → user-info JSON field name. |
+
+Configuring a provider decides *who can sign in*, which on a public provider is everybody. To decide who
+may then get through, see [Authorization](authorization.md).
+
+---
+
 ## Session lifetime and re-validation
 
 Interactive browser sessions are cookie-based, and every cookie AuthProxy issues for identity or tenant

--- a/Documentation/configuration/authorization.md
+++ b/Documentation/configuration/authorization.md
@@ -1,0 +1,328 @@
+# Authorization
+
+Authentication tells you *who* is knocking. On a public host that is not the same as deciding whether they
+may come in.
+
+Put AuthProxy on the internet with GitHub sign-in and the sign-in works — for everybody. Every GitHub
+account on earth is a real, verified identity, so every one of them completes the handshake and lands on
+your application. The application is now responsible for turning away people it has never heard of, on
+every endpoint, forever, and the first mistake is a stranger inside.
+
+`Cratis:AuthProxy:Authorization` makes the proxy the **first gate**: an authenticated caller who does not
+carry what you require never reaches a service at all.
+
+It is off unless you turn it on. Declare nothing and AuthProxy behaves exactly as it always has.
+
+---
+
+## Declaring a requirement
+
+A requirement names a claim, and optionally the values you accept:
+
+```json
+{
+  "Cratis": {
+    "AuthProxy": {
+      "Authorization": {
+        "RequiredClaims": [
+          { "Claim": "urn:github:organization", "AnyOf": [ "Cratis" ] }
+        ]
+      }
+    }
+  }
+}
+```
+
+An authenticated caller carrying `urn:github:organization` with the value `Cratis` gets through. Anyone
+else — signed in or not, and no matter which provider signed them in — is answered with the
+[not-authorized page](#what-a-refused-caller-sees) and goes no further.
+
+Leave `AnyOf` out to require only that the claim is **present**:
+
+```json
+{ "Claim": "urn:example:entitlement" }
+```
+
+That is the right shape when the identity provider already emits the claim only for the people who should
+get in, and enumerating the acceptable values in the proxy would mean restating — and then maintaining — a
+decision the provider has already made.
+
+Values are compared **case-insensitively**, and surrounding whitespace is trimmed. Organization names, team
+slugs and role names are case-insensitive in the systems they come from, and `Cratis` versus `cratis` is not
+a distinction worth locking a deployment out over.
+
+---
+
+## All of the claims, any of the values
+
+Two axes, and they compose in opposite directions. Say them out loud before you write them:
+
+| | Means | Reads as |
+|---|---|---|
+| Several entries in `RequiredClaims` | **All** must be satisfied | *and* |
+| Several values in one entry's `AnyOf` | **Any one** satisfies it | *or* |
+
+So "in the `Cratis` organization **and** on the `planner` team" is two entries:
+
+```json
+"RequiredClaims": [
+  { "Claim": "urn:github:organization", "AnyOf": [ "Cratis" ] },
+  { "Claim": "urn:github:team", "AnyOf": [ "Cratis/planner" ] }
+]
+```
+
+…while "on **either** of these two teams" is one entry with two values:
+
+```json
+"RequiredClaims": [
+  { "Claim": "urn:github:team", "AnyOf": [ "Cratis/planner", "Cratis/operations" ] }
+]
+```
+
+The distinction matters because the wrong reading fails in the dangerous direction. If entries were an
+*or*, adding a team requirement next to an organization requirement would **widen** access — to anyone in
+the organization *or* on that team in any organization — which is the opposite of what you meant by adding
+it.
+
+> [!IMPORTANT]
+> A requirement whose `Claim` is blank refuses to start. It could never be satisfied, so applying it
+> would refuse every caller, and dropping it would silently leave the gate open. AuthProxy fails at
+> startup instead, naming the exact configuration key — which is the one moment somebody is watching.
+
+---
+
+## Narrowing one service
+
+The same section on a service applies to requests routed to that service, **in addition to** whatever the
+root requires:
+
+```json
+{
+  "Cratis": {
+    "AuthProxy": {
+      "Authorization": {
+        "RequiredClaims": [
+          { "Claim": "urn:github:organization", "AnyOf": [ "Cratis" ] }
+        ]
+      },
+      "Services": {
+        "portal": {
+          "Frontend": { "BaseUrl": "http://portal-web:3000/" },
+          "Backend": { "BaseUrl": "http://portal:8080/" }
+        },
+        "admin": {
+          "Frontend": { "BaseUrl": "http://admin-web:3000/" },
+          "Authorization": {
+            "RequiredClaims": [
+              { "Claim": "urn:github:team", "AnyOf": [ "Cratis/operations" ] }
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Everyone reaching either service is in the `Cratis` organization; only the operations team reaches `admin`.
+
+A service can therefore **narrow** who reaches it, never widen it. The alternative — a service section
+replacing the root's — would turn the root into a default rather than a floor, so a section written to add
+an extra check would quietly drop the organization check, and a service added later with no section at all
+would be the way in.
+
+Which service a request targets is worked out the same way the [route table](services.md) works it out: the
+single configured service when there is only one, otherwise the `Service-ID` header or the `service` query
+parameter. A request in a multi-service deployment that names neither reaches no service route either, so
+only the root requirements apply to it.
+
+---
+
+## GitHub organizations and teams
+
+This is the case the feature was built for, and it needs one extra thing.
+
+GitHub's user endpoint — `https://api.github.com/user`, the one you configure as
+`UserInformationEndpoint` — returns a profile and **nothing about membership**. There is no organization
+field to map to a claim, so no amount of `ClaimMappings` produces one. Membership lives behind
+`/user/orgs` and `/user/teams`, and reading those requires the `read:org` scope.
+
+**Ask for `read:org` and AuthProxy fetches it for you**, once, while the sign-in completes, and adds it to
+the session as claims:
+
+| Claim | Value | Example |
+|-------|-------|---------|
+| `urn:github:organization` | The organization's GitHub login | `Cratis` |
+| `urn:github:team` | `organization/team-slug` | `Cratis/planner` |
+
+One claim per organization and one per team. The team slug is the name in the team's URL —
+`github.com/orgs/Cratis/teams/planner` is the slug `planner`. It is qualified by its organization because
+a slug is only unique within one: two organizations may both have a `developers` team, and an unqualified
+claim would let membership of either satisfy a requirement written for one.
+
+The scope **is** the opt-in. There is no second switch to forget, and no way for the two to disagree.
+Without `read:org` nothing extra is requested, no extra call is made, and sign-in is exactly what it was.
+
+Here is a complete configuration restricting a host to the `planner` team in the `Cratis` organization:
+
+```json
+{
+  "Cratis": {
+    "AuthProxy": {
+      "Authentication": {
+        "OAuthProviders": [
+          {
+            "Name": "GitHub",
+            "Type": "GitHub",
+            "AuthorizationEndpoint": "https://github.com/login/oauth/authorize",
+            "TokenEndpoint": "https://github.com/login/oauth/access_token",
+            "UserInformationEndpoint": "https://api.github.com/user",
+            "ClientId": "<client-id>",
+            "ClientSecret": "<client-secret>",
+            "Scopes": [ "read:user", "user:email", "read:org" ],
+            "ClaimMappings": {
+              "sub": "id",
+              "name": "name",
+              "preferred_username": "login",
+              "email": "email"
+            }
+          }
+        ]
+      },
+      "Authorization": {
+        "RequiredClaims": [
+          { "Claim": "urn:github:organization", "AnyOf": [ "Cratis" ] },
+          { "Claim": "urn:github:team", "AnyOf": [ "Cratis/planner" ] }
+        ]
+      }
+    }
+  }
+}
+```
+
+A few things worth knowing before you deploy it:
+
+- **The claims are added at sign-in, not per request.** They live in the authentication cookie, so
+  membership revoked at GitHub takes effect when the session ends — bound by
+  `Cratis:AuthProxy:Session:Lifetime`, twelve hours by default. Shorten it if you need revocation to bite
+  sooner.
+- **The application gets them too.** They travel on the forwarded `x-ms-client-principal` header like every
+  other claim, so your service can read organization and team membership without ever calling GitHub.
+- **A failed read never breaks the sign-in.** If GitHub is unreachable, or the token lacks the scope, the
+  claims are simply absent — which the gate then refuses, with an explanation. That is the closed
+  direction, reached gently.
+- **Membership is read in pages of 100, up to five pages.** Well past any plausible allow-list, and the
+  bound keeps a sign-in someone is waiting on from turning into an unbounded crawl.
+- **`Type` must be `GitHub`.** It is what selects the logo on the provider-selection page, and what tells
+  AuthProxy these endpoints are GitHub's.
+
+GitHub Enterprise works without further configuration: the membership endpoints are derived from whatever
+`UserInformationEndpoint` you configured, so `https://github.example.com/api/v3/user` resolves its own
+`/user/orgs` and `/user/teams`.
+
+---
+
+## What a refused caller sees
+
+The [`not-authorized.html`](well-known-pages.md) page, at `403`, with a **Sign out** link.
+
+Both halves are deliberate. A redirect back to the identity provider — the reflex for "not allowed" — is
+wrong here: the caller *is* signed in, so they would sign in again as the same person and loop forever. And
+`403` is a status a `fetch()` or a command-line client can act on, so browsers and non-browsers get the same
+honest answer.
+
+The sign-out link matters because it is the only way forward. Someone who signed in with a personal account
+by mistake is otherwise stuck looking at a page that will not change. Override the page — brand it, tell
+people who to ask for access — by mounting a pages directory; see [Well-Known Pages](well-known-pages.md).
+
+Every refusal is logged at warning level with the claim that was not satisfied and the path that was
+requested. The claim **type** only — never the value the caller carried, which would put an identity in the
+log to record that it was turned away.
+
+---
+
+## What is never gated
+
+Three things pass through untouched, and each for a reason worth knowing:
+
+- **Callers with no session.** They are refused — or sent to sign in — by the machinery that already does
+  that. This gate is about who a signed-in caller *is*, not whether there is one.
+- **The authentication endpoints themselves** — `/.cratis/providers`, `/.cratis/login/{scheme}`, the
+  provider callbacks, `/.cratis/logout` and the `/_pages` assets. Gating the only route to acquiring the
+  claims on already having them is a door locked from the inside.
+- **Paths a service declares in [`AnonymousPaths`](public-surfaces.md).** This is the one that surprises
+  people, so be clear about it: a declared path exists precisely for callers with **no session** — a
+  webhook receiver, a magic-link landing page — and a caller with no session carries no claims to satisfy
+  anything with. Gating them would refuse every one of them, and a payment provider posting a webhook would
+  get a `403` it can do nothing about. A declared anonymous path is public; requiring a claim somewhere else
+  does not quietly un-declare it.
+
+> [!NOTE]
+> That last point cuts both ways. If a path is declared anonymous, this gate will not protect it — so
+> declare the narrowest prefix that works, and let the application authorize what it serves there.
+
+---
+
+## Environment variables
+
+Everything above is settable purely through environment variables, which is how AuthProxy is normally
+deployed. Array entries are indexed:
+
+```bash
+Cratis__AuthProxy__Authorization__RequiredClaims__0__Claim=urn:github:organization
+Cratis__AuthProxy__Authorization__RequiredClaims__0__AnyOf__0=Cratis
+Cratis__AuthProxy__Authorization__RequiredClaims__1__Claim=urn:github:team
+Cratis__AuthProxy__Authorization__RequiredClaims__1__AnyOf__0=Cratis/planner
+```
+
+Per service, the same list moves under the service key:
+
+```bash
+Cratis__AuthProxy__Services__admin__Authorization__RequiredClaims__0__Claim=urn:github:team
+Cratis__AuthProxy__Services__admin__Authorization__RequiredClaims__0__AnyOf__0=Cratis/operations
+```
+
+Indices must start at `0` and not skip — a gap truncates the list where the gap is, silently dropping every
+requirement after it.
+
+From a .NET Aspire app host, the same thing is expressed as builder calls:
+
+```csharp
+builder.AddAuthProxy("authproxy")
+    .WithRequiredClaim("urn:github:organization", "Cratis")
+    .WithRequiredClaim("urn:github:team", "Cratis/planner")
+    .WithRequiredClaimForService("admin", "urn:github:team", "Cratis/operations");
+```
+
+Repeated calls append, so requirements can be declared wherever they belong in the app host rather than all
+in one place.
+
+---
+
+## Settings reference
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Authorization.RequiredClaims` | `ClaimRequirement[]` | Requirements every authenticated caller must satisfy. **All** of them must hold. Empty (the default) authorizes nobody away — the proxy authenticates without authorizing. |
+| `Authorization.RequiredClaims[].Claim` | `string` | The claim type the caller must carry. Blank fails startup. |
+| `Authorization.RequiredClaims[].AnyOf` | `string[]` | Values that satisfy the requirement, compared case-insensitively. Empty requires only that the claim is present. |
+| `Services.<key>.Authorization` | `Authorization` | The same shape, applied to requests routed to that service **in addition to** the root's. |
+
+---
+
+## Checking it works
+
+Sign in with an account that qualifies and one that does not. The second should land on the not-authorized
+page at `403`, and nothing should reach your backend — no request, and no `/.cratis/me` identity call
+either, because the refusal happens before both.
+
+If a qualifying account is also refused, the requirement and the claim disagree. Read the warning in the
+proxy's log: it names the claim that was not satisfied. For GitHub, the usual causes are the `read:org`
+scope missing from `Scopes`, a team named by its display name rather than its URL slug, or a team written
+without its `organization/` prefix.
+
+If *nobody* is refused, no requirement bound at all. Check the indices in the environment variables — a
+skipped index truncates the list.
+
+Next: [Public Application Surfaces](public-surfaces.md) for the paths this gate deliberately leaves open,
+and [Authentication](authentication.md) for the providers it gates.

--- a/Documentation/configuration/index.md
+++ b/Documentation/configuration/index.md
@@ -8,6 +8,7 @@ Cratis AuthProxy is configured entirely through the `Cratis:AuthProxy` section o
   "Cratis": {
     "AuthProxy": {
       "Authentication": { ... },
+      "Authorization": { ... },
       "TenantResolutions": [ ... ],
       "TenantVerification": { ... },
       "Tenants": { ... },
@@ -22,7 +23,8 @@ Cratis AuthProxy is configured entirely through the `Cratis:AuthProxy` section o
 
 | Topic | Description |
 |-------|-------------|
-| [Authentication](authentication.md) | OIDC providers and JWT Bearer configuration. |
+| [Authentication](authentication.md) | OIDC providers, OAuth 2.0 providers such as GitHub, and JWT Bearer configuration. |
+| [Authorization](authorization.md) | Requiring a claim — a role, a group, a GitHub organization or team — before any request is forwarded. |
 | [Tenancy](tenancy.md) | How the auth proxy resolves the current tenant from each request, and how to verify tenant existence. |
 | [Tenant Selection Page](tenant-selection.md) | How selection-based tenant resolution works and how to build/override `select-tenant.html`. |
 | [Services](services.md) | Routing requests to backend and frontend services. |

--- a/Documentation/configuration/toc.yml
+++ b/Documentation/configuration/toc.yml
@@ -2,6 +2,8 @@
   href: index.md
 - name: Authentication
   href: authentication.md
+- name: Authorization
+  href: authorization.md
 - name: Unauthenticated Responses
   href: unauthenticated-responses.md
 - name: Tenancy

--- a/Documentation/configuration/well-known-pages.md
+++ b/Documentation/configuration/well-known-pages.md
@@ -15,6 +15,7 @@ condition is detected:
 |-----------|-----------|-------------|
 | `404.html` | The requested resource was not found. | 404 |
 | `403.html` | The identity resolver denied access. | 403 |
+| `not-authorized.html` | The caller is signed in but does not satisfy the claim requirements declared in [`Cratis:AuthProxy:Authorization`](authorization.md). | 403 |
 | `tenant-not-found.html` | The resolved tenant does not exist in the platform (see [Tenant verification](tenancy.md#tenant-verification)). | 404 |
 | `select-provider.html` | A protected resource was requested and multiple identity providers are configured. The page reads the `.cratis-providers` cookie to render a sign-in button for each available provider. | 200 |
 | `select-tenant.html` | Tenant selection is enabled and the authenticated user has not selected a tenant yet. The page reads the `.cratis-tenants` cookie to render selectable tenants. | 200 |
@@ -129,3 +130,23 @@ claim.
 `tenant-not-found.html` is served when tenant verification is enabled and the platform reports
 that the resolved tenant ID does not exist. See [Tenant verification](tenancy.md#tenant-verification)
 for how to configure the verification endpoint.
+
+---
+
+## Not authorized
+
+`not-authorized.html` is served when [first-gate authorization](authorization.md) is configured and an
+authenticated caller does not satisfy a required claim — a GitHub organization they do not belong to, a
+role they do not hold. It is distinct from `403.html`, which answers the *application* refusing a caller it
+does recognize; this one is the proxy refusing before the application is reached at all.
+
+If you override it, **keep a way to sign out**. It is the only refusal whose remedy is to come back as
+somebody else, and someone who signed in with the wrong account is otherwise stuck looking at a page that
+will not change. The built-in page links to `/.cratis/logout?redirect=/`:
+
+```html
+<a href="/.cratis/logout?redirect=/">Sign out</a>
+```
+
+This is a good page to brand and to make specific — "ask #it-support for access to the planner" is far more
+useful to the person reading it than "not authorized".

--- a/Documentation/index.mdx
+++ b/Documentation/index.mdx
@@ -43,6 +43,9 @@ AuthProxy is a plain ASP.NET Core service. It pairs naturally with [Arc](/arc/)'
   <SimpleCard title="Authentication" icon="seti:lock" link="/authproxy/configuration/authentication/">
     OpenID Connect and OAuth 2.0 (single or multi-provider), plus JWT Bearer. Unauthenticated requests are challenged or sent to a provider-selection page.
   </SimpleCard>
+  <SimpleCard title="Authorization" icon="seti:lock" link="/authproxy/configuration/authorization/">
+    Require a claim — a role, a group, a GitHub organization or team — before any request is forwarded. Authenticating everyone is not the same as letting everyone in.
+  </SimpleCard>
   <SimpleCard title="Identity enrichment" icon="seti:json" link="/authproxy/configuration/services/#identity-enrichment">
     Calls a <code>/.cratis/me</code> endpoint on your service and attaches the enriched identity to forwarded requests as a trusted header.
   </SimpleCard>

--- a/Source/Aspire.Specs/for_AuthProxyExtensions/when_requiring_claims/and_they_are_required_of_every_service.cs
+++ b/Source/Aspire.Specs/for_AuthProxyExtensions/when_requiring_claims/and_they_are_required_of_every_service.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Aspire.for_AuthProxyExtensions.when_requiring_claims;
+
+/// <summary>
+/// Proxy-wide requirements reach the proxy as the indexed environment variables its configuration binds.
+/// <para>
+/// The key shape is the contract between the app host and the proxy, and it is the one thing about this
+/// feature that fails silently: a wrong prefix, separator or index binds nothing, and a proxy that
+/// requires nothing looks exactly like a proxy that is working. The symptom would be an account that
+/// should have been refused quietly getting in.
+/// </para>
+/// <para>
+/// Repeated calls append rather than restart at zero — the indices are positions in a configuration array,
+/// so a second call that overwrote the first would drop a requirement while the app host still read as
+/// though both were declared.
+/// </para>
+/// </summary>
+public class and_they_are_required_of_every_service : given.an_auth_proxy_resource
+{
+    Dictionary<string, string> _environment;
+
+    void Establish()
+    {
+        _resource.WithRequiredClaim("urn:github:organization", "Cratis");
+        _resource.WithRequiredClaim("urn:github:team", "Cratis/planner", "Cratis/operations");
+    }
+
+    async Task Because() => _environment = await EnvironmentVariables();
+
+    [Fact] void should_write_the_first_claim_at_the_first_index() => _environment["Cratis__AuthProxy__Authorization__RequiredClaims__0__Claim"].ShouldEqual("urn:github:organization");
+    [Fact] void should_write_its_only_value() => _environment["Cratis__AuthProxy__Authorization__RequiredClaims__0__AnyOf__0"].ShouldEqual("Cratis");
+    [Fact] void should_append_the_second_claim_rather_than_overwrite_the_first() => _environment["Cratis__AuthProxy__Authorization__RequiredClaims__1__Claim"].ShouldEqual("urn:github:team");
+    [Fact] void should_write_each_of_its_values() => _environment["Cratis__AuthProxy__Authorization__RequiredClaims__1__AnyOf__1"].ShouldEqual("Cratis/operations");
+}

--- a/Source/Aspire.Specs/for_AuthProxyExtensions/when_requiring_claims/and_they_are_required_of_one_service.cs
+++ b/Source/Aspire.Specs/for_AuthProxyExtensions/when_requiring_claims/and_they_are_required_of_one_service.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Aspire.for_AuthProxyExtensions.when_requiring_claims;
+
+/// <summary>
+/// A requirement scoped to a service is written under that service, and numbered per service.
+/// <para>
+/// Numbering that continued across services would put one service's requirement at another's index, which
+/// binds as a requirement on the wrong traffic — an admin surface left open while an unrelated service
+/// demands a claim nobody has. Requiring the same claim of everything and of one service at once has to
+/// stay two independent sequences.
+/// </para>
+/// </summary>
+public class and_they_are_required_of_one_service : given.an_auth_proxy_resource
+{
+    Dictionary<string, string> _environment;
+
+    void Establish()
+    {
+        _resource.WithRequiredClaim("urn:github:organization", "Cratis");
+        _resource.WithRequiredClaimForService("admin", "urn:github:team", "Cratis/operations");
+        _resource.WithRequiredClaimForService("admin", "urn:example:mfa");
+        _resource.WithRequiredClaimForService("portal", "urn:github:team", "Cratis/support");
+    }
+
+    async Task Because() => _environment = await EnvironmentVariables();
+
+    [Fact] void should_write_the_service_requirement_under_that_service() => _environment["Cratis__AuthProxy__Services__admin__Authorization__RequiredClaims__0__Claim"].ShouldEqual("urn:github:team");
+    [Fact] void should_append_within_the_same_service() => _environment["Cratis__AuthProxy__Services__admin__Authorization__RequiredClaims__1__Claim"].ShouldEqual("urn:example:mfa");
+    [Fact] void should_number_each_service_independently() => _environment["Cratis__AuthProxy__Services__portal__Authorization__RequiredClaims__0__AnyOf__0"].ShouldEqual("Cratis/support");
+    [Fact] void should_keep_the_proxy_wide_requirement_at_its_own_index() => _environment["Cratis__AuthProxy__Authorization__RequiredClaims__0__Claim"].ShouldEqual("urn:github:organization");
+    [Fact] void should_write_no_values_for_a_presence_only_requirement() => _environment.Keys.ShouldNotContain("Cratis__AuthProxy__Services__admin__Authorization__RequiredClaims__1__AnyOf__0");
+}

--- a/Source/Aspire/AuthProxyConfigAnnotation.cs
+++ b/Source/Aspire/AuthProxyConfigAnnotation.cs
@@ -21,9 +21,18 @@ sealed class AuthProxyConfigAnnotation : IResourceAnnotation
     /// <summary>Gets or sets the number of invite claim-forwarding entries that have been registered.</summary>
     public int InviteClaimForwardingCount { get; set; }
 
+    /// <summary>Gets or sets the number of proxy-wide claim requirements that have been registered.</summary>
+    public int RequiredClaimCount { get; set; }
+
     /// <summary>
     /// Gets the number of anonymous paths registered per service key, so that repeated calls append
     /// rather than overwrite the indices an earlier call already wrote.
     /// </summary>
     public Dictionary<string, int> AnonymousPathCounts { get; } = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Gets the number of claim requirements registered per service key, so that repeated calls append
+    /// rather than overwrite the indices an earlier call already wrote.
+    /// </summary>
+    public Dictionary<string, int> ServiceRequiredClaimCounts { get; } = new(StringComparer.Ordinal);
 }

--- a/Source/Aspire/AuthProxyExtensions.cs
+++ b/Source/Aspire/AuthProxyExtensions.cs
@@ -145,6 +145,78 @@ public static class AuthProxyExtensions
     }
 
     /// <summary>
+    /// Requires every authenticated caller to carry a claim before any request is forwarded.
+    /// </summary>
+    /// <typeparam name="T">The resource type (must support environment variables).</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="claim">
+    /// The claim type the caller must carry, for example <c>urn:github:organization</c> or <c>roles</c>.
+    /// </param>
+    /// <param name="anyOf">
+    /// The values that satisfy it. Pass none to require only that the claim is present. Values are
+    /// compared case-insensitively.
+    /// </param>
+    /// <returns>The same <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    /// <remarks>
+    /// Authentication establishes who a caller is; on a public host that is not the same as deciding
+    /// whether they may be here. Without a requirement, any account the configured identity provider will
+    /// authenticate — for a public provider such as GitHub, every account on the internet — completes
+    /// sign-in and reaches the application.
+    /// <para>
+    /// Calling this more than once requires <em>all</em> of the claims: several calls compose as an
+    /// <em>and</em>, while several values in one call compose as an <em>or</em>. Express "in this
+    /// organization and on this team" as two calls, and "in either organization" as one call with two
+    /// values.
+    /// </para>
+    /// </remarks>
+    public static IResourceBuilder<T> WithRequiredClaim<T>(
+        this IResourceBuilder<T> builder,
+        string claim,
+        params string[] anyOf)
+        where T : IResourceWithEnvironment
+    {
+        var annotation = GetOrCreateAnnotation(builder.Resource);
+        var index = annotation.RequiredClaimCount++;
+
+        return WriteClaimRequirement(builder, $"{ConfigPrefix}__Authorization__RequiredClaims__{index}", claim, anyOf);
+    }
+
+    /// <summary>
+    /// Requires every authenticated caller reaching a named service to carry a claim.
+    /// </summary>
+    /// <typeparam name="T">The resource type (must support environment variables).</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="serviceName">
+    /// The service key used in the AuthProxy <c>Services</c> configuration (e.g. <c>"main"</c>).
+    /// </param>
+    /// <param name="claim">The claim type the caller must carry.</param>
+    /// <param name="anyOf">
+    /// The values that satisfy it. Pass none to require only that the claim is present.
+    /// </param>
+    /// <returns>The same <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    /// <remarks>
+    /// Applied in addition to anything <see cref="WithRequiredClaim{T}"/> declares, so a service can narrow
+    /// who reaches it but never widen it.
+    /// </remarks>
+    public static IResourceBuilder<T> WithRequiredClaimForService<T>(
+        this IResourceBuilder<T> builder,
+        string serviceName,
+        string claim,
+        params string[] anyOf)
+        where T : IResourceWithEnvironment
+    {
+        var annotation = GetOrCreateAnnotation(builder.Resource);
+        annotation.ServiceRequiredClaimCounts.TryGetValue(serviceName, out var index);
+        annotation.ServiceRequiredClaimCounts[serviceName] = index + 1;
+
+        return WriteClaimRequirement(
+            builder,
+            $"{ConfigPrefix}__Services__{serviceName}__Authorization__RequiredClaims__{index}",
+            claim,
+            anyOf);
+    }
+
+    /// <summary>
     /// Adds an OIDC provider to the AuthProxy authentication configuration.
     /// </summary>
     /// <typeparam name="T">The resource type (must support environment variables).</typeparam>
@@ -730,6 +802,32 @@ public static class AuthProxyExtensions
         var annotation = GetOrCreateAnnotation(builder.Resource);
         var idx = annotation.TenantResolutionCount++;
         return builder.WithEnvironment($"{ConfigPrefix}__TenantResolutions__{idx}__Strategy", strategy);
+    }
+
+    /// <summary>
+    /// Writes one claim requirement at the given configuration prefix.
+    /// </summary>
+    /// <typeparam name="T">The resource type (must support environment variables).</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="prefix">The indexed configuration prefix to write under.</param>
+    /// <param name="claim">The claim type the caller must carry.</param>
+    /// <param name="anyOf">The values that satisfy it.</param>
+    /// <returns>The same <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    static IResourceBuilder<T> WriteClaimRequirement<T>(
+        IResourceBuilder<T> builder,
+        string prefix,
+        string claim,
+        string[] anyOf)
+        where T : IResourceWithEnvironment
+    {
+        builder.WithEnvironment($"{prefix}__Claim", claim);
+
+        for (var i = 0; i < anyOf.Length; i++)
+        {
+            builder.WithEnvironment($"{prefix}__AnyOf__{i}", anyOf[i]);
+        }
+
+        return builder;
     }
 
     static AuthProxyConfigAnnotation GetOrCreateAnnotation(IResource resource)

--- a/Source/AuthProxy.Security.Specs/for_AccessControl/when_a_claim_gate_is_configured.cs
+++ b/Source/AuthProxy.Security.Specs/for_AccessControl/when_a_claim_gate_is_configured.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Security.for_AccessControl;
+
+/// <summary>
+/// OWASP A01 — Broken Access Control. A deployment that declares a required claim must actually refuse the
+/// callers that lack it, and must refuse them before anything behind the proxy is touched.
+/// <para>
+/// This is the whole reason first-gate authorization exists. AuthProxy authenticates against providers
+/// that will happily verify anyone — a public GitHub account is a real, verified identity — so on a public
+/// host "signed in" and "allowed" are not the same statement, and a proxy that only makes the first one
+/// admits the internet.
+/// </para>
+/// <para>
+/// Asserted against a real origin rather than on the client-facing status, because the status is the part
+/// that is easy to get right. The refusal is only worth anything if nothing reached the backend: the
+/// request itself, obviously, but also the proxy's own <c>/.cratis/me</c> identity call, which runs later
+/// in the pipeline and would otherwise mean a refused caller still caused work — and a log entry — inside
+/// the application.
+/// </para>
+/// </summary>
+/// <param name="harness">The running claim-gated proxy and its origin.</param>
+[Collection(ClaimGateSpecCollection.Name)]
+public class when_a_claim_gate_is_configured(ClaimGatedHarness harness) : IAsyncLifetime
+{
+    HttpResponseMessage? _unqualified;
+    string _unqualifiedBody = string.Empty;
+    bool _originSawTheUnqualifiedCaller;
+
+    HttpResponseMessage? _qualified;
+    bool _originSawTheQualifiedCaller;
+
+    HttpResponseMessage? _anonymousOnAnonymousPath;
+    bool _originSawTheAnonymousCaller;
+
+    HttpResponseMessage? _unqualifiedOnAnonymousPath;
+    bool _originSawTheUnqualifiedCallerOnTheAnonymousPath;
+
+    public async Task InitializeAsync()
+    {
+        using var client = harness.CreateSecurityClient();
+
+        harness.Origin.Clear();
+        _unqualified = await client.SendAsync(ClaimGatedHarness.Unqualified(ClaimGatedHarness.ProtectedPath));
+        _unqualifiedBody = await _unqualified.Content.ReadAsStringAsync();
+        _originSawTheUnqualifiedCaller = !harness.Origin.Received.IsEmpty;
+
+        harness.Origin.Clear();
+        _qualified = await client.SendAsync(ClaimGatedHarness.Qualified(ClaimGatedHarness.ProtectedPath));
+        _originSawTheQualifiedCaller = harness.Origin.ReceivedAnythingFor(ClaimGatedHarness.ProtectedPath);
+
+        harness.Origin.Clear();
+        _anonymousOnAnonymousPath = await client.SendAsync(SecurityHarness.Anonymous(HttpMethod.Get, ClaimGatedHarness.AnonymousPath));
+        _originSawTheAnonymousCaller = harness.Origin.ReceivedAnythingFor(ClaimGatedHarness.AnonymousPath);
+
+        harness.Origin.Clear();
+        _unqualifiedOnAnonymousPath = await client.SendAsync(ClaimGatedHarness.Unqualified(ClaimGatedHarness.AnonymousPath));
+        _originSawTheUnqualifiedCallerOnTheAnonymousPath = harness.Origin.ReceivedAnythingFor(ClaimGatedHarness.AnonymousPath);
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public void should_refuse_an_authenticated_caller_without_the_required_claim() =>
+        Assert.Equal(HttpStatusCode.Forbidden, _unqualified!.StatusCode);
+
+    [Fact]
+    public void should_explain_the_refusal_with_the_not_authorized_page() =>
+        Assert.Contains(ClaimGatedHarness.NotAuthorizedMarker, _unqualifiedBody, StringComparison.Ordinal);
+
+    [Fact]
+    public void should_offer_the_refused_caller_a_way_to_sign_out() =>
+        Assert.Contains(WellKnownPaths.Logout, _unqualifiedBody, StringComparison.Ordinal);
+
+    [Fact]
+    public void should_not_redirect_the_refused_caller_back_into_a_sign_in_loop() =>
+        Assert.False(_unqualified!.Headers.Location is not null);
+
+    [Fact]
+    public void should_let_nothing_at_all_reach_the_origin_for_a_refused_caller() =>
+        Assert.False(_originSawTheUnqualifiedCaller);
+
+    [Fact]
+    public void should_forward_an_authenticated_caller_carrying_the_required_claim() =>
+        Assert.Equal(HttpStatusCode.OK, _qualified!.StatusCode);
+
+    [Fact]
+    public void should_let_the_qualified_caller_reach_the_origin() =>
+        Assert.True(_originSawTheQualifiedCaller);
+
+    [Fact]
+    public void should_not_gate_a_declared_anonymous_path_for_a_caller_with_no_session() =>
+        Assert.True(_originSawTheAnonymousCaller);
+
+    [Fact]
+    public void should_answer_the_anonymous_path_from_the_origin() =>
+        Assert.Equal(HttpStatusCode.OK, _anonymousOnAnonymousPath!.StatusCode);
+
+    [Fact]
+    public void should_not_gate_a_declared_anonymous_path_for_a_signed_in_caller_who_lacks_the_claim() =>
+        Assert.True(_originSawTheUnqualifiedCallerOnTheAnonymousPath);
+
+    [Fact]
+    public void should_answer_the_anonymous_path_for_that_caller_too() =>
+        Assert.Equal(HttpStatusCode.OK, _unqualifiedOnAnonymousPath!.StatusCode);
+}

--- a/Source/AuthProxy.Security.Specs/given/ClaimGateSpecCollection.cs
+++ b/Source/AuthProxy.Security.Specs/given/ClaimGateSpecCollection.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Security.given;
+
+/// <summary>
+/// Runs the claim-gated specs against one shared proxy and origin, in sequence.
+/// </summary>
+/// <remarks>
+/// Separate from <see cref="SecuritySpecCollection"/> because it is a different deployment, with its own
+/// origin recording its own traffic. Serialized for the same reason that one is: two specs reading one
+/// recorder would read each other's requests.
+/// </remarks>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public class ClaimGateSpecCollection : ICollectionFixture<ClaimGatedHarness>
+{
+    /// <summary>The collection name every claim-gated spec joins.</summary>
+    public const string Name = "ClaimGate";
+}

--- a/Source/AuthProxy.Security.Specs/given/ClaimGatedHarness.cs
+++ b/Source/AuthProxy.Security.Specs/given/ClaimGatedHarness.cs
@@ -1,0 +1,155 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.AuthProxy.Security.given;
+
+/// <summary>
+/// A running AuthProxy that requires a claim of everyone before forwarding anything, in front of a real
+/// recording origin.
+/// </summary>
+/// <remarks>
+/// A second harness rather than a setting on the shared one, because the shared one is the deployment
+/// every other security spec reasons about — "authenticated is enough" — and gating it would change the
+/// premise of all of them. The question here is different: given that a deployment does gate, what still
+/// gets through.
+/// <para>
+/// It is deliberately end to end. The unit specs establish what the policy decides; only a running proxy
+/// establishes that the decision is on the request path at all — ahead of tenancy, of the identity call to
+/// the backend, and of the reverse proxy. A middleware that was never wired in would pass every unit spec
+/// and gate nothing.
+/// </para>
+/// </remarks>
+public class ClaimGatedHarness : WebApplicationFactory<Program>
+{
+    /// <summary>The claim this deployment requires.</summary>
+    public const string RequiredClaim = "urn:github:organization";
+
+    /// <summary>The one value of that claim this deployment accepts.</summary>
+    public const string RequiredValue = "Cratis";
+
+    /// <summary>The tenant every request resolves to.</summary>
+    public const string TenantId = "22222222-2222-2222-2222-222222222222";
+
+    /// <summary>The one path this deployment declares anonymous.</summary>
+    public const string AnonymousPath = "/public";
+
+    /// <summary>A path that is not anonymous and therefore passes the gate.</summary>
+    public const string ProtectedPath = "/private";
+
+    /// <summary>The body of the page a refused caller is served, so a spec can recognize it.</summary>
+    public const string NotAuthorizedMarker = "not-authorized-page";
+
+    readonly string _pagesPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ClaimGatedHarness"/> class.
+    /// </summary>
+    public ClaimGatedHarness()
+    {
+        Directory.CreateDirectory(_pagesPath);
+        File.WriteAllText(Path.Combine(_pagesPath, WellKnownPageNames.SelectProvider), "<html><body>Select Provider</body></html>");
+        File.WriteAllText(
+            Path.Combine(_pagesPath, WellKnownPageNames.NotAuthorized),
+            $"<html><body>{NotAuthorizedMarker}<a href=\"{WellKnownPaths.Logout}?redirect=/\">Sign out</a></body></html>");
+
+        Origin = RecordingBackend.Start().GetAwaiter().GetResult();
+    }
+
+    /// <summary>
+    /// Gets the origin AuthProxy forwards to, and the record of what reached it.
+    /// </summary>
+    public RecordingBackend Origin { get; }
+
+    /// <summary>
+    /// Builds a request from an authenticated caller carrying the required claim.
+    /// </summary>
+    /// <param name="pathAndQuery">The path and query to request.</param>
+    /// <returns>The request.</returns>
+    public static HttpRequestMessage Qualified(string pathAndQuery) =>
+        WithClaims(pathAndQuery, $"{RequiredClaim}={RequiredValue}");
+
+    /// <summary>
+    /// Builds a request from an authenticated caller carrying the claim with an unaccepted value — the
+    /// account that completes sign-in at a public identity provider and should still get nowhere.
+    /// </summary>
+    /// <param name="pathAndQuery">The path and query to request.</param>
+    /// <returns>The request.</returns>
+    public static HttpRequestMessage Unqualified(string pathAndQuery) =>
+        WithClaims(pathAndQuery, $"{RequiredClaim}=some-other-org");
+
+    /// <summary>
+    /// Builds a request from an authenticated caller carrying the given claims.
+    /// </summary>
+    /// <param name="pathAndQuery">The path and query to request.</param>
+    /// <param name="claims">The claims, as <c>type=value</c> pairs separated by semicolons.</param>
+    /// <returns>The request.</returns>
+    public static HttpRequestMessage WithClaims(string pathAndQuery, string claims)
+    {
+        var request = SecurityHarness.Authenticated(HttpMethod.Get, pathAndQuery, SecurityHarness.UniqueUser("claim-gate"));
+        request.Headers.TryAddWithoutValidation(HeaderAuthenticationHandler.ClaimsHeader, claims);
+
+        return request;
+    }
+
+    /// <summary>
+    /// Creates a client that surfaces redirects as responses rather than following them.
+    /// </summary>
+    /// <returns>A configured <see cref="HttpClient"/>.</returns>
+    public HttpClient CreateSecurityClient() =>
+        CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false, HandleCookies = false });
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+
+        if (!disposing)
+        {
+            return;
+        }
+
+        Origin.DisposeAsync().AsTask().GetAwaiter().GetResult();
+
+        if (Directory.Exists(_pagesPath))
+        {
+            Directory.Delete(_pagesPath, recursive: true);
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder
+            .UseEnvironment("Production")
+            .ConfigureAppConfiguration((_, config) => config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"{C.AuthProxy.SectionKey}:Services:app:Backend:BaseUrl"] = Origin.BaseUrl,
+                [$"{C.AuthProxy.SectionKey}:Services:app:Frontend:BaseUrl"] = Origin.BaseUrl,
+                [$"{C.AuthProxy.SectionKey}:Services:app:AnonymousPaths:0"] = AnonymousPath,
+
+                [$"{C.Authorization.SectionKey}:RequiredClaims:0:Claim"] = RequiredClaim,
+                [$"{C.Authorization.SectionKey}:RequiredClaims:0:AnyOf:0"] = RequiredValue,
+
+                [$"{C.AuthProxy.SectionKey}:PagesPath"] = _pagesPath,
+
+                [$"{C.AuthProxy.SectionKey}:TenantResolutions:0:Strategy"] = nameof(C.TenantSourceIdentifierResolverType.Specified),
+                [$"{C.AuthProxy.SectionKey}:TenantResolutions:0:Options:TenantId"] = TenantId,
+
+                [$"{C.Authentication.SectionKey}:OidcProviders:0:Name"] = "Provider One",
+                [$"{C.Authentication.SectionKey}:OidcProviders:0:Authority"] = "https://login.example.test/one",
+                [$"{C.Authentication.SectionKey}:OidcProviders:0:ClientId"] = "client-one",
+            }))
+            .ConfigureTestServices(services => services
+                .AddAuthentication(HeaderAuthenticationHandler.Scheme)
+                .AddScheme<AuthenticationSchemeOptions, HeaderAuthenticationHandler>(
+                    HeaderAuthenticationHandler.Scheme,
+                    _ => { }));
+    }
+}

--- a/Source/AuthProxy.Security.Specs/given/HeaderAuthenticationHandler.cs
+++ b/Source/AuthProxy.Security.Specs/given/HeaderAuthenticationHandler.cs
@@ -31,6 +31,17 @@ public class HeaderAuthenticationHandler(
     /// <summary>The scheme name the harness registers this under.</summary>
     public const string Scheme = "SecuritySpecScheme";
 
+    /// <summary>
+    /// The header a spec sends to give its caller extra claims, as <c>type=value</c> pairs separated by
+    /// semicolons.
+    /// </summary>
+    /// <remarks>
+    /// Everything the first authorization gate decides on is a claim, so a spec asking what a caller can
+    /// reach has to be able to say which claims they carry — including none, which is the interesting one.
+    /// A caller sending no such header is unchanged, so this is invisible to every spec that predates it.
+    /// </remarks>
+    public const string ClaimsHeader = "X-Security-Spec-Claims";
+
     /// <inheritdoc/>
     protected override Task<AuthenticateResult> HandleAuthenticateAsync()
     {
@@ -41,15 +52,30 @@ public class HeaderAuthenticationHandler(
             return Task.FromResult(AuthenticateResult.NoResult());
         }
 
-        var identity = new ClaimsIdentity(
-            [
-                new Claim(ClaimTypes.NameIdentifier, user),
-                new Claim("oid", user),
-                new Claim(ClaimTypes.Name, user),
-            ],
-            Scheme);
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, user),
+            new("oid", user),
+            new(ClaimTypes.Name, user),
+        };
+
+        claims.AddRange(DeclaredClaims());
 
         return Task.FromResult(AuthenticateResult.Success(
-            new AuthenticationTicket(new ClaimsPrincipal(identity), Scheme)));
+            new AuthenticationTicket(new ClaimsPrincipal(new ClaimsIdentity(claims, Scheme)), Scheme)));
+    }
+
+    IEnumerable<Claim> DeclaredClaims()
+    {
+        var declared = Request.Headers[ClaimsHeader].ToString();
+
+        foreach (var pair in declared.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var separator = pair.IndexOf('=', StringComparison.Ordinal);
+            if (separator > 0)
+            {
+                yield return new Claim(pair[..separator], pair[(separator + 1)..]);
+            }
+        }
     }
 }

--- a/Source/AuthProxy.Specs/Authentication/GitHubApi.cs
+++ b/Source/AuthProxy.Specs/Authentication/GitHubApi.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net;
+using System.Text;
+
+namespace Cratis.AuthProxy.Authentication;
+
+/// <summary>
+/// A stand-in for GitHub's REST API that records what was asked of it.
+/// </summary>
+/// <remarks>
+/// Responses are produced per request rather than handed over up front, because a paged read disposes each
+/// response as it goes and asks for the next page from the previous one's <c>Link</c> header — a fixed
+/// response would be read once and disposed before the second page needed it.
+/// </remarks>
+/// <param name="respond">Produces the response for a requested URL.</param>
+class GitHubApi(Func<Uri, HttpResponseMessage> respond) : HttpMessageHandler
+{
+    readonly List<Uri> _requested = [];
+
+    /// <summary>Gets every URL that was requested, in order.</summary>
+    public IReadOnlyList<Uri> Requested => _requested;
+
+    /// <summary>
+    /// Builds a JSON array response, optionally linking a next page.
+    /// </summary>
+    /// <param name="json">The JSON array body.</param>
+    /// <param name="nextPage">The absolute URL of the next page, when there is one.</param>
+    /// <returns>The response.</returns>
+    public static HttpResponseMessage Page(string json, string? nextPage = null)
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        };
+
+        if (nextPage is not null)
+        {
+            response.Headers.TryAddWithoutValidation("Link", $"<{nextPage}>; rel=\"next\", <{nextPage}>; rel=\"last\"");
+        }
+
+        return response;
+    }
+
+    /// <summary>
+    /// Builds a refusal, as GitHub answers a token without the scope to read organization membership.
+    /// </summary>
+    /// <returns>The response.</returns>
+    public static HttpResponseMessage Refused() => new(HttpStatusCode.Forbidden);
+
+    /// <summary>
+    /// Creates the client the enricher reads through.
+    /// </summary>
+    /// <returns>A client backed by this handler.</returns>
+    public HttpClient CreateClient() => new(this, disposeHandler: false);
+
+    /// <inheritdoc/>
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        _requested.Add(request.RequestUri!);
+        return Task.FromResult(respond(request.RequestUri!));
+    }
+}

--- a/Source/AuthProxy.Specs/Authentication/for_GitHubMembershipClaimsEnricher/given/a_github_provider.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_GitHubMembershipClaimsEnricher/given/a_github_provider.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authentication.for_GitHubMembershipClaimsEnricher.given;
+
+/// <summary>
+/// A GitHub OAuth provider configured the way the documentation says to configure it, and an identity for
+/// the enricher to add claims to.
+/// </summary>
+public class a_github_provider : Specification
+{
+    protected GitHubMembershipClaimsEnricher _enricher;
+    protected C.OAuthProvider _provider;
+    protected ClaimsIdentity _identity;
+
+    void Establish()
+    {
+        _enricher = new GitHubMembershipClaimsEnricher(Substitute.For<ILogger<GitHubMembershipClaimsEnricher>>());
+
+        _provider = new C.OAuthProvider
+        {
+            Name = "GitHub",
+            Type = C.OidcProviderType.GitHub,
+            AuthorizationEndpoint = "https://github.com/login/oauth/authorize",
+            TokenEndpoint = "https://github.com/login/oauth/access_token",
+            UserInformationEndpoint = "https://api.github.com/user",
+            ClientId = "client-id",
+            Scopes = ["read:user", "read:org"],
+        };
+
+        _identity = new ClaimsIdentity([new Claim(ClaimTypes.Name, "octocat")], "github");
+    }
+
+    protected IEnumerable<string> ValuesOf(string claimType) =>
+        _identity.FindAll(claimType).Select(_ => _.Value);
+}

--- a/Source/AuthProxy.Specs/Authentication/for_GitHubMembershipClaimsEnricher/when_deciding_whether_a_provider_needs_enriching.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_GitHubMembershipClaimsEnricher/when_deciding_whether_a_provider_needs_enriching.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authentication.for_GitHubMembershipClaimsEnricher;
+
+/// <summary>
+/// The organization-read scope is the opt-in, and it is the only opt-in.
+/// <para>
+/// Tying it to the scope rather than to a separate switch avoids the state where the two disagree — a
+/// switch turned on without the scope produces empty membership and a deployment nobody can sign in to,
+/// while the scope granted without the switch produces claims that were fetched and then not used. GitHub
+/// answers <c>/user/orgs</c> with public memberships only and refuses <c>/user/teams</c> outright without
+/// it, so the scope is not merely correlated with wanting the claims: it is the condition under which they
+/// can be true.
+/// </para>
+/// <para>
+/// It also keeps this off by default and off entirely for everyone else: no scope, no extra request during
+/// sign-in, and a provider that is not GitHub is never considered at all.
+/// </para>
+/// </summary>
+public class when_deciding_whether_a_provider_needs_enriching : given.a_github_provider
+{
+    bool _withReadOrg;
+    bool _withAdminOrg;
+    bool _withDifferentlyCasedScope;
+    bool _withoutAnyOrganizationScope;
+    bool _forAnotherProviderBrand;
+
+    void Because()
+    {
+        _withReadOrg = _enricher.CanEnrich(_provider);
+
+        _provider.Scopes = ["admin:org"];
+        _withAdminOrg = _enricher.CanEnrich(_provider);
+
+        _provider.Scopes = [" Read:Org "];
+        _withDifferentlyCasedScope = _enricher.CanEnrich(_provider);
+
+        _provider.Scopes = ["read:user", "user:email"];
+        _withoutAnyOrganizationScope = _enricher.CanEnrich(_provider);
+
+        _provider.Scopes = ["read:org"];
+        _provider.Type = C.OidcProviderType.Custom;
+        _forAnotherProviderBrand = _enricher.CanEnrich(_provider);
+    }
+
+    [Fact] void should_enrich_when_the_read_scope_is_requested() => _withReadOrg.ShouldBeTrue();
+    [Fact] void should_enrich_when_a_wider_organization_scope_is_requested() => _withAdminOrg.ShouldBeTrue();
+    [Fact] void should_not_care_about_the_casing_or_padding_of_the_scope() => _withDifferentlyCasedScope.ShouldBeTrue();
+    [Fact] void should_stay_out_of_a_sign_in_that_never_asked_for_membership() => _withoutAnyOrganizationScope.ShouldBeFalse();
+    [Fact] void should_stay_out_of_a_provider_that_is_not_github() => _forAnotherProviderBrand.ShouldBeFalse();
+}

--- a/Source/AuthProxy.Specs/Authentication/for_GitHubMembershipClaimsEnricher/when_github_refuses_the_membership_read.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_GitHubMembershipClaimsEnricher/when_github_refuses_the_membership_read.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authentication.for_GitHubMembershipClaimsEnricher;
+
+/// <summary>
+/// A membership read that fails leaves the sign-in intact and the claims absent — which is the closed
+/// direction, not the open one.
+/// <para>
+/// This runs inside the sign-in handshake. Throwing would turn a missing claim into a broken login, and
+/// the person on the other end would see an authentication error for something that has nothing to do with
+/// their credentials. Swallowing it costs nothing, because the outcome of no claims is a caller the gate
+/// refuses with an explanation — the fail-closed direction reached the gentle way.
+/// </para>
+/// <para>
+/// GitHub genuinely answers this way: <c>/user/teams</c> is <c>403</c> for a token without the scope, and
+/// a network fault mid-handshake looks the same.
+/// </para>
+/// </summary>
+public class when_github_refuses_the_membership_read : given.a_github_provider
+{
+    GitHubApi _api;
+    Exception _error;
+
+    void Establish() => _api = new GitHubApi(url => url.AbsolutePath.EndsWith("/orgs", StringComparison.Ordinal)
+        ? GitHubApi.Page("""[{ "login": "Cratis" }]""")
+        : GitHubApi.Refused());
+
+    async Task Because()
+    {
+        using var client = _api.CreateClient();
+        _error = await Catch.Exception(() => _enricher.Enrich(_identity, _provider, client, "access-token", CancellationToken.None));
+    }
+
+    [Fact] void should_not_break_the_sign_in() => _error.ShouldBeNull();
+    [Fact] void should_add_nothing_for_the_read_that_failed() => ValuesOf(GitHubClaimTypes.Team).ShouldBeEmpty();
+    [Fact] void should_keep_what_the_read_that_succeeded_returned() => ValuesOf(GitHubClaimTypes.Organization).ShouldContainOnly("Cratis");
+}

--- a/Source/AuthProxy.Specs/Authentication/for_GitHubMembershipClaimsEnricher/when_membership_spans_several_pages.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_GitHubMembershipClaimsEnricher/when_membership_spans_several_pages.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authentication.for_GitHubMembershipClaimsEnricher;
+
+/// <summary>
+/// Paging is followed, and only within the host the read started from.
+/// <para>
+/// GitHub pages every collection and links the next page from a <c>Link</c> header rather than from the
+/// body, so a read that stopped at the first response would answer "the first hundred organizations" — a
+/// different question from the one authorization is asking, and one whose wrong answer is a member being
+/// refused for a reason nothing in the configuration explains.
+/// </para>
+/// <para>
+/// The link is a URL out of a response, so it is followed only while it stays on the same host. Without
+/// that, a spoofed or compromised response could walk the proxy's authenticated back channel — carrying
+/// the user's access token — to a host of its choosing.
+/// </para>
+/// </summary>
+public class when_membership_spans_several_pages : given.a_github_provider
+{
+    GitHubApi _api;
+
+    void Establish() => _api = new GitHubApi(url => url switch
+    {
+        _ when url.AbsolutePath.EndsWith("/teams", StringComparison.Ordinal) =>
+            GitHubApi.Page("[]", "https://exfiltration.test/user/teams?page=2"),
+        _ when url.Query.Contains("page=2", StringComparison.Ordinal) =>
+            GitHubApi.Page("""[{ "login": "Contoso" }]"""),
+        _ =>
+            GitHubApi.Page("""[{ "login": "Cratis" }]""", "https://api.github.com/user/orgs?per_page=100&page=2"),
+    });
+
+    async Task Because()
+    {
+        using var client = _api.CreateClient();
+        await _enricher.Enrich(_identity, _provider, client, "access-token", CancellationToken.None);
+    }
+
+    [Fact] void should_keep_the_first_page() => ValuesOf(GitHubClaimTypes.Organization).ShouldContain("Cratis");
+    [Fact] void should_follow_the_link_to_the_next_page() => ValuesOf(GitHubClaimTypes.Organization).ShouldContain("Contoso");
+    [Fact] void should_not_follow_a_link_to_another_host() => _api.Requested.ShouldNotContain(_ => _.Host.Equals("exfiltration.test", StringComparison.Ordinal));
+    [Fact] void should_ask_for_the_largest_page_github_will_return() => _api.Requested[0].Query.ShouldContain("per_page=100");
+}

--- a/Source/AuthProxy.Specs/Authentication/for_GitHubMembershipClaimsEnricher/when_reading_membership.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_GitHubMembershipClaimsEnricher/when_reading_membership.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authentication.for_GitHubMembershipClaimsEnricher;
+
+/// <summary>
+/// Organizations and teams come back as ordinary claims, so the ordinary claim requirements can gate on
+/// them.
+/// <para>
+/// This is the piece that makes gating on a GitHub organization possible at all: GitHub's user endpoint
+/// returns a profile and nothing about membership, so there is no claim to require and no field mapping
+/// that could invent one. Fetching it here and adding it as a claim is what keeps a single authorization
+/// mechanism rather than a second, GitHub-shaped one — and it hands the application the same membership on
+/// the forwarded principal.
+/// </para>
+/// <para>
+/// A team claim is qualified by its organization because a slug is only unique within one: two
+/// organizations may both have a <c>planner</c> team, and an unqualified claim would let membership of
+/// either satisfy a requirement written for one. The endpoints are derived from the configured user
+/// endpoint, which is what lets GitHub Enterprise work without another setting.
+/// </para>
+/// </summary>
+public class when_reading_membership : given.a_github_provider
+{
+    GitHubApi _api;
+
+    void Establish() => _api = new GitHubApi(url => url.AbsolutePath.EndsWith("/orgs", StringComparison.Ordinal)
+        ? GitHubApi.Page("""[{ "login": "Cratis" }, { "login": "Contoso" }]""")
+        : GitHubApi.Page("""[{ "slug": "planner", "organization": { "login": "Cratis" } }]"""));
+
+    async Task Because()
+    {
+        using var client = _api.CreateClient();
+        await _enricher.Enrich(_identity, _provider, client, "access-token", CancellationToken.None);
+    }
+
+    [Fact] void should_add_a_claim_per_organization() => ValuesOf(GitHubClaimTypes.Organization).ShouldContainOnly("Cratis", "Contoso");
+    [Fact] void should_qualify_a_team_by_its_organization() => ValuesOf(GitHubClaimTypes.Team).ShouldContainOnly("Cratis/planner");
+    [Fact] void should_read_the_organizations_under_the_configured_user_endpoint() => _api.Requested.ShouldContain(_ => _.AbsoluteUri.StartsWith("https://api.github.com/user/orgs", StringComparison.Ordinal));
+    [Fact] void should_read_the_teams_under_the_configured_user_endpoint() => _api.Requested.ShouldContain(_ => _.AbsoluteUri.StartsWith("https://api.github.com/user/teams", StringComparison.Ordinal));
+    [Fact] void should_leave_the_claims_the_identity_arrived_with() => _identity.FindFirst(ClaimTypes.Name)!.Value.ShouldEqual("octocat");
+}

--- a/Source/AuthProxy.Specs/Authorization/for_AccessControlMiddleware/given/an_access_control_middleware.cs
+++ b/Source/AuthProxy.Specs/Authorization/for_AccessControlMiddleware/given/an_access_control_middleware.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authorization.for_AccessControlMiddleware.given;
+
+/// <summary>
+/// The middleware wired to the real policy, in front of a next that records whether it ran.
+/// <para>
+/// The policy is the real one rather than a substitute: what these specs are about is which requests the
+/// middleware submits to it at all, and a substitute would answer the same way for a request that should
+/// never have reached it — making a skipped check indistinguishable from a passed one.
+/// </para>
+/// </summary>
+public class an_access_control_middleware : Specification
+{
+    protected const string AnonymousPath = "/api/webhooks/payments";
+
+    protected AccessControlMiddleware _middleware;
+    protected DefaultHttpContext _context;
+    protected IErrorPageProvider _errorPageProvider;
+    protected C.AuthProxy _config;
+    protected bool _nextCalled;
+
+    void Establish()
+    {
+        _config = new C.AuthProxy
+        {
+            Authorization = new C.Authorization
+            {
+                RequiredClaims = [new C.ClaimRequirement { Claim = "urn:github:organization", AnyOf = ["Cratis"] }],
+            },
+            Services = new Dictionary<string, C.Service>
+            {
+                ["main"] = new()
+                {
+                    Backend = new C.ServiceEndpoint { BaseUrl = "http://backend.test/" },
+                    AnonymousPaths = [AnonymousPath],
+                },
+            },
+        };
+
+        _errorPageProvider = Substitute.For<IErrorPageProvider>();
+        _context = new DefaultHttpContext();
+        _context.Request.Path = "/";
+    }
+
+    /// <summary>
+    /// Builds the middleware over the current configuration.
+    /// </summary>
+    /// <remarks>
+    /// Deferred to the spec rather than done in <c>Establish</c>, so a spec can change the configuration
+    /// first — the options monitor captures the instance it is told about.
+    /// </remarks>
+    protected void BuildMiddleware()
+    {
+        var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        config.CurrentValue.Returns(_config);
+
+        _middleware = new AccessControlMiddleware(
+            _ =>
+            {
+                _nextCalled = true;
+                return Task.CompletedTask;
+            },
+            config,
+            new AccessPolicy(),
+            _errorPageProvider,
+            Substitute.For<ILogger<AccessControlMiddleware>>());
+    }
+
+    /// <summary>
+    /// Puts an authenticated caller carrying the given claims on the request.
+    /// </summary>
+    /// <param name="claims">The claims the caller carries.</param>
+    protected void CallerCarrying(params Claim[] claims) =>
+        _context.User = new ClaimsPrincipal(new ClaimsIdentity(claims, "spec"));
+}

--- a/Source/AuthProxy.Specs/Authorization/for_AccessControlMiddleware/when_no_authorization_is_configured.cs
+++ b/Source/AuthProxy.Specs/Authorization/for_AccessControlMiddleware/when_no_authorization_is_configured.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authorization.for_AccessControlMiddleware;
+
+/// <summary>
+/// With nothing declared the middleware is a pass-through, which is what makes this a safe upgrade.
+/// <para>
+/// Every AuthProxy deployment that exists today declares nothing, and the middleware is now in all of
+/// their pipelines. Any behavior at all here — a refusal, a header, a changed status — would be a change
+/// they never asked for, delivered by a version bump.
+/// </para>
+/// </summary>
+public class when_no_authorization_is_configured : given.an_access_control_middleware
+{
+    void Establish()
+    {
+        _config.Authorization = new C.Authorization();
+        CallerCarrying(new Claim(ClaimTypes.NameIdentifier, "anyone-at-all"));
+        BuildMiddleware();
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_forward_the_request() => _nextCalled.ShouldBeTrue();
+    [Fact] void should_not_write_an_error_page() => _errorPageProvider.DidNotReceiveWithAnyArgs().WriteErrorPageAsync(default!, default!, default);
+    [Fact] void should_leave_the_status_alone() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status200OK);
+}

--- a/Source/AuthProxy.Specs/Authorization/for_AccessControlMiddleware/when_the_caller_does_not_satisfy_a_requirement.cs
+++ b/Source/AuthProxy.Specs/Authorization/for_AccessControlMiddleware/when_the_caller_does_not_satisfy_a_requirement.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authorization.for_AccessControlMiddleware;
+
+/// <summary>
+/// A signed-in caller who does not qualify is answered with the not-authorized page and goes no further.
+/// <para>
+/// Two properties, and both matter. The request must not continue — everything downstream is tenancy,
+/// identity resolution against a backend, and the reverse proxy, so continuing would mean the very caller
+/// being refused had already caused a call into the application. And the answer must be a page at
+/// <c>403</c> rather than a redirect: the caller <em>is</em> authenticated, so sending them back to the
+/// identity provider signs them in again as the same person and loops forever. <c>403</c> is also a status
+/// a non-browser client can act on, so one answer serves both.
+/// </para>
+/// </summary>
+public class when_the_caller_does_not_satisfy_a_requirement : given.an_access_control_middleware
+{
+    void Establish()
+    {
+        CallerCarrying(new Claim("urn:github:organization", "some-other-org"));
+        BuildMiddleware();
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_not_forward_the_request() => _nextCalled.ShouldBeFalse();
+
+    [Fact]
+    void should_serve_the_not_authorized_page() =>
+        _errorPageProvider.Received(1).WriteErrorPageAsync(_context, WellKnownPageNames.NotAuthorized, StatusCodes.Status403Forbidden);
+}

--- a/Source/AuthProxy.Specs/Authorization/for_AccessControlMiddleware/when_the_caller_has_no_session.cs
+++ b/Source/AuthProxy.Specs/Authorization/for_AccessControlMiddleware/when_the_caller_has_no_session.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authorization.for_AccessControlMiddleware;
+
+/// <summary>
+/// A caller with no session is left to the machinery that already refuses them.
+/// <para>
+/// Refusing them here instead would replace a sign-in with a dead end: <c>SelectProviderMiddleware</c>
+/// answers an unauthenticated browser with the provider chooser or a challenge, and the
+/// not-authorized page offers only signing out — of a session that does not exist. This gate is about who
+/// a signed-in caller <em>is</em>, not about whether there is one.
+/// </para>
+/// </summary>
+public class when_the_caller_has_no_session : given.an_access_control_middleware
+{
+    void Establish() => BuildMiddleware();
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_leave_the_request_to_the_rest_of_the_pipeline() => _nextCalled.ShouldBeTrue();
+    [Fact] void should_not_write_an_error_page() => _errorPageProvider.DidNotReceiveWithAnyArgs().WriteErrorPageAsync(default!, default!, default);
+}

--- a/Source/AuthProxy.Specs/Authorization/for_AccessControlMiddleware/when_the_caller_satisfies_every_requirement.cs
+++ b/Source/AuthProxy.Specs/Authorization/for_AccessControlMiddleware/when_the_caller_satisfies_every_requirement.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authorization.for_AccessControlMiddleware;
+
+/// <summary>
+/// A caller who qualifies is forwarded untouched, with nothing written to the response.
+/// </summary>
+public class when_the_caller_satisfies_every_requirement : given.an_access_control_middleware
+{
+    void Establish()
+    {
+        CallerCarrying(new Claim("urn:github:organization", "Cratis"));
+        BuildMiddleware();
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_forward_the_request() => _nextCalled.ShouldBeTrue();
+    [Fact] void should_not_write_an_error_page() => _errorPageProvider.DidNotReceiveWithAnyArgs().WriteErrorPageAsync(default!, default!, default);
+    [Fact] void should_leave_the_status_alone() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status200OK);
+}

--- a/Source/AuthProxy.Specs/Authorization/for_AccessControlMiddleware/when_the_path_is_anonymous.cs
+++ b/Source/AuthProxy.Specs/Authorization/for_AccessControlMiddleware/when_the_path_is_anonymous.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authorization.for_AccessControlMiddleware;
+
+/// <summary>
+/// A path a service declares anonymous is not gated — not for the caller with no session, and not for the
+/// one who happens to have one.
+/// <para>
+/// This is not a loophole so much as the only coherent reading. A declared path exists precisely for
+/// callers who have no session — a webhook receiver, a magic-link landing page, a signed-token report —
+/// and a caller with no session carries no claims, so any requirement at all would refuse every one of
+/// them. A payment provider posting a webhook would get a <c>403</c> it cannot do anything about, and the
+/// declaration that was supposed to make the path reachable would have been undone by a setting made
+/// somewhere else entirely.
+/// </para>
+/// <para>
+/// The authenticated case is asserted alongside it because the two go through different branches and only
+/// one of them is obvious: a signed-in person following a link into a public page must not be refused for
+/// lacking membership the page never required.
+/// </para>
+/// </summary>
+public class when_the_path_is_anonymous : given.an_access_control_middleware
+{
+    bool _anonymousCallerForwarded;
+    bool _authenticatedCallerForwarded;
+
+    void Establish()
+    {
+        _context.Request.Path = AnonymousPath;
+        BuildMiddleware();
+    }
+
+    async Task Because()
+    {
+        await _middleware.InvokeAsync(_context);
+        _anonymousCallerForwarded = _nextCalled;
+
+        _nextCalled = false;
+        CallerCarrying(new Claim("urn:github:organization", "some-other-org"));
+        await _middleware.InvokeAsync(_context);
+        _authenticatedCallerForwarded = _nextCalled;
+    }
+
+    [Fact] void should_forward_a_caller_with_no_session() => _anonymousCallerForwarded.ShouldBeTrue();
+    [Fact] void should_forward_a_signed_in_caller_who_would_otherwise_be_refused() => _authenticatedCallerForwarded.ShouldBeTrue();
+    [Fact] void should_not_write_an_error_page() => _errorPageProvider.DidNotReceiveWithAnyArgs().WriteErrorPageAsync(default!, default!, default);
+}

--- a/Source/AuthProxy.Specs/Authorization/for_AccessControlMiddleware/when_the_request_is_authentication_bootstrap.cs
+++ b/Source/AuthProxy.Specs/Authorization/for_AccessControlMiddleware/when_the_request_is_authentication_bootstrap.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authorization.for_AccessControlMiddleware;
+
+/// <summary>
+/// The endpoints that establish a session are never gated by the session they establish.
+/// <para>
+/// The provider list, the per-provider login endpoint and the provider callback are all reached while
+/// signing in — and a callback is reached by a caller who has just become authenticated but whose claims
+/// are still being assembled. Gating them is a chicken and egg: the only way to acquire the claims runs
+/// through the endpoints that would demand them.
+/// </para>
+/// </summary>
+public class when_the_request_is_authentication_bootstrap : given.an_access_control_middleware
+{
+    bool _providersForwarded;
+    bool _loginForwarded;
+    bool _callbackForwarded;
+
+    void Establish()
+    {
+        CallerCarrying(new Claim("urn:github:organization", "some-other-org"));
+        BuildMiddleware();
+    }
+
+    async Task Because()
+    {
+        _context.Request.Path = WellKnownPaths.Providers;
+        await _middleware.InvokeAsync(_context);
+        _providersForwarded = _nextCalled;
+
+        _nextCalled = false;
+        _context.Request.Path = $"{WellKnownPaths.LoginPrefix}/github";
+        await _middleware.InvokeAsync(_context);
+        _loginForwarded = _nextCalled;
+
+        _nextCalled = false;
+        _context.Request.Path = "/signin-github";
+        await _middleware.InvokeAsync(_context);
+        _callbackForwarded = _nextCalled;
+    }
+
+    [Fact] void should_forward_the_providers_endpoint() => _providersForwarded.ShouldBeTrue();
+    [Fact] void should_forward_the_login_endpoint() => _loginForwarded.ShouldBeTrue();
+    [Fact] void should_forward_the_provider_callback() => _callbackForwarded.ShouldBeTrue();
+}

--- a/Source/AuthProxy.Specs/Authorization/for_AccessPolicy/given/an_access_policy.cs
+++ b/Source/AuthProxy.Specs/Authorization/for_AccessPolicy/given/an_access_policy.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authorization.for_AccessPolicy.given;
+
+/// <summary>
+/// A policy and a request to evaluate it against.
+/// </summary>
+public class an_access_policy : Specification
+{
+    protected AccessPolicy _policy;
+    protected DefaultHttpContext _context;
+
+    void Establish()
+    {
+        _policy = new AccessPolicy();
+        _context = new DefaultHttpContext();
+    }
+
+    /// <summary>
+    /// Puts an authenticated caller carrying the given claims on the request.
+    /// </summary>
+    /// <param name="claims">The claims the caller carries.</param>
+    protected void CallerCarrying(params Claim[] claims) =>
+        _context.User = new ClaimsPrincipal(new ClaimsIdentity(claims, "spec"));
+
+    /// <summary>
+    /// Builds a configuration declaring proxy-wide requirements.
+    /// </summary>
+    /// <param name="requirements">The requirements to declare.</param>
+    /// <returns>The configuration.</returns>
+    protected static C.AuthProxy Requiring(params C.ClaimRequirement[] requirements) =>
+        new() { Authorization = new C.Authorization { RequiredClaims = requirements } };
+
+    /// <summary>
+    /// Builds a requirement for a claim, optionally narrowed to a set of values.
+    /// </summary>
+    /// <param name="claim">The claim type.</param>
+    /// <param name="anyOf">The values that satisfy it; none requires only presence.</param>
+    /// <returns>The requirement.</returns>
+    protected static C.ClaimRequirement Claiming(string claim, params string[] anyOf) =>
+        new() { Claim = claim, AnyOf = anyOf };
+}

--- a/Source/AuthProxy.Specs/Authorization/for_AccessPolicy/when_a_required_claim_is_missing.cs
+++ b/Source/AuthProxy.Specs/Authorization/for_AccessPolicy/when_a_required_claim_is_missing.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authorization.for_AccessPolicy;
+
+/// <summary>
+/// The whole point: an authenticated caller carrying nothing that satisfies the requirement is refused.
+/// <para>
+/// This is the case that motivates the feature. Sign-in succeeded — the caller is a real, verified account
+/// at a real identity provider — and that says nothing about whether this deployment is theirs to reach.
+/// The refusal names the claim, so a refusal in a log is something an operator can act on rather than a
+/// bare "denied"; it names the claim <em>type</em> and never the caller's value, which would put an
+/// identity into the log to explain that it was turned away.
+/// </para>
+/// </summary>
+public class when_a_required_claim_is_missing : given.an_access_policy
+{
+    C.AuthProxy _config;
+    AccessDecision _decision;
+
+    void Establish()
+    {
+        _config = Requiring(Claiming("urn:github:organization", "Cratis"));
+        CallerCarrying(
+            new Claim(ClaimTypes.NameIdentifier, "some-github-user"),
+            new Claim(ClaimTypes.Name, "octocat"));
+    }
+
+    void Because() => _decision = _policy.Evaluate(_context, _config);
+
+    [Fact] void should_deny_access() => _decision.IsGranted.ShouldBeFalse();
+    [Fact] void should_name_the_claim_that_was_not_satisfied() => _decision.UnsatisfiedClaim.ShouldEqual("urn:github:organization");
+}

--- a/Source/AuthProxy.Specs/Authorization/for_AccessPolicy/when_a_required_claim_is_present.cs
+++ b/Source/AuthProxy.Specs/Authorization/for_AccessPolicy/when_a_required_claim_is_present.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authorization.for_AccessPolicy;
+
+/// <summary>
+/// A requirement listing no values asks only that the claim be there.
+/// <para>
+/// That is the shape for an identity provider that emits a claim only for the people who should get in — a
+/// group membership mapped to a claim, an entitlement — where enumerating the acceptable values would mean
+/// restating the provider's own decision in the proxy, and keeping it restated.
+/// </para>
+/// </summary>
+public class when_a_required_claim_is_present : given.an_access_policy
+{
+    C.AuthProxy _config;
+    AccessDecision _decision;
+
+    void Establish()
+    {
+        _config = Requiring(Claiming("urn:example:entitlement"));
+        CallerCarrying(new Claim("urn:example:entitlement", "anything-at-all"));
+    }
+
+    void Because() => _decision = _policy.Evaluate(_context, _config);
+
+    [Fact] void should_consider_authorization_configured() => _policy.IsConfigured(_config).ShouldBeTrue();
+    [Fact] void should_grant_access() => _decision.IsGranted.ShouldBeTrue();
+}

--- a/Source/AuthProxy.Specs/Authorization/for_AccessPolicy/when_a_requirement_names_no_claim.cs
+++ b/Source/AuthProxy.Specs/Authorization/for_AccessPolicy/when_a_requirement_names_no_claim.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authorization.for_AccessPolicy;
+
+/// <summary>
+/// A requirement that names no claim denies rather than being skipped.
+/// <para>
+/// Startup validation refuses such a configuration outright, so this is the second line rather than the
+/// first — but it is the line that decides which way the failure falls. Discarding an unusable requirement
+/// is how an unusable <c>AnonymousPaths</c> entry is handled, and it is fail-closed <em>there</em> because
+/// discarding leaves the path authenticated. Here the same move would leave the gate open, so the
+/// direction has to be the other one: unsatisfiable means nobody satisfies it.
+/// </para>
+/// </summary>
+public class when_a_requirement_names_no_claim : given.an_access_policy
+{
+    C.AuthProxy _config;
+    AccessDecision _decision;
+
+    void Establish()
+    {
+        _config = Requiring(Claiming("   "));
+        CallerCarrying(new Claim("urn:github:organization", "Cratis"));
+    }
+
+    void Because() => _decision = _policy.Evaluate(_context, _config);
+
+    [Fact] void should_deny_access() => _decision.IsGranted.ShouldBeFalse();
+}

--- a/Source/AuthProxy.Specs/Authorization/for_AccessPolicy/when_a_service_declares_its_own_requirements.cs
+++ b/Source/AuthProxy.Specs/Authorization/for_AccessPolicy/when_a_service_declares_its_own_requirements.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authorization.for_AccessPolicy;
+
+/// <summary>
+/// A service's requirements are added to the proxy-wide ones, never substituted for them.
+/// <para>
+/// A service can therefore only narrow who reaches it. The substituting reading is the dangerous one: it
+/// would make the root a default rather than a floor, so a service section written to add an
+/// administrator check would quietly <em>drop</em> the organization check, and a service added later with
+/// no section at all would be the way in.
+/// </para>
+/// <para>
+/// The request here names no service — this is a single-service deployment, where everything routes to the
+/// one service, exactly as the route table's catch-all does.
+/// </para>
+/// </summary>
+public class when_a_service_declares_its_own_requirements : given.an_access_policy
+{
+    C.AuthProxy _config;
+    AccessDecision _satisfyingBoth;
+    AccessDecision _satisfyingOnlyTheServiceOne;
+    AccessDecision _satisfyingOnlyTheGlobalOne;
+
+    void Establish() => _config = new C.AuthProxy
+    {
+        Authorization = new C.Authorization { RequiredClaims = [Claiming("urn:github:organization", "Cratis")] },
+        Services = new Dictionary<string, C.Service>
+        {
+            ["main"] = new()
+            {
+                Backend = new C.ServiceEndpoint { BaseUrl = "http://backend.test/" },
+                Authorization = new C.Authorization { RequiredClaims = [Claiming("urn:github:team", "Cratis/planner")] },
+            },
+        },
+    };
+
+    void Because()
+    {
+        CallerCarrying(new Claim("urn:github:organization", "Cratis"), new Claim("urn:github:team", "Cratis/planner"));
+        _satisfyingBoth = _policy.Evaluate(_context, _config);
+
+        CallerCarrying(new Claim("urn:github:team", "Cratis/planner"));
+        _satisfyingOnlyTheServiceOne = _policy.Evaluate(_context, _config);
+
+        CallerCarrying(new Claim("urn:github:organization", "Cratis"));
+        _satisfyingOnlyTheGlobalOne = _policy.Evaluate(_context, _config);
+    }
+
+    [Fact] void should_consider_authorization_configured() => _policy.IsConfigured(_config).ShouldBeTrue();
+    [Fact] void should_grant_a_caller_satisfying_both() => _satisfyingBoth.IsGranted.ShouldBeTrue();
+    [Fact] void should_still_apply_the_proxy_wide_requirement() => _satisfyingOnlyTheServiceOne.IsGranted.ShouldBeFalse();
+    [Fact] void should_also_apply_the_service_requirement() => _satisfyingOnlyTheGlobalOne.IsGranted.ShouldBeFalse();
+    [Fact] void should_name_the_service_requirement_when_that_is_the_one_missing() => _satisfyingOnlyTheGlobalOne.UnsatisfiedClaim.ShouldEqual("urn:github:team");
+}

--- a/Source/AuthProxy.Specs/Authorization/for_AccessPolicy/when_every_requirement_is_satisfied.cs
+++ b/Source/AuthProxy.Specs/Authorization/for_AccessPolicy/when_every_requirement_is_satisfied.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authorization.for_AccessPolicy;
+
+/// <summary>
+/// Several requirements compose as an <em>and</em>, and a caller satisfying all of them gets in.
+/// <para>
+/// This is the shape the GitHub case is written in: one requirement for the organization, one for the
+/// team. Splitting it that way is what lets the organization requirement stand on its own if the team is
+/// later dropped, and it is why the two axes are separate requirements rather than a single compound
+/// value.
+/// </para>
+/// </summary>
+public class when_every_requirement_is_satisfied : given.an_access_policy
+{
+    C.AuthProxy _config;
+    AccessDecision _decision;
+
+    void Establish()
+    {
+        _config = Requiring(
+            Claiming("urn:github:organization", "Cratis"),
+            Claiming("urn:github:team", "Cratis/planner"));
+
+        CallerCarrying(
+            new Claim("urn:github:organization", "Cratis"),
+            new Claim("urn:github:team", "Cratis/planner"),
+            new Claim("urn:github:team", "Cratis/docs"));
+    }
+
+    void Because() => _decision = _policy.Evaluate(_context, _config);
+
+    [Fact] void should_grant_access() => _decision.IsGranted.ShouldBeTrue();
+}

--- a/Source/AuthProxy.Specs/Authorization/for_AccessPolicy/when_nothing_is_required.cs
+++ b/Source/AuthProxy.Specs/Authorization/for_AccessPolicy/when_nothing_is_required.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authorization.for_AccessPolicy;
+
+/// <summary>
+/// A deployment that declares nothing is a deployment this feature does not exist in.
+/// <para>
+/// Every AuthProxy already running predates first-gate authorization, and none of them will declare a
+/// requirement the day they take the upgrade. The one outcome that would matter is the one where an empty
+/// configuration started meaning "nobody satisfies anything" — an instant, total outage on a version bump.
+/// So the empty case is pinned separately from the satisfied case: not merely granted, but not even
+/// recognized as configured, which is what keeps the evaluation off the request path entirely.
+/// </para>
+/// </summary>
+public class when_nothing_is_required : given.an_access_policy
+{
+    C.AuthProxy _config;
+    bool _isConfigured;
+    AccessDecision _decision;
+
+    void Establish()
+    {
+        _config = new C.AuthProxy
+        {
+            Services = new Dictionary<string, C.Service>
+            {
+                ["main"] = new() { Backend = new C.ServiceEndpoint { BaseUrl = "http://backend.test/" } },
+            },
+        };
+
+        CallerCarrying(new Claim(ClaimTypes.NameIdentifier, "someone"));
+    }
+
+    void Because()
+    {
+        _isConfigured = _policy.IsConfigured(_config);
+        _decision = _policy.Evaluate(_context, _config);
+    }
+
+    [Fact] void should_not_consider_authorization_configured() => _isConfigured.ShouldBeFalse();
+    [Fact] void should_grant_access() => _decision.IsGranted.ShouldBeTrue();
+}

--- a/Source/AuthProxy.Specs/Authorization/for_AccessPolicy/when_one_of_several_requirements_is_not_satisfied.cs
+++ b/Source/AuthProxy.Specs/Authorization/for_AccessPolicy/when_one_of_several_requirements_is_not_satisfied.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authorization.for_AccessPolicy;
+
+/// <summary>
+/// Requirements are an <em>and</em>: satisfying most of them is not satisfying them.
+/// <para>
+/// The alternative reading — any one requirement being enough — is the one that has to be ruled out
+/// explicitly, because the two are indistinguishable in a configuration file and produce opposite
+/// deployments. Under an <em>or</em>, adding a team requirement to an organization requirement would
+/// <em>widen</em> access to anyone in the organization <em>or</em> on the team of any organization, which
+/// is the precise opposite of what the person adding it meant.
+/// </para>
+/// </summary>
+public class when_one_of_several_requirements_is_not_satisfied : given.an_access_policy
+{
+    C.AuthProxy _config;
+    AccessDecision _decision;
+
+    void Establish()
+    {
+        _config = Requiring(
+            Claiming("urn:github:organization", "Cratis"),
+            Claiming("urn:github:team", "Cratis/planner"));
+
+        CallerCarrying(
+            new Claim("urn:github:organization", "Cratis"),
+            new Claim("urn:github:team", "Cratis/docs"));
+    }
+
+    void Because() => _decision = _policy.Evaluate(_context, _config);
+
+    [Fact] void should_deny_access() => _decision.IsGranted.ShouldBeFalse();
+    [Fact] void should_name_the_requirement_that_failed() => _decision.UnsatisfiedClaim.ShouldEqual("urn:github:team");
+}

--- a/Source/AuthProxy.Specs/Authorization/for_AccessPolicy/when_several_services_declare_different_requirements.cs
+++ b/Source/AuthProxy.Specs/Authorization/for_AccessPolicy/when_several_services_declare_different_requirements.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authorization.for_AccessPolicy;
+
+/// <summary>
+/// The service a request targets is worked out the way the route table works it out, so a service's
+/// requirements apply to that service's traffic and to nothing else.
+/// <para>
+/// The gate runs before endpoint selection — it has to refuse a caller before a tenant is resolved or a
+/// backend is called, and long before YARP picks a route — so it cannot ask which route was chosen and has
+/// to read the request the same way the route table will. That is the <c>Service-ID</c> header, then the
+/// <c>service</c> query parameter. If the two ever disagreed, one service's requirements would guard
+/// another service's traffic.
+/// </para>
+/// </summary>
+public class when_several_services_declare_different_requirements : given.an_access_policy
+{
+    C.AuthProxy _config;
+    AccessDecision _selectedByHeader;
+    AccessDecision _selectedByQueryParameter;
+    AccessDecision _selectingNoService;
+
+    void Establish() => _config = new C.AuthProxy
+    {
+        Services = new Dictionary<string, C.Service>
+        {
+            ["admin"] = new()
+            {
+                Backend = new C.ServiceEndpoint { BaseUrl = "http://admin.test/" },
+                Authorization = new C.Authorization { RequiredClaims = [Claiming("urn:github:team", "Cratis/operations")] },
+            },
+            ["portal"] = new()
+            {
+                Backend = new C.ServiceEndpoint { BaseUrl = "http://portal.test/" },
+            },
+        },
+    };
+
+    void Because()
+    {
+        CallerCarrying(new Claim("urn:github:organization", "Cratis"));
+
+        _context.Request.Headers[Headers.ServiceId] = "admin";
+        _selectedByHeader = _policy.Evaluate(_context, _config);
+
+        _context.Request.Headers.Remove(Headers.ServiceId);
+        _context.Request.QueryString = new QueryString("?service=admin");
+        _selectedByQueryParameter = _policy.Evaluate(_context, _config);
+
+        _context.Request.QueryString = QueryString.Empty;
+        _selectingNoService = _policy.Evaluate(_context, _config);
+    }
+
+    [Fact] void should_apply_the_requirements_of_the_service_named_by_the_header() => _selectedByHeader.IsGranted.ShouldBeFalse();
+    [Fact] void should_apply_the_requirements_of_the_service_named_by_the_query_parameter() => _selectedByQueryParameter.IsGranted.ShouldBeFalse();
+    [Fact] void should_not_apply_one_service_requirements_to_a_request_naming_no_service() => _selectingNoService.IsGranted.ShouldBeTrue();
+}

--- a/Source/AuthProxy.Specs/Authorization/for_AccessPolicy/when_the_claim_carries_a_value_that_is_not_allowed.cs
+++ b/Source/AuthProxy.Specs/Authorization/for_AccessPolicy/when_the_claim_carries_a_value_that_is_not_allowed.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authorization.for_AccessPolicy;
+
+/// <summary>
+/// Carrying the claim is not the same as carrying an accepted value.
+/// <para>
+/// A GitHub account belongs to organizations, so the claim is there for everybody who signs in — it is the
+/// value that separates the people who work here from everybody else. A check that stopped at presence
+/// would let the entire internet through while looking, in configuration, exactly like a check that did
+/// not.
+/// </para>
+/// </summary>
+public class when_the_claim_carries_a_value_that_is_not_allowed : given.an_access_policy
+{
+    C.AuthProxy _config;
+    AccessDecision _decision;
+
+    void Establish()
+    {
+        _config = Requiring(Claiming("urn:github:organization", "Cratis"));
+        CallerCarrying(new Claim("urn:github:organization", "some-other-org"));
+    }
+
+    void Because() => _decision = _policy.Evaluate(_context, _config);
+
+    [Fact] void should_deny_access() => _decision.IsGranted.ShouldBeFalse();
+    [Fact] void should_name_the_claim_that_was_not_satisfied() => _decision.UnsatisfiedClaim.ShouldEqual("urn:github:organization");
+}

--- a/Source/AuthProxy.Specs/Authorization/for_AccessPolicy/when_the_claim_carries_one_of_the_allowed_values.cs
+++ b/Source/AuthProxy.Specs/Authorization/for_AccessPolicy/when_the_claim_carries_one_of_the_allowed_values.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authorization.for_AccessPolicy;
+
+/// <summary>
+/// Several values in one requirement are an <em>or</em>, and the comparison ignores case.
+/// <para>
+/// The values being matched are organization names, team slugs and role names — identifiers their own
+/// systems treat as case-insensitive, and which an operator copies out of a URL or a settings page, where
+/// <c>Cratis</c> and <c>cratis</c> are the same thing. An ordinal comparison would turn that into a
+/// deployment nobody can sign in to, with a <c>403</c> that says nothing about why.
+/// </para>
+/// <para>
+/// Also pinned here: a caller carrying several claims of the same type — the ordinary case for someone in
+/// more than one organization — is satisfied when <em>any</em> of them matches, not only the first.
+/// </para>
+/// </summary>
+public class when_the_claim_carries_one_of_the_allowed_values : given.an_access_policy
+{
+    C.AuthProxy _config;
+    AccessDecision _decision;
+
+    void Establish()
+    {
+        _config = Requiring(Claiming("urn:github:organization", "Cratis", "Contoso"));
+        CallerCarrying(
+            new Claim("urn:github:organization", "some-unrelated-org"),
+            new Claim("urn:github:organization", "cratis"));
+    }
+
+    void Because() => _decision = _policy.Evaluate(_context, _config);
+
+    [Fact] void should_grant_access() => _decision.IsGranted.ShouldBeTrue();
+}

--- a/Source/AuthProxy.Specs/Authorization/for_AuthorizationConfigurationValidator/when_a_requirement_names_no_claim.cs
+++ b/Source/AuthProxy.Specs/Authorization/for_AuthorizationConfigurationValidator/when_a_requirement_names_no_claim.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authorization.for_AuthorizationConfigurationValidator;
+
+/// <summary>
+/// A requirement with no claim type fails startup, naming exactly where it is.
+/// <para>
+/// The alternative outcomes are both bad in ways that are hard to diagnose. Starting and applying it means
+/// every caller is refused, because nothing satisfies a requirement for nothing — a total outage caused by
+/// an environment variable that failed to interpolate. Starting and ignoring it means the gate is silently
+/// open, which is the failure this feature exists to close. Refusing to start is the only answer that
+/// happens while somebody is watching.
+/// </para>
+/// </summary>
+public class when_a_requirement_names_no_claim : Specification
+{
+    AuthorizationConfigurationValidator _validator;
+    C.AuthProxy _config;
+    ValidateOptionsResult _result;
+
+    void Establish()
+    {
+        _validator = new AuthorizationConfigurationValidator();
+        _config = new C.AuthProxy
+        {
+            Authorization = new C.Authorization
+            {
+                RequiredClaims =
+                [
+                    new C.ClaimRequirement { Claim = "urn:github:organization", AnyOf = ["Cratis"] },
+                    new C.ClaimRequirement { Claim = string.Empty, AnyOf = ["Cratis/planner"] },
+                ],
+            },
+            Services = new Dictionary<string, C.Service>
+            {
+                ["main"] = new()
+                {
+                    Authorization = new C.Authorization { RequiredClaims = [new C.ClaimRequirement { Claim = "  " }] },
+                },
+            },
+        };
+    }
+
+    void Because() => _result = _validator.Validate(null, _config);
+
+    [Fact] void should_fail_validation() => _result.Failed.ShouldBeTrue();
+    [Fact] void should_point_at_the_offending_proxy_wide_requirement() => _result.Failures.ShouldContain(_ => _.Contains("Cratis:AuthProxy:Authorization:RequiredClaims:1:Claim", StringComparison.Ordinal));
+    [Fact] void should_point_at_the_offending_service_requirement() => _result.Failures.ShouldContain(_ => _.Contains("Cratis:AuthProxy:Services:main:Authorization:RequiredClaims:0:Claim", StringComparison.Ordinal));
+    [Fact] void should_not_complain_about_the_usable_requirement() => _result.Failures.Count().ShouldEqual(2);
+}

--- a/Source/AuthProxy.Specs/Authorization/for_AuthorizationConfigurationValidator/when_every_requirement_names_a_claim.cs
+++ b/Source/AuthProxy.Specs/Authorization/for_AuthorizationConfigurationValidator/when_every_requirement_names_a_claim.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authorization.for_AuthorizationConfigurationValidator;
+
+/// <summary>
+/// A usable configuration — and a configuration declaring nothing at all — start.
+/// <para>
+/// The empty case is the one worth pinning: this validator runs on every AuthProxy, including the great
+/// majority that will never declare a requirement, and a validator that refused an absent section would
+/// stop every one of them from starting.
+/// </para>
+/// </summary>
+public class when_every_requirement_names_a_claim : Specification
+{
+    AuthorizationConfigurationValidator _validator;
+    ValidateOptionsResult _declaringRequirements;
+    ValidateOptionsResult _declaringNothing;
+
+    void Establish() => _validator = new AuthorizationConfigurationValidator();
+
+    void Because()
+    {
+        _declaringRequirements = _validator.Validate(null, new C.AuthProxy
+        {
+            Authorization = new C.Authorization
+            {
+                RequiredClaims = [new C.ClaimRequirement { Claim = "urn:github:organization", AnyOf = ["Cratis"] }],
+            },
+            Services = new Dictionary<string, C.Service>
+            {
+                ["main"] = new() { Backend = new C.ServiceEndpoint { BaseUrl = "http://backend.test/" } },
+            },
+        });
+
+        _declaringNothing = _validator.Validate(null, new C.AuthProxy());
+    }
+
+    [Fact] void should_accept_a_usable_configuration() => _declaringRequirements.Succeeded.ShouldBeTrue();
+    [Fact] void should_accept_a_configuration_that_declares_nothing() => _declaringNothing.Succeeded.ShouldBeTrue();
+}

--- a/Source/AuthProxy/Authentication/AuthenticationServiceCollectionExtensions.cs
+++ b/Source/AuthProxy/Authentication/AuthenticationServiceCollectionExtensions.cs
@@ -64,6 +64,7 @@ public static class AuthenticationServiceCollectionExtensions
         RegisterOidcProviders(authBuilder, authConfig.OidcProviders);
         RegisterOAuthProviders(authBuilder, authConfig.OAuthProviders);
 
+        builder.Services.AddSingleton<IProviderClaimsEnricher, GitHubMembershipClaimsEnricher>();
         builder.Services.AddSingleton<ClientCredentialsServiceResolver>();
         builder.Services.AddSingleton<ClientCredentialsVerifier>();
         builder.Services.AddSingleton<ClientCredentialsTokenProtector>();
@@ -264,10 +265,44 @@ public static class AuthenticationServiceCollectionExtensions
                         using var user = JsonDocument.Parse(
                             await response.Content.ReadAsStringAsync(ctx.HttpContext.RequestAborted));
                         ctx.RunClaimActions(user.RootElement);
+
+                        await EnrichProviderClaims(ctx, capturedProvider);
                     },
                     OnTicketReceived = HandleTicketReceived
                 };
             });
+        }
+    }
+
+    /// <summary>
+    /// Adds any provider-specific claims that do not come from the user-information endpoint.
+    /// </summary>
+    /// <param name="context">The ticket-creation context.</param>
+    /// <param name="provider">The provider completing the sign-in.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    /// <remarks>
+    /// Runs after <c>RunClaimActions</c>, on the identity that is about to be signed into the cookie, so
+    /// what an enricher adds is persisted with the session and travels with every later request — no
+    /// second call to the provider, and nothing to re-fetch. An enricher that has nothing to contribute for
+    /// this provider is not called at all, so a deployment with no such provider pays for none of this.
+    /// </remarks>
+    static async Task EnrichProviderClaims(OAuthCreatingTicketContext context, C.OAuthProvider provider)
+    {
+        if (context.Identity is null || string.IsNullOrEmpty(context.AccessToken))
+        {
+            return;
+        }
+
+        var enrichers = context.HttpContext.RequestServices.GetServices<IProviderClaimsEnricher>();
+
+        foreach (var enricher in enrichers.Where(_ => _.CanEnrich(provider)))
+        {
+            await enricher.Enrich(
+                context.Identity,
+                provider,
+                context.Backchannel,
+                context.AccessToken,
+                context.HttpContext.RequestAborted);
         }
     }
 

--- a/Source/AuthProxy/Authentication/GitHubClaimTypes.cs
+++ b/Source/AuthProxy/Authentication/GitHubClaimTypes.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authentication;
+
+/// <summary>
+/// Holds the claim types AuthProxy adds for a GitHub sign-in when the session is allowed to read
+/// organization membership.
+/// </summary>
+/// <remarks>
+/// GitHub's user endpoint returns a profile and nothing about where its owner belongs, so no claim about
+/// organizations or teams exists to authorize against until one is fetched and added. These are the types
+/// under which it is added — the same claims the authorization requirements name, and the same claims the
+/// application receives on the forwarded principal.
+/// </remarks>
+public static class GitHubClaimTypes
+{
+    /// <summary>
+    /// The claim carrying an organization the signed-in user belongs to, as its GitHub login
+    /// (for example <c>Cratis</c>). One claim is added per organization.
+    /// </summary>
+    public const string Organization = "urn:github:organization";
+
+    /// <summary>
+    /// The claim carrying a team the signed-in user belongs to, as <c>organization/team-slug</c>
+    /// (for example <c>Cratis/planner</c>). One claim is added per team.
+    /// </summary>
+    /// <remarks>
+    /// Qualified by organization because a team slug is only unique within one: two organizations may both
+    /// have a <c>developers</c> team, and an unqualified claim would let membership of either satisfy a
+    /// requirement meant for one. The slug is the name in the team's URL, which is what an operator has in
+    /// front of them when writing the requirement.
+    /// </remarks>
+    public const string Team = "urn:github:team";
+}

--- a/Source/AuthProxy/Authentication/GitHubMembershipClaimsEnricher.cs
+++ b/Source/AuthProxy/Authentication/GitHubMembershipClaimsEnricher.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Security.Claims;
+using C = Cratis.AuthProxy.Configuration;
+
+namespace Cratis.AuthProxy.Authentication;
+
+/// <summary>
+/// Adds a claim per GitHub organization and per GitHub team the signing-in user belongs to, so the ordinary
+/// claim requirements can gate on membership.
+/// </summary>
+/// <remarks>
+/// GitHub's user endpoint — the one <see cref="C.OAuthProvider.UserInformationEndpoint"/> names — returns a
+/// profile and nothing about membership, so there is no claim to match on and no mapping that could produce
+/// one. Membership lives behind <c>/user/orgs</c> and <c>/user/teams</c>, which is why gating on a GitHub
+/// organization is not a matter of configuration alone.
+/// <para>
+/// Fetching it once, at sign-in, and turning it into claims is what keeps a single authorization mechanism:
+/// the requirement that names <see cref="GitHubClaimTypes.Organization"/> is the same kind of requirement as
+/// one naming a role from an OIDC provider, evaluated by the same code. The application behind the proxy
+/// gets the membership too, on the forwarded principal, without asking GitHub itself.
+/// </para>
+/// <para>
+/// The alternative — a GitHub-specific rule calling GitHub during authorization — would need a second rule
+/// type, a second evaluator, and a live API call on requests rather than on sign-ins.
+/// </para>
+/// </remarks>
+/// <param name="logger">The logger.</param>
+public class GitHubMembershipClaimsEnricher(ILogger<GitHubMembershipClaimsEnricher> logger) : IProviderClaimsEnricher
+{
+    /// <summary>
+    /// The scopes that let a token see the organizations and teams a user belongs to.
+    /// </summary>
+    /// <remarks>
+    /// This is also the opt-in. Without one of these GitHub answers <c>/user/orgs</c> with public
+    /// memberships only and refuses <c>/user/teams</c> outright, so membership claims would be
+    /// misleading where they were not simply absent. Requesting the scope is therefore the same statement
+    /// as asking for the claims, and a deployment that does not request it makes no extra calls and gets
+    /// exactly the sign-in it got before.
+    /// </remarks>
+    static readonly string[] _organizationReadScopes = ["read:org", "write:org", "admin:org"];
+
+    /// <inheritdoc/>
+    public bool CanEnrich(C.OAuthProvider provider) =>
+        provider.Type == C.OidcProviderType.GitHub
+        && provider.Scopes.Any(scope => _organizationReadScopes.Contains(scope?.Trim() ?? string.Empty, StringComparer.OrdinalIgnoreCase));
+
+    /// <inheritdoc/>
+    public async Task Enrich(
+        ClaimsIdentity identity,
+        C.OAuthProvider provider,
+        HttpClient backchannel,
+        string accessToken,
+        CancellationToken cancellationToken)
+    {
+        if (!TryResolveResource(provider, "orgs", out var organizations)
+            || !TryResolveResource(provider, "teams", out var teams))
+        {
+            logger.MembershipEndpointUnresolvable(provider.Name);
+            return;
+        }
+
+        Add(identity, GitHubClaimTypes.Organization, await GitHubPagedResourceReader.Read(backchannel, accessToken, organizations, SelectOrganization, logger, cancellationToken));
+        Add(identity, GitHubClaimTypes.Team, await GitHubPagedResourceReader.Read(backchannel, accessToken, teams, SelectTeam, logger, cancellationToken));
+    }
+
+    /// <summary>
+    /// Resolves a membership collection endpoint from the configured user-information endpoint.
+    /// </summary>
+    /// <param name="provider">The provider whose endpoints to read.</param>
+    /// <param name="resource">The collection under the user endpoint (<c>orgs</c> or <c>teams</c>).</param>
+    /// <param name="url">The resolved URL when the endpoint is usable.</param>
+    /// <returns><see langword="true"/> when the URL could be resolved; otherwise <see langword="false"/>.</returns>
+    /// <remarks>
+    /// Derived rather than configured, so GitHub Enterprise works without a second setting: the collections
+    /// sit directly under whatever user endpoint is already configured, whether that is
+    /// <c>https://api.github.com/user</c> or <c>https://github.example.com/api/v3/user</c>.
+    /// </remarks>
+    static bool TryResolveResource(C.OAuthProvider provider, string resource, out Uri url)
+    {
+        url = null!;
+
+        if (!Uri.TryCreate($"{provider.UserInformationEndpoint?.TrimEnd('/')}/{resource}", UriKind.Absolute, out var resolved))
+        {
+            return false;
+        }
+
+        url = resolved;
+        return true;
+    }
+
+    static string? SelectOrganization(JsonElement element) =>
+        element.ValueKind == JsonValueKind.Object
+        && element.TryGetProperty("login", out var login)
+        && login.ValueKind == JsonValueKind.String
+            ? login.GetString()
+            : null;
+
+    static string? SelectTeam(JsonElement element) =>
+        element.ValueKind == JsonValueKind.Object
+        && element.TryGetProperty("slug", out var slug)
+        && slug.ValueKind == JsonValueKind.String
+        && element.TryGetProperty("organization", out var organization)
+        && organization.ValueKind == JsonValueKind.Object
+        && organization.TryGetProperty("login", out var login)
+        && login.ValueKind == JsonValueKind.String
+            ? $"{login.GetString()}/{slug.GetString()}"
+            : null;
+
+    static void Add(ClaimsIdentity identity, string claimType, IEnumerable<string> values)
+    {
+        foreach (var value in values.Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            if (!identity.HasClaim(claim => string.Equals(claim.Type, claimType, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(claim.Value, value, StringComparison.OrdinalIgnoreCase)))
+            {
+                identity.AddClaim(new Claim(claimType, value));
+            }
+        }
+    }
+}

--- a/Source/AuthProxy/Authentication/GitHubMembershipClaimsEnricherLogging.cs
+++ b/Source/AuthProxy/Authentication/GitHubMembershipClaimsEnricherLogging.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authentication;
+
+internal static partial class GitHubMembershipClaimsEnricherLogging
+{
+    [LoggerMessage(LogLevel.Warning, "GitHub membership read of {Resource} answered {StatusCode}. Signing in without the membership claims it would have added.")]
+    internal static partial void MembershipReadFailed(this ILogger logger, string resource, int statusCode);
+
+    [LoggerMessage(LogLevel.Warning, "GitHub membership read of {Resource} could not be completed. Signing in without the membership claims it would have added.")]
+    internal static partial void MembershipReadUnavailable(this ILogger logger, string resource, Exception exception);
+
+    [LoggerMessage(LogLevel.Warning, "GitHub membership read of {Resource} returned something that could not be read as JSON. Signing in without the membership claims it would have added.")]
+    internal static partial void MembershipReadUnreadable(this ILogger logger, string resource, Exception exception);
+
+    [LoggerMessage(LogLevel.Warning, "The UserInformationEndpoint configured for provider '{Provider}' is not an absolute URL, so its membership endpoints cannot be resolved. No membership claims are added.")]
+    internal static partial void MembershipEndpointUnresolvable(this ILogger logger, string provider);
+}

--- a/Source/AuthProxy/Authentication/GitHubPagedResourceReader.cs
+++ b/Source/AuthProxy/Authentication/GitHubPagedResourceReader.cs
@@ -1,0 +1,164 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net.Http.Headers;
+
+namespace Cratis.AuthProxy.Authentication;
+
+/// <summary>
+/// Reads a paged GitHub REST collection and projects each entry to a single string.
+/// </summary>
+/// <remarks>
+/// GitHub pages every collection endpoint and links the next page from a <c>Link</c> header rather than
+/// from the body, so a single request answers "the first hundred organizations", which for authorization
+/// is a different question from the one being asked. Following the links is what makes membership in the
+/// hundred-and-first organization count.
+/// </remarks>
+internal static class GitHubPagedResourceReader
+{
+    /// <summary>The page size requested; GitHub's maximum, so the common case is one request.</summary>
+    const int PageSize = 100;
+
+    /// <summary>
+    /// The number of pages followed before stopping.
+    /// </summary>
+    /// <remarks>
+    /// A bound rather than "until GitHub stops linking", because this runs inside a sign-in handshake a
+    /// person is waiting on, and every claim collected ends up in the authentication cookie. Five pages is
+    /// five hundred organizations or teams, far past any plausible allow-list, and the cost of stopping
+    /// there is a requirement that is not satisfied — the fail-closed direction.
+    /// </remarks>
+    const int MaxPages = 5;
+
+    const string LinkHeader = "Link";
+    const string NextRelation = "rel=\"next\"";
+    const string MediaType = "application/vnd.github+json";
+
+    /// <summary>
+    /// Reads every page of a collection, projecting each entry.
+    /// </summary>
+    /// <param name="client">The HTTP client to read through.</param>
+    /// <param name="accessToken">The access token to present.</param>
+    /// <param name="resource">The absolute URL of the collection.</param>
+    /// <param name="select">Projects one entry to the value to keep, or <see langword="null"/> to skip it.</param>
+    /// <param name="logger">The logger used to report a failed read.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> for the operation.</param>
+    /// <returns>The projected values, in the order returned.</returns>
+    /// <remarks>
+    /// Never throws: a failure returns what was read before it. The caller is completing a sign-in, and a
+    /// user who cannot be signed in at all is a worse outcome than one signed in without the claims — which
+    /// leaves them refused by the gate, with an explanation, rather than staring at a broken login.
+    /// </remarks>
+    internal static async Task<IEnumerable<string>> Read(
+        HttpClient client,
+        string accessToken,
+        Uri resource,
+        Func<JsonElement, string?> select,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var values = new List<string>();
+        var next = WithPageSize(resource);
+
+        try
+        {
+            for (var page = 0; page < MaxPages && next is not null; page++)
+            {
+                using var request = BuildRequest(next, accessToken);
+                using var response = await client.SendAsync(request, cancellationToken);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    logger.MembershipReadFailed(resource.AbsolutePath, (int)response.StatusCode);
+                    break;
+                }
+
+                using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync(cancellationToken));
+                if (document.RootElement.ValueKind != JsonValueKind.Array)
+                {
+                    break;
+                }
+
+                foreach (var element in document.RootElement.EnumerateArray())
+                {
+                    var value = select(element);
+                    if (!string.IsNullOrWhiteSpace(value))
+                    {
+                        values.Add(value);
+                    }
+                }
+
+                next = NextPage(response, resource);
+            }
+        }
+        catch (HttpRequestException ex)
+        {
+            logger.MembershipReadUnavailable(resource.AbsolutePath, ex);
+        }
+        catch (JsonException ex)
+        {
+            logger.MembershipReadUnreadable(resource.AbsolutePath, ex);
+        }
+        catch (OperationCanceledException)
+        {
+            // The caller went away mid-handshake. Nothing to report and nothing to sign in.
+        }
+
+        return values;
+    }
+
+    static HttpRequestMessage BuildRequest(Uri url, string accessToken)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaType));
+        request.Headers.UserAgent.Add(new ProductInfoHeaderValue("Cratis-AuthProxy", "1.0"));
+
+        return request;
+    }
+
+    static Uri WithPageSize(Uri resource) =>
+        new UriBuilder(resource)
+        {
+            Query = string.IsNullOrEmpty(resource.Query)
+                ? $"per_page={PageSize}"
+                : $"{resource.Query.TrimStart('?')}&per_page={PageSize}"
+        }.Uri;
+
+    /// <summary>
+    /// Resolves the next page from the response's <c>Link</c> header.
+    /// </summary>
+    /// <param name="response">The response just read.</param>
+    /// <param name="origin">The collection URL the read started from.</param>
+    /// <returns>The next page, or <see langword="null"/> when there is none.</returns>
+    /// <remarks>
+    /// The link is a URL out of a response, so it is followed only when it stays on the host the read
+    /// started from. Without that check a compromised or spoofed response could walk the proxy's
+    /// authenticated back channel — carrying the user's access token — to a host of its choosing.
+    /// </remarks>
+    static Uri? NextPage(HttpResponseMessage response, Uri origin)
+    {
+        if (!response.Headers.TryGetValues(LinkHeader, out var headers))
+        {
+            return null;
+        }
+
+        foreach (var candidate in headers.SelectMany(header => header.Split(',')))
+        {
+            var segments = candidate.Split(';');
+            if (segments.Length < 2 || !segments.Any(_ => _.Contains(NextRelation, StringComparison.OrdinalIgnoreCase)))
+            {
+                continue;
+            }
+
+            if (Uri.TryCreate(segments[0].Trim().Trim('<', '>'), UriKind.Absolute, out var next)
+                && string.Equals(next.Scheme, origin.Scheme, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(next.Authority, origin.Authority, StringComparison.OrdinalIgnoreCase))
+            {
+                return next;
+            }
+        }
+
+        return null;
+    }
+}

--- a/Source/AuthProxy/Authentication/IProviderClaimsEnricher.cs
+++ b/Source/AuthProxy/Authentication/IProviderClaimsEnricher.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Security.Claims;
+using C = Cratis.AuthProxy.Configuration;
+
+namespace Cratis.AuthProxy.Authentication;
+
+/// <summary>
+/// Defines something that adds provider-specific claims to an identity while a sign-in is being completed.
+/// </summary>
+/// <remarks>
+/// An OAuth 2.0 provider's user-information endpoint returns a profile, and
+/// <see cref="C.OAuthProvider.ClaimMappings"/> turns fields of that profile into claims. Anything the
+/// provider keeps behind a <em>different</em> endpoint — GitHub's organization and team membership is the
+/// case that motivated this — has no field to map, so it needs fetching before the ticket is signed in.
+/// <para>
+/// Doing it here rather than in a provider-specific authorization rule keeps one authorization mechanism
+/// instead of two: what arrives is an ordinary claim, so the generic claim requirements gate on it, and
+/// the application behind the proxy receives it on the forwarded principal like every other claim.
+/// </para>
+/// </remarks>
+public interface IProviderClaimsEnricher
+{
+    /// <summary>
+    /// Determines whether this enricher has anything to contribute for a provider.
+    /// </summary>
+    /// <param name="provider">The OAuth provider completing a sign-in.</param>
+    /// <returns><see langword="true"/> when it applies to the provider; otherwise <see langword="false"/>.</returns>
+    bool CanEnrich(C.OAuthProvider provider);
+
+    /// <summary>
+    /// Adds claims to the identity being signed in.
+    /// </summary>
+    /// <param name="identity">The identity to add claims to.</param>
+    /// <param name="provider">The OAuth provider completing the sign-in.</param>
+    /// <param name="backchannel">The provider handler's HTTP client, already configured for the provider.</param>
+    /// <param name="accessToken">The access token issued for the signing-in user.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> for the operation.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    /// <remarks>
+    /// An implementation must never throw. It runs inside the sign-in handshake, so a failure here would
+    /// surface to the user as a broken login rather than as the missing claims it actually is — and the
+    /// missing claims already fail closed, because a requirement naming a claim that was never added is
+    /// not satisfied.
+    /// </remarks>
+    Task Enrich(ClaimsIdentity identity, C.OAuthProvider provider, HttpClient backchannel, string accessToken, CancellationToken cancellationToken);
+}

--- a/Source/AuthProxy/Authorization/AccessControlMiddleware.cs
+++ b/Source/AuthProxy/Authorization/AccessControlMiddleware.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.ErrorPages;
+using Microsoft.Extensions.Options;
+using C = Cratis.AuthProxy.Configuration;
+
+namespace Cratis.AuthProxy.Authorization;
+
+/// <summary>
+/// Middleware that refuses an authenticated caller who does not satisfy the claim requirements declared in
+/// <see cref="C.AuthProxy.Authorization"/> or on the targeted <see cref="C.Service"/>.
+/// </summary>
+/// <remarks>
+/// It runs directly after authorization and ahead of tenancy, identity resolution and the reverse proxy,
+/// so a caller who is not allowed in is turned away before any of them run — no tenant is resolved, no
+/// <c>/.cratis/me</c> call is made against a backend, and nothing is forwarded. That ordering is the whole
+/// point of calling it a first gate.
+/// <para>
+/// The refusal is an HTML page at <c>403</c> rather than a redirect. A redirect back to the identity
+/// provider is the obvious wrong answer here: the caller is already signed in and would sign in again as
+/// the same person, so it loops. <c>403</c> is also a status a non-browser caller can act on, unlike the
+/// <c>200</c> a provider-selection page has to be served with, so the same answer works for both and the
+/// page carries the way out — signing out and coming back as someone else.
+/// </para>
+/// <para>
+/// Skipped for anyone with no session, for the authentication endpoints themselves, and for paths a
+/// service declares in <see cref="C.Service.AnonymousPaths"/>. The last is not an exemption so much as an
+/// impossibility: a declared path exists precisely for callers who have no session — a webhook receiver, a
+/// magic-link landing page — and a caller with no session has no claims to satisfy any requirement with,
+/// so gating those paths would refuse every one of them.
+/// </para>
+/// </remarks>
+/// <param name="next">The next middleware in the pipeline.</param>
+/// <param name="config">The auth proxy configuration monitor.</param>
+/// <param name="accessPolicy">The policy deciding whether the caller may pass.</param>
+/// <param name="errorPageProvider">The error page provider used to serve the refusal page.</param>
+/// <param name="logger">The logger.</param>
+public class AccessControlMiddleware(
+    RequestDelegate next,
+    IOptionsMonitor<C.AuthProxy> config,
+    IAccessPolicy accessPolicy,
+    IErrorPageProvider errorPageProvider,
+    ILogger<AccessControlMiddleware> logger)
+{
+    /// <inheritdoc cref="IMiddleware.InvokeAsync"/>
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var current = config.CurrentValue;
+
+        if (!accessPolicy.IsConfigured(current)
+            || context.User.Identity?.IsAuthenticated != true
+            || context.IsAuthenticationBootstrap()
+            || context.IsAnonymousPath(current))
+        {
+            await next(context);
+            return;
+        }
+
+        var decision = accessPolicy.Evaluate(context, current);
+        if (decision.IsGranted)
+        {
+            await next(context);
+            return;
+        }
+
+        logger.AccessDenied(decision.UnsatisfiedClaim, SanitizePath(context.Request.Path));
+
+        await errorPageProvider.WriteErrorPageAsync(
+            context,
+            WellKnownPageNames.NotAuthorized,
+            StatusCodes.Status403Forbidden);
+    }
+
+    static string SanitizePath(PathString path) =>
+        (path.Value ?? string.Empty).Replace('\r', '_').Replace('\n', '_');
+}

--- a/Source/AuthProxy/Authorization/AccessControlMiddlewareLogging.cs
+++ b/Source/AuthProxy/Authorization/AccessControlMiddlewareLogging.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authorization;
+
+internal static partial class AccessControlMiddlewareLogging
+{
+    [LoggerMessage(LogLevel.Warning, "Authenticated caller does not satisfy the required claim '{Claim}' for request {Path}. Serving the not-authorized page.")]
+    internal static partial void AccessDenied(this ILogger logger, string claim, string path);
+}

--- a/Source/AuthProxy/Authorization/AccessDecision.cs
+++ b/Source/AuthProxy/Authorization/AccessDecision.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authorization;
+
+/// <summary>
+/// Represents the outcome of evaluating the configured claim requirements for a request.
+/// </summary>
+/// <param name="IsGranted">Whether the caller satisfies every configured requirement.</param>
+/// <param name="UnsatisfiedClaim">
+/// The claim type of the first requirement the caller did not satisfy; empty when access is granted.
+/// </param>
+/// <remarks>
+/// The unsatisfied claim is carried so a refusal can be logged as something an operator can act on. A
+/// deployment that gates on organization membership and a deployment that gates on a role produce the
+/// same <c>403</c>, and "which requirement was it" is the only part that differs and the only part worth
+/// looking up. It is deliberately the claim <em>type</em> and never the value the caller carried, which
+/// would put an identity into the log.
+/// </remarks>
+public record AccessDecision(bool IsGranted, string UnsatisfiedClaim)
+{
+    /// <summary>
+    /// Gets the decision for a caller that satisfies everything required of them.
+    /// </summary>
+    public static AccessDecision Granted { get; } = new(true, string.Empty);
+
+    /// <summary>
+    /// Creates the decision for a caller that failed a requirement.
+    /// </summary>
+    /// <param name="unsatisfiedClaim">The claim type of the requirement that was not satisfied.</param>
+    /// <returns>A denied <see cref="AccessDecision"/>.</returns>
+    public static AccessDecision Denied(string unsatisfiedClaim) => new(false, unsatisfiedClaim);
+}

--- a/Source/AuthProxy/Authorization/AccessPolicy.cs
+++ b/Source/AuthProxy/Authorization/AccessPolicy.cs
@@ -1,0 +1,150 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Security.Claims;
+using C = Cratis.AuthProxy.Configuration;
+
+namespace Cratis.AuthProxy.Authorization;
+
+/// <summary>
+/// Decides whether an authenticated caller satisfies the claim requirements declared for the proxy and for
+/// the service the request targets.
+/// </summary>
+/// <remarks>
+/// The composition is deliberately the strict one in both directions: root requirements and service
+/// requirements are <em>added</em> together rather than the service overriding the root, and every
+/// requirement in the combined set has to hold. A service can therefore only ever narrow who reaches it,
+/// which is the property that makes a root requirement worth writing — if a service section could replace
+/// it, the root would be a default rather than a floor, and a service added later without an
+/// <c>Authorization</c> section would silently be the way in.
+/// </remarks>
+public class AccessPolicy : IAccessPolicy
+{
+    /// <summary>
+    /// The query-string parameter naming the target service, mirrored from the reverse-proxy route table.
+    /// </summary>
+    const string ServiceQueryParameter = "service";
+
+    /// <inheritdoc/>
+    public bool IsConfigured(C.AuthProxy config) =>
+        config.Authorization.HasRequirements
+        || config.Services.Values.Any(_ => _.Authorization?.HasRequirements == true);
+
+    /// <inheritdoc/>
+    public AccessDecision Evaluate(HttpContext context, C.AuthProxy config)
+    {
+        foreach (var requirement in RequirementsFor(context, config))
+        {
+            if (!IsSatisfied(requirement, context.User))
+            {
+                return AccessDecision.Denied(requirement.Claim);
+            }
+        }
+
+        return AccessDecision.Granted;
+    }
+
+    /// <summary>
+    /// Gets every requirement that applies to a request: the root's, then the target service's.
+    /// </summary>
+    /// <param name="context">The current <see cref="HttpContext"/>.</param>
+    /// <param name="config">The auth proxy configuration to read.</param>
+    /// <returns>The applicable requirements, root-first.</returns>
+    static IEnumerable<C.ClaimRequirement> RequirementsFor(HttpContext context, C.AuthProxy config)
+    {
+        foreach (var requirement in config.Authorization.RequiredClaims)
+        {
+            yield return requirement;
+        }
+
+        var service = ResolveService(context, config);
+        if (service?.Authorization is null)
+        {
+            yield break;
+        }
+
+        foreach (var requirement in service.Authorization.RequiredClaims)
+        {
+            yield return requirement;
+        }
+    }
+
+    /// <summary>
+    /// Resolves the service a request targets, the same way the route table does.
+    /// </summary>
+    /// <param name="context">The current <see cref="HttpContext"/>.</param>
+    /// <param name="config">The auth proxy configuration to read.</param>
+    /// <returns>The targeted service, or <see langword="null"/> when the request names none.</returns>
+    /// <remarks>
+    /// This runs before endpoint selection — the gate has to refuse a caller before anything reads a
+    /// backend, and long before YARP picks a route — so the target is worked out from the request rather
+    /// than from a selected endpoint. It mirrors <c>MicroserviceReverseProxyConfigProvider</c> exactly: a
+    /// single-service deployment routes everything to that service, and beyond that a service is named by
+    /// the <c>Service-ID</c> header or the <c>service</c> query parameter, header first.
+    /// <para>
+    /// A request in a multi-service deployment that names no service reaches no service route either, so
+    /// answering <see langword="null"/> costs nothing: the root requirements still apply, and the request
+    /// goes on to match nothing.
+    /// </para>
+    /// </remarks>
+    static C.Service? ResolveService(HttpContext context, C.AuthProxy config)
+    {
+        if (config.Services.Count == 1)
+        {
+            return config.Services.Values.First();
+        }
+
+        var serviceId = context.Request.Headers[Headers.ServiceId].FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(serviceId))
+        {
+            serviceId = context.Request.Query[ServiceQueryParameter].FirstOrDefault();
+        }
+
+        if (string.IsNullOrWhiteSpace(serviceId))
+        {
+            return null;
+        }
+
+        return config.Services
+            .Where(_ => string.Equals(_.Key, serviceId.Trim(), StringComparison.OrdinalIgnoreCase))
+            .Select(_ => _.Value)
+            .FirstOrDefault();
+    }
+
+    /// <summary>
+    /// Determines whether a principal satisfies a single requirement.
+    /// </summary>
+    /// <param name="requirement">The requirement to evaluate.</param>
+    /// <param name="user">The authenticated principal.</param>
+    /// <returns><see langword="true"/> when the requirement is satisfied; otherwise <see langword="false"/>.</returns>
+    /// <remarks>
+    /// A requirement naming no claim can never be satisfied, so it denies. That is the fail-closed
+    /// direction, and the opposite of how an unusable <c>AnonymousPaths</c> entry is treated: discarding an
+    /// entry there leaves a path authenticated, discarding a requirement here would let everybody in.
+    /// Startup validation refuses the configuration outright, so this is the second line rather than the
+    /// first.
+    /// <para>
+    /// Values are compared case-insensitively. The values being matched are organization names, team
+    /// slugs, group names and roles — identifiers their own systems treat as case-insensitive — so an
+    /// ordinal comparison would turn <c>cratis</c> against <c>Cratis</c> into a locked-out deployment with
+    /// nothing in the response to say why.
+    /// </para>
+    /// </remarks>
+    static bool IsSatisfied(C.ClaimRequirement requirement, ClaimsPrincipal user)
+    {
+        if (string.IsNullOrWhiteSpace(requirement.Claim))
+        {
+            return false;
+        }
+
+        var claims = user.FindAll(requirement.Claim.Trim());
+        var allowed = requirement.AnyOf;
+
+        if (allowed.Count == 0)
+        {
+            return claims.Any();
+        }
+
+        return claims.Any(claim => allowed.Any(value => string.Equals(value.Trim(), claim.Value.Trim(), StringComparison.OrdinalIgnoreCase)));
+    }
+}

--- a/Source/AuthProxy/Authorization/AuthorizationConfigurationValidator.cs
+++ b/Source/AuthProxy/Authorization/AuthorizationConfigurationValidator.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Options;
+using C = Cratis.AuthProxy.Configuration;
+
+namespace Cratis.AuthProxy.Authorization;
+
+/// <summary>
+/// Refuses a configuration declaring a claim requirement that names no claim.
+/// </summary>
+/// <remarks>
+/// Such a requirement can never be satisfied, so the proxy would start and then refuse every single
+/// caller — an outage whose cause is a blank value in an environment variable and whose symptom is a
+/// <c>403</c> page saying nothing about it. Failing at startup names it instead, at the one moment
+/// somebody is watching.
+/// <para>
+/// The alternative — dropping the malformed requirement — is the one thing that must not happen: a
+/// requirement that is silently not applied is a gate that is silently open, which is the failure mode
+/// this whole feature exists to close.
+/// </para>
+/// </remarks>
+public class AuthorizationConfigurationValidator : IValidateOptions<C.AuthProxy>
+{
+    /// <inheritdoc/>
+    public ValidateOptionsResult Validate(string? name, C.AuthProxy options)
+    {
+        var failures = new List<string>();
+
+        AddFailureForBlankClaims(options.Authorization, "Cratis:AuthProxy:Authorization", failures);
+
+        foreach (var (key, service) in options.Services)
+        {
+            AddFailureForBlankClaims(service.Authorization, $"Cratis:AuthProxy:Services:{key}:Authorization", failures);
+        }
+
+        return failures.Count > 0
+            ? ValidateOptionsResult.Fail(failures)
+            : ValidateOptionsResult.Success;
+    }
+
+    static void AddFailureForBlankClaims(C.Authorization? authorization, string section, List<string> failures)
+    {
+        if (authorization is null)
+        {
+            return;
+        }
+
+        for (var index = 0; index < authorization.RequiredClaims.Count; index++)
+        {
+            if (string.IsNullOrWhiteSpace(authorization.RequiredClaims[index].Claim))
+            {
+                failures.Add($"{section}:RequiredClaims:{index}:Claim must name a claim type. A requirement without one can never be satisfied and would refuse every caller.");
+            }
+        }
+    }
+}

--- a/Source/AuthProxy/Authorization/AuthorizationServiceCollectionExtensions.cs
+++ b/Source/AuthProxy/Authorization/AuthorizationServiceCollectionExtensions.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Options;
+using C = Cratis.AuthProxy.Configuration;
+
+namespace Cratis.AuthProxy.Authorization;
+
+/// <summary>
+/// Extension methods for registering the first-gate authorization services on <see cref="WebApplicationBuilder"/>.
+/// </summary>
+public static class AuthorizationServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the access policy and the validation that refuses an unsatisfiable claim requirement at startup.
+    /// </summary>
+    /// <param name="builder">The <see cref="WebApplicationBuilder"/> to configure.</param>
+    /// <returns>The same <see cref="WebApplicationBuilder"/> for chaining.</returns>
+    public static WebApplicationBuilder AddIngressAuthorization(this WebApplicationBuilder builder)
+    {
+        builder.Services.AddSingleton<IAccessPolicy, AccessPolicy>();
+        builder.Services.AddSingleton<IValidateOptions<C.AuthProxy>, AuthorizationConfigurationValidator>();
+
+        return builder;
+    }
+}

--- a/Source/AuthProxy/Authorization/IAccessPolicy.cs
+++ b/Source/AuthProxy/Authorization/IAccessPolicy.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using C = Cratis.AuthProxy.Configuration;
+
+namespace Cratis.AuthProxy.Authorization;
+
+/// <summary>
+/// Defines the policy deciding whether an authenticated caller may pass the proxy at all.
+/// </summary>
+public interface IAccessPolicy
+{
+    /// <summary>
+    /// Determines whether the configuration declares anything to authorize against.
+    /// </summary>
+    /// <param name="config">The auth proxy configuration to read.</param>
+    /// <returns><see langword="true"/> when at least one requirement is declared; otherwise <see langword="false"/>.</returns>
+    /// <remarks>
+    /// Nothing declared is the state every deployment that never opts in is in, and it has to stay
+    /// indistinguishable from this feature not existing. Asking first keeps the whole evaluation — and the
+    /// question of which service a request targets — off the path of a deployment that does not use it.
+    /// </remarks>
+    bool IsConfigured(C.AuthProxy config);
+
+    /// <summary>
+    /// Evaluates the configured claim requirements against the caller on the current request.
+    /// </summary>
+    /// <param name="context">The current <see cref="HttpContext"/>, carrying the authenticated principal.</param>
+    /// <param name="config">The auth proxy configuration to read.</param>
+    /// <returns>The <see cref="AccessDecision"/> for this caller and request.</returns>
+    AccessDecision Evaluate(HttpContext context, C.AuthProxy config);
+}

--- a/Source/AuthProxy/Configuration/AuthProxy.cs
+++ b/Source/AuthProxy/Configuration/AuthProxy.cs
@@ -19,6 +19,13 @@ public class AuthProxy
     public Authentication Authentication { get; set; } = new();
 
     /// <summary>
+    /// Gets or sets the authorization configuration applied to every service — the first gate an
+    /// authenticated caller has to pass before any request is forwarded.
+    /// Leave it empty (the default) to authenticate without authorizing, as the proxy has always done.
+    /// </summary>
+    public Authorization Authorization { get; set; } = new();
+
+    /// <summary>
     /// Gets or sets the browser-session hardening configuration: the bounded authentication session
     /// lifetime and the identity/tenant re-validation intervals.
     /// </summary>

--- a/Source/AuthProxy/Configuration/Authorization.cs
+++ b/Source/AuthProxy/Configuration/Authorization.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Configuration;
+
+/// <summary>
+/// Represents the first-gate authorization configuration: what an authenticated caller must carry before
+/// the proxy will let the request through to a service at all.
+/// </summary>
+/// <remarks>
+/// Authentication answers <em>who</em> a caller is; on a public host that is not the same as deciding
+/// whether they may be here. Without this, any account the configured identity provider is willing to
+/// authenticate — which for a public provider such as GitHub is every account on the internet — completes
+/// sign-in and reaches the application. Declaring requirements here turns the proxy into the first gate,
+/// so the application is never asked to answer for a caller who should not have arrived.
+/// <para>
+/// Declared at the root it applies to every service; declared on a <see cref="Service"/> it applies to
+/// that service in addition to the root's. Nothing declared anywhere is the default, and it leaves the
+/// proxy behaving exactly as it did before this existed.
+/// </para>
+/// </remarks>
+public class Authorization
+{
+    /// <summary>
+    /// The configuration section key for the global authorization settings.
+    /// </summary>
+    public const string SectionKey = $"{AuthProxy.SectionKey}:Authorization";
+
+    /// <summary>
+    /// Gets or sets the claim requirements an authenticated caller must satisfy.
+    /// </summary>
+    /// <remarks>
+    /// <strong>Every</strong> requirement must hold — the list is an <em>and</em>. Within one requirement,
+    /// any of its listed values will do — <see cref="ClaimRequirement.AnyOf"/> is an <em>or</em>. Express
+    /// "in this organization <em>and</em> on this team" as two requirements, and "in either of these two
+    /// organizations" as one requirement with two values.
+    /// </remarks>
+    public IList<ClaimRequirement> RequiredClaims { get; set; } = [];
+
+    /// <summary>
+    /// Gets a value indicating whether anything is required at all.
+    /// </summary>
+    public bool HasRequirements => RequiredClaims.Count > 0;
+}

--- a/Source/AuthProxy/Configuration/ClaimRequirement.cs
+++ b/Source/AuthProxy/Configuration/ClaimRequirement.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Configuration;
+
+/// <summary>
+/// Represents a single claim a caller must carry to get past the proxy.
+/// </summary>
+/// <remarks>
+/// A requirement is satisfied when the principal carries the named claim and — if <see cref="AnyOf"/>
+/// lists any values — the claim's value is one of them. Listing several values is therefore an
+/// <em>or</em>: "in any of these organizations". Requiring several claims (see
+/// <see cref="Authorization.RequiredClaims"/>) is an <em>and</em>: every requirement has to hold.
+/// <para>
+/// Leaving <see cref="AnyOf"/> empty requires the claim to be <em>present</em>, whatever its value. That is
+/// the right shape when the identity provider only emits the claim for the people who should get in.
+/// </para>
+/// </remarks>
+public class ClaimRequirement
+{
+    /// <summary>
+    /// Gets or sets the claim type that must be present on the authenticated principal, for example
+    /// <c>urn:github:organization</c> or <c>roles</c>.
+    /// </summary>
+    public string Claim { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the values that satisfy the requirement. Leave empty to require only that the claim is
+    /// present. Values are compared case-insensitively, after trimming surrounding whitespace.
+    /// </summary>
+    public IList<string> AnyOf { get; set; } = [];
+}

--- a/Source/AuthProxy/Configuration/Service.cs
+++ b/Source/AuthProxy/Configuration/Service.cs
@@ -55,6 +55,21 @@ public class Service
     public IList<string> AnonymousPaths { get; set; } = [];
 
     /// <summary>
+    /// Gets or sets the authorization requirements that apply to requests routed to this service.
+    /// </summary>
+    /// <remarks>
+    /// These are applied <em>in addition to</em> any declared at the root — a service can narrow who gets
+    /// in, never widen it. Leave unset to require only what the root requires.
+    /// <para>
+    /// The service a request targets is resolved the way the route table resolves it: the single
+    /// configured service when there is only one, otherwise the <c>Service-ID</c> header or the
+    /// <c>service</c> query parameter. A request in a multi-service deployment that names no service
+    /// matches no service route either, so only the root requirements apply to it.
+    /// </para>
+    /// </remarks>
+    public Authorization? Authorization { get; set; }
+
+    /// <summary>
     /// Gets or sets whether to call the <c>/.cratis/me</c> identity endpoint on this service
     /// to enrich the identity details cookie. Defaults to <see langword="true"/> when a Backend is configured.
     /// </summary>

--- a/Source/AuthProxy/IngressExtensions.cs
+++ b/Source/AuthProxy/IngressExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.AuthProxy.Authentication;
+using Cratis.AuthProxy.Authorization;
 using Cratis.AuthProxy.ErrorPages;
 using Cratis.AuthProxy.Identity;
 using Cratis.AuthProxy.Invites;
@@ -82,6 +83,7 @@ public static class IngressExtensions
         app.UseMiddleware<Authentication.SelectProviderMiddleware>();
         app.UseMiddleware<LinkMiddleware>();
         app.UseAuthorization();
+        app.UseMiddleware<AccessControlMiddleware>();
         app.UseMiddleware<TenantSelectionMiddleware>();
         app.UseMiddleware<TenancyMiddleware>();
         app.UseMiddleware<InviteMiddleware>();

--- a/Source/AuthProxy/Pages/not-authorized.html
+++ b/Source/AuthProxy/Pages/not-authorized.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Not Authorized</title>
+    <style>
+        body { font-family: system-ui, sans-serif; display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; background: #f5f5f5; }
+        .card { background: #fff; border-radius: 8px; box-shadow: 0 2px 8px rgba(0,0,0,.12); padding: 2.5rem 3rem; text-align: center; max-width: 480px; }
+        h1 { font-size: 1.5rem; font-weight: 700; margin: 0 0 .75rem; color: #333; }
+        p  { color: #666; margin: 0 0 1.5rem; }
+        a.button { display: inline-block; background: #333; color: #fff; text-decoration: none; border-radius: 6px; padding: .65rem 1.4rem; font-size: .95rem; font-weight: 600; }
+        a.button:hover { background: #111; }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <h1>Not authorized</h1>
+        <p>You are signed in, but this account does not have access. If you have another account that does, sign out and sign in with that one.</p>
+        <a class="button" href="/.cratis/logout?redirect=/">Sign out</a>
+    </div>
+</body>
+</html>

--- a/Source/AuthProxy/Program.cs
+++ b/Source/AuthProxy/Program.cs
@@ -3,6 +3,7 @@
 
 using Cratis.AuthProxy;
 using Cratis.AuthProxy.Authentication;
+using Cratis.AuthProxy.Authorization;
 using Cratis.AuthProxy.Identity;
 using Cratis.AuthProxy.Invites;
 using Cratis.AuthProxy.Links;
@@ -16,6 +17,7 @@ builder.Configuration.AddEnvironmentVariables();
 
 builder.AddIngressConfiguration();
 builder.AddIngressAuthentication();
+builder.AddIngressAuthorization();
 builder.AddTenancy();
 builder.AddIdentityResolution();
 builder.AddInvites();

--- a/Source/AuthProxy/WellKnownPageNames.cs
+++ b/Source/AuthProxy/WellKnownPageNames.cs
@@ -19,6 +19,18 @@ public static class WellKnownPageNames
     public const string Forbidden = "403.html";
 
     /// <summary>
+    /// The page returned when an authenticated caller does not satisfy the claim requirements declared in
+    /// <c>Cratis:AuthProxy:Authorization</c> — signed in, but not someone this deployment lets in.
+    /// </summary>
+    /// <remarks>
+    /// Distinct from <see cref="Forbidden"/>, which answers the application refusing a caller it does
+    /// recognize. This one is the proxy refusing before the application is ever reached, and it is the only
+    /// refusal whose remedy is to come back as somebody else — so the page has to offer signing out, or the
+    /// person is stuck on it.
+    /// </remarks>
+    public const string NotAuthorized = "not-authorized.html";
+
+    /// <summary>
     /// The page returned when the resolved tenant does not exist in the system.
     /// </summary>
     public const string TenantNotFound = "tenant-not-found.html";


### PR DESCRIPTION
# Summary

AuthProxy authenticated but never authorized. On a public host with a public identity provider that means every account on the internet completes sign-in and reaches the application. `Cratis:AuthProxy:Authorization` makes the proxy the first gate: an authenticated caller who does not carry what you require never reaches a service at all. It is off unless configured, so an existing deployment is unaffected.

## Added

- `Cratis:AuthProxy:Authorization:RequiredClaims` — require an authenticated caller to carry a claim, optionally with a set of accepted values, before any request is forwarded. Every requirement must be satisfied (an *and*); within one requirement any listed value will do (an *or*). Values are compared case-insensitively.
- The same section on a service (`Cratis:AuthProxy:Services:<key>:Authorization`) applies in addition to the proxy-wide requirements, so a service can narrow who reaches it but never widen it. The targeted service is resolved the way the route table resolves it — the single configured service, otherwise the `Service-ID` header or the `service` query parameter.
- GitHub organization and team membership as claims. A GitHub OAuth provider that requests the `read:org` scope has its organizations and teams read once while sign-in completes and added to the session as `urn:github:organization` and `urn:github:team` (as `organization/team-slug`). The claims also travel to the application on the forwarded principal. GitHub Enterprise works without extra configuration — the endpoints are derived from the configured `UserInformationEndpoint`.
- `not-authorized.html`, a new well-known page served at `403` to a signed-in caller who does not satisfy a requirement. It carries a sign-out link, since coming back as a different account is the only way forward, and can be overridden like every other page through `PagesPath`.
- Aspire builders `WithRequiredClaim(claim, anyOf…)` and `WithRequiredClaimForService(service, claim, anyOf…)`. Repeated calls append.
- Documentation: a new [Authorization](Documentation/configuration/authorization.md) page with a worked GitHub organization and team example, and an OAuth 2.0 provider section in Authentication, which was previously undocumented.

## Changed

- A claim requirement that names no claim type now fails startup, naming the exact configuration key. It could never be satisfied, so starting would refuse every caller and ignoring it would leave the gate silently open.

Notes on behavior worth knowing before configuring it:

- Paths a service declares in `AnonymousPaths` are **not** gated. They exist for callers with no session, who carry no claims, so gating them would refuse every one of them — a webhook receiver would get a `403` it could do nothing about.
- The authentication endpoints and callers with no session are not gated either; the existing sign-in machinery handles them.
- GitHub membership is read at sign-in and lives in the session, so revoked membership takes effect when the session ends — bounded by `Cratis:AuthProxy:Session:Lifetime`.
