### PR TITLE
Fix bundled web assets returning 401 behind a configured reverse proxy

### DIFF
--- a/Source/AuthProxy.Specs/Scenarios/when_a_bundled_web_asset_is_requested/AuthProxyFactory.cs
+++ b/Source/AuthProxy.Specs/Scenarios/when_a_bundled_web_asset_is_requested/AuthProxyFactory.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+
+namespace Cratis.AuthProxy.Scenarios.when_a_bundled_web_asset_is_requested;
+
+/// <summary>
+/// A proxy with a configured backend service — so its reverse-proxy route exists, the way it always does
+/// in a real deployment — and a bundled web asset under <c>wwwroot</c>, the way the login-selection SPA's
+/// build output is.
+/// </summary>
+public class AuthProxyFactory : WebApplicationFactory<Program>
+{
+    public const string BackendBaseUrl = "http://backend.test/";
+    public const string TenantId = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+    public const string AssetPath = "/assets/app.js";
+    public const string AssetContent = "console.log('bundled web asset');";
+
+    readonly string _webRootPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+    public AuthProxyFactory()
+    {
+        var assetsDirectory = Path.Combine(_webRootPath, "assets");
+        Directory.CreateDirectory(assetsDirectory);
+        File.WriteAllText(Path.Combine(assetsDirectory, "app.js"), AssetContent);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        if (disposing && Directory.Exists(_webRootPath))
+        {
+            Directory.Delete(_webRootPath, recursive: true);
+        }
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder
+            .UseEnvironment("Production")
+            .UseWebRoot(_webRootPath)
+            .ConfigureAppConfiguration((_, config) => config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                // A configured backend is what gives the reverse proxy a real route to match — the
+                // condition every production deployment is always in, and the one the bug depended on.
+                [$"{C.AuthProxy.SectionKey}:Services:app:Backend:BaseUrl"] = BackendBaseUrl,
+                [$"{C.AuthProxy.SectionKey}:Services:app:Frontend:BaseUrl"] = BackendBaseUrl,
+
+                [$"{C.AuthProxy.SectionKey}:TenantResolutions:0:Strategy"] = nameof(C.TenantSourceIdentifierResolverType.Specified),
+                [$"{C.AuthProxy.SectionKey}:TenantResolutions:0:Options:TenantId"] = TenantId,
+            }));
+    }
+
+    public HttpClient CreateAnonymousClient() =>
+        CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+}

--- a/Source/AuthProxy.Specs/Scenarios/when_a_bundled_web_asset_is_requested/and_the_caller_is_anonymous.cs
+++ b/Source/AuthProxy.Specs/Scenarios/when_a_bundled_web_asset_is_requested/and_the_caller_is_anonymous.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Scenarios.when_a_bundled_web_asset_is_requested;
+
+/// <summary>
+/// Regression coverage for a bundled <c>wwwroot</c> asset (e.g. the login-selection SPA's own script)
+/// being refused instead of served once the reverse proxy has a real backend configured. Without an
+/// explicit <c>UseRouting()</c> anchored after <c>UseStaticFiles()</c>, ASP.NET Core's implicit routing
+/// insertion matches the reverse proxy's catch-all route before static files run, and
+/// <c>UseStaticFiles</c> — being endpoint-aware — skips a request that already carries a matched endpoint.
+/// The request then falls through to <c>SelectProviderMiddleware</c>, which refuses every unauthenticated,
+/// non-navigating caller with a <c>401</c>, so the asset never loads and the page it belongs to renders
+/// blank.
+/// </summary>
+/// <param name="factory">The proxy under test, with a real backend route and a bundled asset.</param>
+public class and_the_caller_is_anonymous(AuthProxyFactory factory) : IClassFixture<AuthProxyFactory>, IAsyncLifetime
+{
+    HttpResponseMessage? _response;
+    string? _responseBody;
+
+    public async Task InitializeAsync()
+    {
+        using var client = factory.CreateAnonymousClient();
+        _response = await client.GetAsync(AuthProxyFactory.AssetPath);
+        _responseBody = await _response.Content.ReadAsStringAsync();
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact] public void should_return_200() => Assert.Equal(System.Net.HttpStatusCode.OK, _response!.StatusCode);
+    [Fact] public void should_return_the_asset_content() => Assert.Equal(AuthProxyFactory.AssetContent, _responseBody);
+}

--- a/Source/AuthProxy/IngressExtensions.cs
+++ b/Source/AuthProxy/IngressExtensions.cs
@@ -78,6 +78,17 @@ public static class IngressExtensions
         app.UseForwardedHeaders();
         app.Map(WellKnownPaths.Pages, pagesApp => ConfigurePagesPipeline(pagesApp, app.Environment, app.Services.GetRequiredService<IOptionsMonitor<C.AuthProxy>>()));
         app.UseStaticFiles();
+
+        // Without an explicit UseRouting(), ASP.NET Core's implicit routing insertion matches an endpoint
+        // before UseStaticFiles ever runs whenever the reverse proxy has a configured route — YARP's
+        // catch-all matches every path, including this app's own bundled assets. UseStaticFiles is
+        // endpoint-aware and skips serving a file once an endpoint is already selected for the request
+        // (see https://learn.microsoft.com/aspnet/core/fundamentals/static-files), so every asset request
+        // fell through to SelectProviderMiddleware and was refused with 401 instead of being served. Placing
+        // UseRouting() here, right after UseStaticFiles(), anchors endpoint matching to this exact position
+        // so static files are always served before any route — including the reverse proxy's — can claim
+        // the request.
+        app.UseRouting();
         app.UseAuthentication();
         app.UseMiddleware<LogoutMiddleware>();
         app.UseMiddleware<Authentication.SelectProviderMiddleware>();


### PR DESCRIPTION
## Fixed

- Fixed the login-selection page (and any other bundled `wwwroot` asset) rendering a blank page for anyone signing in or accepting an invite. `UseIngress()` never called `app.UseRouting()` explicitly, so once the reverse proxy had a configured backend — the case in every real deployment — ASP.NET Core's implicit routing insertion matched the proxy's catch-all route against every request, including AuthProxy's own bundled assets. `UseStaticFiles()` is endpoint-aware and skips serving a file once a route is already matched, so every asset request fell through to `SelectProviderMiddleware`, which refuses unauthenticated, non-navigating callers with a `401`.