### PR TITLE
Serve the branded selection page when landing on its own path

### DIFF
--- a/Source/AuthProxy.Specs/Authentication/for_SelectProviderMiddleware/when_request_is_for_the_selection_page_itself/and_a_single_provider_is_configured_with_an_explicit_return_url.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_SelectProviderMiddleware/when_request_is_for_the_selection_page_itself/and_a_single_provider_is_configured_with_an_explicit_return_url.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.Authentication.for_SelectProviderMiddleware.when_request_is_for_the_selection_page_itself;
+
+/// <summary>
+/// When the caller already landed on <c>/.cratis/select-provider?returnUrl=...</c> — the wrapper the
+/// cookie authentication handler's redirect and the invite flow use — the real destination is the query
+/// value, not the wrapper path around it. Regression coverage for a challenge that used to redirect back
+/// to the wrapper URL instead of the caller's actual destination once this path stopped being skipped.
+/// </summary>
+public class and_a_single_provider_is_configured_with_an_explicit_return_url : Specification
+{
+    SelectProviderMiddleware _middleware;
+    DefaultHttpContext _context;
+    AuthenticationProperties _challengeProperties;
+
+    void Establish()
+    {
+        var proxyConfig = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        proxyConfig.CurrentValue.Returns(new C.AuthProxy());
+
+        var authConfig = Substitute.For<IOptionsMonitor<C.Authentication>>();
+        authConfig.CurrentValue.Returns(new C.Authentication
+        {
+            OidcProviders = [new C.OidcProvider { Name = "my-provider", Authority = "https://auth.example.com", ClientId = "id" }]
+        });
+
+        _middleware = new SelectProviderMiddleware(
+            _ => Task.CompletedTask,
+            proxyConfig,
+            authConfig,
+            Substitute.For<IErrorPageProvider>(),
+            Substitute.For<ITenantResolver>(),
+            Substitute.For<IAuthenticationSchemeProvider>());
+
+        _context = new DefaultHttpContext();
+        _context.Request.Path = WellKnownPaths.LoginPage;
+        _context.Request.QueryString = new QueryString("?returnUrl=%2Finvite%2Fabc123");
+        _context.Request.Headers["Sec-Fetch-Dest"] = "document";
+        _context.Response.Body = new System.IO.MemoryStream();
+
+        var authService = Substitute.For<IAuthenticationService>();
+        authService
+            .ChallengeAsync(Arg.Any<HttpContext>(), Arg.Any<string>(), Arg.Do<AuthenticationProperties>(p => _challengeProperties = p))
+            .Returns(Task.CompletedTask);
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IAuthenticationService)).Returns(authService);
+        _context.RequestServices = serviceProvider;
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_redirect_to_the_unwrapped_return_url() => _challengeProperties.RedirectUri.ShouldEqual("/invite/abc123");
+}

--- a/Source/AuthProxy.Specs/Authentication/for_SelectProviderMiddleware/when_request_is_for_the_selection_page_itself/and_multiple_providers_are_configured.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_SelectProviderMiddleware/when_request_is_for_the_selection_page_itself/and_multiple_providers_are_configured.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.Authentication.for_SelectProviderMiddleware.when_request_is_for_the_selection_page_itself;
+
+/// <summary>
+/// A request landing directly on <c>/.cratis/select-provider</c> — the way the cookie authentication
+/// handler's redirect and the invite flow both send an unauthenticated caller there — must be answered
+/// by this middleware itself, not deferred to a later handler. Regression coverage: this path used to be
+/// treated as already-authentication-UI and skipped via <c>next()</c>, landing on a separate, unbranded
+/// page instead of the one this middleware serves for every other unauthenticated request.
+/// </summary>
+public class and_multiple_providers_are_configured : Specification
+{
+    SelectProviderMiddleware _middleware;
+    DefaultHttpContext _context;
+    bool _nextCalled;
+    IErrorPageProvider _errorPageProvider;
+
+    void Establish()
+    {
+        var authConfig = Substitute.For<IOptionsMonitor<C.Authentication>>();
+        authConfig.CurrentValue.Returns(new C.Authentication
+        {
+            OidcProviders =
+            [
+                new C.OidcProvider { Name = "Provider One", Authority = "https://a.example.com", ClientId = "c1" },
+                new C.OidcProvider { Name = "Provider Two", Authority = "https://b.example.com", ClientId = "c2" }
+            ]
+        });
+
+        _errorPageProvider = Substitute.For<IErrorPageProvider>();
+        _errorPageProvider
+            .WriteErrorPageAsync(Arg.Any<HttpContext>(), Arg.Any<string>(), Arg.Any<int>())
+            .Returns(Task.CompletedTask);
+
+        var proxyConfig = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        proxyConfig.CurrentValue.Returns(new C.AuthProxy());
+
+        _middleware = new SelectProviderMiddleware(
+            _ =>
+            {
+                _nextCalled = true;
+                return Task.CompletedTask;
+            },
+            proxyConfig,
+            authConfig,
+            _errorPageProvider,
+            Substitute.For<ITenantResolver>(),
+            Substitute.For<IAuthenticationSchemeProvider>());
+
+        _context = new DefaultHttpContext();
+        _context.Request.Path = WellKnownPaths.LoginPage;
+        _context.Request.QueryString = new QueryString("?returnUrl=%2Finvite%2Fabc123");
+        _context.Request.Headers["Sec-Fetch-Dest"] = "document";
+        _context.Response.Body = new System.IO.MemoryStream();
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_not_call_next() => _nextCalled.ShouldBeFalse();
+
+    [Fact]
+    void should_serve_select_provider_page() =>
+        _errorPageProvider.Received(1).WriteErrorPageAsync(
+            _context,
+            WellKnownPageNames.SelectProvider,
+            StatusCodes.Status200OK);
+}

--- a/Source/AuthProxy/Authentication/SelectProviderMiddleware.cs
+++ b/Source/AuthProxy/Authentication/SelectProviderMiddleware.cs
@@ -17,8 +17,11 @@ namespace Cratis.AuthProxy.Authentication;
 /// enabled and a lobby URL is configured), unauthenticated requests without an invite token or
 /// pending invite cookie are immediately answered with the <c>invitation-required.html</c> page
 /// instead of being redirected to a login provider.
-/// Skips invite paths, authentication paths, paths a service declares in
-/// <see cref="C.Service.AnonymousPaths"/>, and requests with a pending invite cookie.
+/// Skips invite paths, registration paths, a provider's login-challenge endpoint, the providers and
+/// token endpoints, paths a service declares in <see cref="C.Service.AnonymousPaths"/>, and requests
+/// with a pending invite cookie. It does NOT skip its own selection-page path — a request landing there
+/// directly (e.g. a redirect from the cookie authentication handler, or an invite flow) is exactly what
+/// this middleware answers.
 /// Both answers are only served to a browser navigating to a document; every other caller is refused
 /// with <c>401</c>, because a page or a login redirect reads as a delivered success to a client that
 /// checks the status code.
@@ -49,7 +52,9 @@ public class SelectProviderMiddleware(
         if (context.User.Identity?.IsAuthenticated == true
             || context.IsInvitation()
             || context.IsRegistration()
-            || context.IsAuthenticationUI()
+            || context.IsLoginChallenge()
+            || context.IsProviders()
+            || context.IsToken()
             || context.IsAnonymousPath(proxyConfig.CurrentValue)
             || context.HasPendingInvitation())
         {
@@ -112,9 +117,36 @@ public class SelectProviderMiddleware(
         }
 
         var scheme = OidcProviderScheme.FromName(providers[0].Name);
-        var returnUrl = context.GetPathAndQuery();
+        var returnUrl = ResolveReturnUrl(context);
         var properties = TenantAuthenticationState.CreateChallengeProperties(context, tenantResolver, returnUrl);
         await context.ChallengeAsync(scheme, properties);
+    }
+
+    /// <summary>
+    /// Resolves where the caller should land after signing in.
+    /// </summary>
+    /// <param name="context">The current <see cref="HttpContext"/>.</param>
+    /// <returns>The resolved return URL.</returns>
+    /// <remarks>
+    /// Ordinarily the current request IS the destination — this middleware answers in place of
+    /// whatever the caller was navigating to, so its path and query say where that was. The one
+    /// exception is a request that already landed on the selection page's own path carrying an
+    /// explicit <c>returnUrl</c> — the cookie authentication handler's redirect, or the invite flow,
+    /// send callers there this way — in which case that query value, not the wrapper URL around it, is
+    /// the real destination.
+    /// </remarks>
+    static string ResolveReturnUrl(HttpContext context)
+    {
+        if (context.Request.Path.StartsWithSegments(WellKnownPaths.LoginPage))
+        {
+            var explicitReturnUrl = context.Request.Query["returnUrl"].FirstOrDefault();
+            if (!string.IsNullOrEmpty(explicitReturnUrl))
+            {
+                return explicitReturnUrl;
+            }
+        }
+
+        return context.GetPathAndQuery();
     }
 
     /// <summary>

--- a/Source/AuthProxy/HttpContextExtensions.cs
+++ b/Source/AuthProxy/HttpContextExtensions.cs
@@ -59,6 +59,20 @@ public static class HttpContextExtensions
         || context.Request.Path.StartsWithSegments(WellKnownPaths.LoginPage);
 
     /// <summary>
+    /// Determines whether the request targets a specific provider's login challenge endpoint
+    /// (e.g. <c>/.cratis/login/github</c>) — as opposed to the provider-selection page itself.
+    /// </summary>
+    /// <param name="context">The <see cref="HttpContext"/> to evaluate.</param>
+    /// <returns><see langword="true"/> if the request initiates a specific provider's challenge; otherwise <see langword="false"/>.</returns>
+    /// <remarks>
+    /// <see cref="Cratis.AuthProxy.Authentication.SelectProviderMiddleware"/> uses this instead of <see cref="IsLogin"/> to decide
+    /// whether to defer to a later handler: it must defer for a challenge-initiation request (there is
+    /// one further down the pipeline that starts it), but must NOT defer for the selection page's own
+    /// path — that page is what it answers.
+    /// </remarks>
+    public static bool IsLoginChallenge(this HttpContext context) => context.Request.Path.StartsWithSegments(WellKnownPaths.LoginPrefix);
+
+    /// <summary>
     /// Determines whether the request targets the well-known providers endpoint.
     /// </summary>
     /// <param name="context">The <see cref="HttpContext"/> to evaluate.</param>


### PR DESCRIPTION
## Fixed

- Fixed the sign-in page a caller sees after being redirected to accept an invite or from any other unauthenticated deep link no longer matching the branded selection page shown on a direct visit to `/`. `SelectProviderMiddleware` deferred any request under `/.cratis/select-provider` to a separate fallback endpoint instead of answering it directly, so a redirect there (the cookie authentication handler's `OnRedirectToLogin`, and the invite flow, both redirect there whenever more than one provider is configured) never reached the page a deployment customizes via `PagesPath`.
- Fixed the single-provider direct-challenge redirect landing back on the selection page's own wrapper URL instead of the caller's real destination when reached this way.