### PR TITLE
Never white-screen on failed sign-ins and never proxy without a forwardable identity

### DIFF
--- a/Documentation/configuration/failed-sign-ins.md
+++ b/Documentation/configuration/failed-sign-ins.md
@@ -1,0 +1,64 @@
+# Failed Sign-ins
+
+A sign-in that leaves AuthProxy for an identity provider can come back broken: the provider round-trip
+fails validation (a stale correlation cookie, an expired state in another tab, a replayed callback URL),
+or the person cancels the sign-in at the provider. AuthProxy never surfaces any of these as an error
+page — the browser is redirected back to the provider-selection page (`/.cratis/select-provider`) with a
+machine-readable reason, and the transient handshake cookies that poison retries are cleared along the
+way.
+
+---
+
+## The `reason` parameter
+
+The selection page is opened with a `reason` query-string parameter describing what happened:
+
+| Reason | Meaning |
+|--------|---------|
+| `remote-failure` | The provider callback could not be validated — correlation failed, the OAuth state was missing or invalid, or the provider reported an error. |
+| `access-denied` | The identity provider reported that access was denied — typically the person cancelled the sign-in or declined the consent prompt. |
+| `invalid-session` | An authenticated session could no longer be turned into a forwardable identity, so it was terminated and a fresh sign-in is required. |
+
+The bundled `select-provider.html` shows a matching message above the provider buttons; a custom page
+(see [Well-Known Pages](well-known-pages.md)) can rely on the same contract. When the original
+destination is known it is carried along in `returnUrl` (validated as same-site relative), so a
+successful retry still lands where the person was heading.
+
+With a **single** configured provider a failed sign-in still lands on the selection page rather than
+being challenged again automatically — an immediate re-challenge would loop straight back into the very
+handshake that failed. The person sees the reason and retries deliberately.
+
+---
+
+## Handshake-cookie hygiene
+
+Every provider handshake writes transient correlation and nonce cookies
+(`.AspNetCore.Correlation.*`, `.AspNetCore.OpenIdConnect.Nonce.*`). Abandoned and half-cleared
+handshakes leave them behind, and a browser full of stale handshake cookies is exactly what makes the
+next sign-in fail correlation. AuthProxy clears every one it can see:
+
+- on **every failed** provider callback (this page's redirect),
+- on **every successful** provider callback — one successful sign-in heals a poisoned browser,
+- on [logout](logout.md).
+
+On the provider callback path the deletion is issued for both the root path and the callback path
+itself, which also reaches cookies written by older AuthProxy versions that scoped them to the callback
+path — those are invisible to the logout endpoint and would otherwise accumulate forever.
+
+---
+
+## Sessions that cannot be forwarded
+
+A proxied request must either carry the full identity headers or not be proxied at all. Authorization
+guarantees that a protected route is only reached by an authenticated session, but building the
+forwardable client principal can still fail closed — for example when
+[canonical identity](authentication.md#canonical-federated-identity) resolution refuses the session
+after a configuration change. Instead of forwarding such a request with no identity headers (which the
+backend refuses, leaving the application blank while the person is "signed in"), AuthProxy terminates
+the session — signing out and clearing every AuthProxy cookie — and answers:
+
+- a browser navigation with a redirect to the selection page carrying `reason=invalid-session` and the
+  original destination as `returnUrl`;
+- any other caller with `401 Unauthorized`.
+
+Routes a service declares in `AnonymousPaths` are exempt — they are proxied without identity by design.

--- a/Documentation/configuration/logout.md
+++ b/Documentation/configuration/logout.md
@@ -56,13 +56,22 @@ Both the local logout and the post-logout callback:
 1. Sign the user out of the authentication cookie (`.Cratis.AuthProxy.Auth.v2`), including any chunked variants.
 2. Delete every AuthProxy session cookie:
    - `.cratis-identity`
+   - `.cratis-identity-authorization`
    - `.cratis-tenant`
    - `.cratis-tenants`
    - `.cratis-invite`
+   - `.cratis-invite-state`
    - `.cratis-registration`
    - `.cratis-providers`
+3. Delete every transient sign-in handshake cookie the browser sent (`.AspNetCore.Correlation.*`,
+   `.AspNetCore.OpenIdConnect.Nonce.*`) — the leftovers of abandoned handshakes that would otherwise
+   poison the next sign-in. See [Failed Sign-ins](failed-sign-ins.md#handshake-cookie-hygiene).
 
 The `.cratis-logout` carry cookie is deleted by the callback once the final target has been read from it.
+
+After logout nothing of the session survives, so the next visit to a protected resource lands on the
+provider-selection page (or the single provider's login) rather than silently reusing anything local.
+Whether the *identity provider* still remembers the user is governed by the full-chain behavior above.
 
 ---
 

--- a/Documentation/configuration/toc.yml
+++ b/Documentation/configuration/toc.yml
@@ -6,6 +6,8 @@
   href: authorization.md
 - name: Unauthenticated Responses
   href: unauthenticated-responses.md
+- name: Failed Sign-ins
+  href: failed-sign-ins.md
 - name: Tenancy
   href: tenancy.md
 - name: Tenant Selection Page

--- a/Documentation/configuration/well-known-pages.md
+++ b/Documentation/configuration/well-known-pages.md
@@ -17,7 +17,7 @@ condition is detected:
 | `403.html` | The identity resolver denied access. | 403 |
 | `not-authorized.html` | The caller is signed in but does not satisfy the claim requirements declared in [`Cratis:AuthProxy:Authorization`](authorization.md). | 403 |
 | `tenant-not-found.html` | The resolved tenant does not exist in the platform (see [Tenant verification](tenancy.md#tenant-verification)). | 404 |
-| `select-provider.html` | A protected resource was requested and multiple identity providers are configured. The page reads the `.cratis-providers` cookie to render a sign-in button for each available provider. | 200 |
+| `select-provider.html` | A protected resource was requested and multiple identity providers are configured, or a sign-in failed (see [Failed Sign-ins](failed-sign-ins.md)). The page reads the `.cratis-providers` cookie to render a sign-in button for each available provider, and shows a message when a `reason` query parameter is present. | 200 |
 | `select-tenant.html` | Tenant selection is enabled and the authenticated user has not selected a tenant yet. The page reads the `.cratis-tenants` cookie to render selectable tenants. | 200 |
 | `invitation-expired.html` | The JWT token on an invite link has passed its expiry time. Served in either phase — when the link is followed (Phase 1) and when the token is re-validated at the exchange (Phase 2). | 401 |
 | `invitation-invalid.html` | The JWT token on an invite link is malformed or has an invalid signature. Served in either phase — when the link is followed (Phase 1) and when the token is re-validated at the exchange (Phase 2). | 401 |

--- a/Source/AuthProxy.Specs/Authentication/for_RemoteAuthenticationFailureHandler/given/a_remote_authentication_failure_context.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_RemoteAuthenticationFailureHandler/given/a_remote_authentication_failure_context.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+
+namespace Cratis.AuthProxy.Authentication.for_RemoteAuthenticationFailureHandler.given;
+
+public class a_remote_authentication_failure_context : Specification
+{
+    protected DefaultHttpContext _context;
+    protected AuthenticationScheme _scheme;
+    protected RemoteAuthenticationOptions _options;
+
+    void Establish()
+    {
+        _context = new DefaultHttpContext();
+        _context.Request.Scheme = "https";
+        _context.Request.Host = new HostString("cratis.studio");
+        _context.Request.Path = "/signin-microsoft";
+        _context.Response.Body = new MemoryStream();
+
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        loggerFactory.CreateLogger(Arg.Any<string>()).Returns(Substitute.For<ILogger>());
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(ILoggerFactory)).Returns(loggerFactory);
+        _context.RequestServices = serviceProvider;
+
+        _scheme = new AuthenticationScheme("microsoft", "microsoft", typeof(OpenIdConnectHandler));
+        _options = new RemoteAuthenticationOptions();
+    }
+}

--- a/Source/AuthProxy.Specs/Authentication/for_RemoteAuthenticationFailureHandler/when_remote_sign_in_fails_with_a_return_url.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_RemoteAuthenticationFailureHandler/when_remote_sign_in_fails_with_a_return_url.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.Authentication.for_RemoteAuthenticationFailureHandler;
+
+public class when_remote_sign_in_fails_with_a_return_url : given.a_remote_authentication_failure_context
+{
+    RemoteFailureContext _failureContext;
+
+    void Establish()
+    {
+        // Stale handshake cookies from earlier attempts — one at the root path and, from an older AuthProxy
+        // version, one scoped to the callback path — alongside an unrelated cookie that must be preserved.
+        _context.Request.Headers.Cookie =
+            $"{Cookies.CorrelationPrefix}abc=one; {Cookies.NoncePrefix}def=two; keep-me=value";
+
+        _failureContext = new RemoteFailureContext(_context, _scheme, _options, new InvalidOperationException("Correlation failed."))
+        {
+            Properties = new AuthenticationProperties { RedirectUri = "/deep/link" }
+        };
+    }
+
+    async Task Because() => await RemoteAuthenticationFailureHandler.HandleRemoteFailure(_failureContext);
+
+    [Fact] void should_handle_the_response() => _failureContext.Result.Handled.ShouldBeTrue();
+    [Fact] void should_redirect() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status302Found);
+
+    [Fact] void should_redirect_to_provider_selection_with_the_reason_and_return_url() =>
+        _context.Response.Headers.Location.ToString().ShouldEqual(
+            $"{WellKnownPaths.LoginPage}?{SignInFailureReason.QueryKey}={SignInFailureReason.RemoteFailure}&returnUrl={Uri.EscapeDataString("/deep/link")}");
+
+    [Fact] void should_clear_the_correlation_cookie_at_the_root_path() =>
+        _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.CorrelationPrefix}abc=; expires");
+
+    [Fact] void should_clear_the_correlation_cookie_at_the_callback_path() =>
+        _context.Response.Headers.SetCookie.ToString().ShouldContain("path=/signin-microsoft");
+
+    [Fact] void should_clear_the_nonce_cookie() =>
+        _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.NoncePrefix}def=; expires");
+
+    [Fact] void should_not_clear_unrelated_cookies() =>
+        _context.Response.Headers.SetCookie.ToString().ShouldNotContain("keep-me=;");
+}

--- a/Source/AuthProxy.Specs/Authentication/for_RemoteAuthenticationFailureHandler/when_remote_sign_in_fails_with_an_absolute_return_url.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_RemoteAuthenticationFailureHandler/when_remote_sign_in_fails_with_an_absolute_return_url.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.Authentication.for_RemoteAuthenticationFailureHandler;
+
+public class when_remote_sign_in_fails_with_an_absolute_return_url : given.a_remote_authentication_failure_context
+{
+    RemoteFailureContext _failureContext;
+
+    void Establish() =>
+        _failureContext = new RemoteFailureContext(_context, _scheme, _options, new InvalidOperationException("Correlation failed."))
+        {
+            Properties = new AuthenticationProperties { RedirectUri = "https://evil.test/phish" }
+        };
+
+    async Task Because() => await RemoteAuthenticationFailureHandler.HandleRemoteFailure(_failureContext);
+
+    [Fact] void should_not_carry_the_absolute_target_forward() =>
+        _context.Response.Headers.Location.ToString().ShouldEqual(
+            $"{WellKnownPaths.LoginPage}?{SignInFailureReason.QueryKey}={SignInFailureReason.RemoteFailure}");
+}

--- a/Source/AuthProxy.Specs/Authentication/for_RemoteAuthenticationFailureHandler/when_remote_sign_in_fails_without_authentication_properties.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_RemoteAuthenticationFailureHandler/when_remote_sign_in_fails_without_authentication_properties.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.Authentication.for_RemoteAuthenticationFailureHandler;
+
+public class when_remote_sign_in_fails_without_authentication_properties : given.a_remote_authentication_failure_context
+{
+    RemoteFailureContext _failureContext;
+
+    void Establish() =>
+        _failureContext = new RemoteFailureContext(_context, _scheme, _options, new InvalidOperationException("The oauth state was missing or invalid."));
+
+    async Task Because() => await RemoteAuthenticationFailureHandler.HandleRemoteFailure(_failureContext);
+
+    [Fact] void should_handle_the_response() => _failureContext.Result.Handled.ShouldBeTrue();
+
+    [Fact] void should_redirect_to_provider_selection_with_only_the_reason() =>
+        _context.Response.Headers.Location.ToString().ShouldEqual(
+            $"{WellKnownPaths.LoginPage}?{SignInFailureReason.QueryKey}={SignInFailureReason.RemoteFailure}");
+}

--- a/Source/AuthProxy.Specs/Authentication/for_RemoteAuthenticationFailureHandler/when_the_identity_provider_denies_access.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_RemoteAuthenticationFailureHandler/when_the_identity_provider_denies_access.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.Authentication.for_RemoteAuthenticationFailureHandler;
+
+public class when_the_identity_provider_denies_access : given.a_remote_authentication_failure_context
+{
+    AccessDeniedContext _accessDeniedContext;
+
+    void Establish() =>
+        _accessDeniedContext = new AccessDeniedContext(_context, _scheme, _options)
+        {
+            Properties = new AuthenticationProperties { RedirectUri = "/dashboard" }
+        };
+
+    async Task Because() => await RemoteAuthenticationFailureHandler.HandleAccessDenied(_accessDeniedContext);
+
+    [Fact] void should_handle_the_response() => _accessDeniedContext.Result.Handled.ShouldBeTrue();
+
+    [Fact] void should_redirect_to_provider_selection_with_the_access_denied_reason() =>
+        _context.Response.Headers.Location.ToString().ShouldEqual(
+            $"{WellKnownPaths.LoginPage}?{SignInFailureReason.QueryKey}={SignInFailureReason.AccessDenied}&returnUrl={Uri.EscapeDataString("/dashboard")}");
+}

--- a/Source/AuthProxy.Specs/Authentication/for_SelectProviderMiddleware/when_a_sign_in_failure_reason_is_present.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_SelectProviderMiddleware/when_a_sign_in_failure_reason_is_present.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.Authentication.for_SelectProviderMiddleware;
+
+public class when_a_sign_in_failure_reason_is_present : Specification
+{
+    SelectProviderMiddleware _middleware;
+    DefaultHttpContext _context;
+    bool _nextCalled;
+    bool _challenged;
+    IErrorPageProvider _errorPageProvider;
+
+    void Establish()
+    {
+        var proxyConfig = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        proxyConfig.CurrentValue.Returns(new C.AuthProxy());
+
+        // A single provider would normally be challenged directly — but this caller just came back from a
+        // failed sign-in, and an immediate re-challenge is a redirect loop when the failure persists.
+        var authConfig = Substitute.For<IOptionsMonitor<C.Authentication>>();
+        authConfig.CurrentValue.Returns(new C.Authentication
+        {
+            OidcProviders = [new C.OidcProvider { Name = "my-provider", Authority = "https://auth.example.com", ClientId = "id" }]
+        });
+
+        _errorPageProvider = Substitute.For<IErrorPageProvider>();
+        _errorPageProvider
+            .WriteErrorPageAsync(Arg.Any<HttpContext>(), Arg.Any<string>(), Arg.Any<int>())
+            .Returns(Task.CompletedTask);
+
+        _middleware = new SelectProviderMiddleware(
+            _ =>
+            {
+                _nextCalled = true;
+                return Task.CompletedTask;
+            },
+            proxyConfig,
+            authConfig,
+            _errorPageProvider,
+            Substitute.For<ITenantResolver>(),
+            Substitute.For<IAuthenticationSchemeProvider>());
+
+        _context = new DefaultHttpContext();
+        _context.Request.Path = WellKnownPaths.LoginPage;
+        _context.Request.QueryString = new QueryString($"?{SignInFailureReason.QueryKey}={SignInFailureReason.RemoteFailure}&returnUrl=%2Fdashboard");
+        _context.Request.Headers["Sec-Fetch-Dest"] = "document";
+        _context.Response.Body = new MemoryStream();
+
+        var authService = Substitute.For<IAuthenticationService>();
+        authService
+            .ChallengeAsync(Arg.Any<HttpContext>(), Arg.Do<string?>(_ => _challenged = true), Arg.Any<AuthenticationProperties?>())
+            .Returns(Task.CompletedTask);
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IAuthenticationService)).Returns(authService);
+        _context.RequestServices = serviceProvider;
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_not_call_next() => _nextCalled.ShouldBeFalse();
+    [Fact] void should_not_challenge_the_provider() => _challenged.ShouldBeFalse();
+
+    [Fact]
+    void should_serve_the_selection_page() =>
+        _errorPageProvider.Received(1).WriteErrorPageAsync(
+            _context,
+            WellKnownPageNames.SelectProvider,
+            StatusCodes.Status200OK);
+
+    [Fact]
+    void should_set_the_providers_cookie() =>
+        _context.Response.Headers.SetCookie.ToString().ShouldContain(Cookies.Providers);
+}

--- a/Source/AuthProxy.Specs/Authentication/for_TransientAuthenticationCookies/when_clearing_at_the_root_path.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_TransientAuthenticationCookies/when_clearing_at_the_root_path.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authentication.for_TransientAuthenticationCookies;
+
+public class when_clearing_at_the_root_path : Specification
+{
+    DefaultHttpContext _context;
+    string _setCookies;
+
+    void Establish()
+    {
+        _context = new DefaultHttpContext();
+        _context.Request.Path = "/";
+        _context.Request.Headers.Cookie = $"{Cookies.CorrelationPrefix}abc=one";
+    }
+
+    void Because()
+    {
+        TransientAuthenticationCookies.Clear(_context);
+        _setCookies = _context.Response.Headers.SetCookie.ToString();
+    }
+
+    [Fact] void should_clear_the_correlation_cookie() => _setCookies.ShouldContain($"{Cookies.CorrelationPrefix}abc=; expires");
+
+    [Fact]
+    void should_only_emit_a_single_deletion() =>
+        _context.Response.Headers.SetCookie.Count.ShouldEqual(1);
+}

--- a/Source/AuthProxy.Specs/Authentication/for_TransientAuthenticationCookies/when_clearing_on_a_provider_callback_path.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_TransientAuthenticationCookies/when_clearing_on_a_provider_callback_path.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authentication.for_TransientAuthenticationCookies;
+
+public class when_clearing_on_a_provider_callback_path : Specification
+{
+    DefaultHttpContext _context;
+    string _setCookies;
+
+    void Establish()
+    {
+        _context = new DefaultHttpContext();
+        _context.Request.Path = "/signin-microsoft";
+        _context.Request.Headers.Cookie =
+            $"{Cookies.CorrelationPrefix}abc=one; {Cookies.NoncePrefix}def=two; keep-me=value";
+    }
+
+    void Because()
+    {
+        TransientAuthenticationCookies.Clear(_context);
+        _setCookies = _context.Response.Headers.SetCookie.ToString();
+    }
+
+    [Fact] void should_clear_the_correlation_cookie_at_the_root_path() => _setCookies.ShouldContain($"{Cookies.CorrelationPrefix}abc=; expires");
+    [Fact] void should_clear_the_nonce_cookie() => _setCookies.ShouldContain($"{Cookies.NoncePrefix}def=; expires");
+
+    [Fact]
+    void should_also_clear_at_the_callback_path_where_legacy_cookies_were_scoped() =>
+        _setCookies.ShouldContain("path=/signin-microsoft");
+
+    [Fact] void should_not_clear_unrelated_cookies() => _setCookies.ShouldNotContain("keep-me=;");
+}

--- a/Source/AuthProxy.Specs/Identity/for_ClientPrincipalExtensions/when_building_from_a_canonical_oidc_session_after_cookie_authentication.cs
+++ b/Source/AuthProxy.Specs/Identity/for_ClientPrincipalExtensions/when_building_from_a_canonical_oidc_session_after_cookie_authentication.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Authentication;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.AuthProxy.Identity.for_ClientPrincipalExtensions;
+
+/// <summary>
+/// The production shape of every canonical OIDC session: the token-validated identity carries
+/// "AuthenticationTypes.Federation" as its authentication type — never the provider scheme — and the
+/// request was authenticated by the cookie handler, recorded in the authenticate-result feature. Building
+/// the client principal must resolve against the scheme that authenticated the request, not the identity's
+/// authentication type; getting that wrong made every proxied request go out without identity headers
+/// while the session itself stayed valid.
+/// </summary>
+public class when_building_from_a_canonical_oidc_session_after_cookie_authentication : Specification
+{
+    const string Subject = "entra-object-id";
+    DefaultHttpContext _context;
+    ClientPrincipal? _result;
+
+    void Establish()
+    {
+        var configuration = new C.Authentication
+        {
+            OidcProviders =
+            [
+                new C.OidcProvider
+                {
+                    Name = "Microsoft Entra",
+                    CanonicalIdentity = new C.CanonicalIdentity
+                    {
+                        ProviderKey = "workforce",
+                        SubjectClaimType = "oid"
+                    }
+                }
+            ]
+        };
+        var options = Substitute.For<IOptionsMonitor<C.Authentication>>();
+        options.CurrentValue.Returns(configuration);
+        var resolver = new CanonicalIdentityResolver(options);
+
+        // The fresh callback enriches the principal under the provider scheme, exactly as the real ticket
+        // handler does — but the identity itself carries the federation authentication type the OIDC token
+        // validation stamps on it.
+        var enriched = resolver.Resolve(
+            new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim("oid", Subject),
+                new Claim("name", "Cosmetic Name")
+            ],
+            "AuthenticationTypes.Federation")),
+            "microsoft-entra",
+            "https://identity.example.com/",
+            isFreshAuthentication: true);
+
+        var services = new ServiceCollection()
+            .AddSingleton<ICanonicalIdentityResolver>(resolver)
+            .BuildServiceProvider();
+
+        _context = new DefaultHttpContext
+        {
+            RequestServices = services,
+            User = enriched.Principal!
+        };
+
+        // On a later request the cookie handler authenticates and the framework records the winning scheme.
+        _context.Features.Set<IAuthenticateResultFeature>(new TestAuthenticateResultFeature(
+            AuthenticateResult.Success(new AuthenticationTicket(
+                enriched.Principal!,
+                CookieAuthenticationDefaults.AuthenticationScheme))));
+    }
+
+    void Because() => _result = _context.BuildClientPrincipal();
+
+    [Fact] void should_build_a_principal() => _result.ShouldNotBeNull();
+    [Fact] void should_use_the_canonical_subject_as_user_id() => _result!.UserId.ShouldEqual(Subject);
+    [Fact] void should_keep_the_stable_provider_key() => _result!.IdentityProvider.ShouldEqual("workforce");
+
+    sealed class TestAuthenticateResultFeature(AuthenticateResult result) : IAuthenticateResultFeature
+    {
+        public AuthenticateResult? AuthenticateResult { get; set; } = result;
+    }
+}

--- a/Source/AuthProxy.Specs/Identity/for_IdentityForwardingGuardMiddleware/given/a_proxied_request.cs
+++ b/Source/AuthProxy.Specs/Identity/for_IdentityForwardingGuardMiddleware/given/a_proxied_request.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Authentication;
+using Microsoft.AspNetCore.Authentication;
+using Yarp.ReverseProxy.Configuration;
+using Yarp.ReverseProxy.Forwarder;
+using Yarp.ReverseProxy.Model;
+
+namespace Cratis.AuthProxy.Identity.for_IdentityForwardingGuardMiddleware.given;
+
+public class a_proxied_request : Specification
+{
+    protected IdentityForwardingGuardMiddleware _middleware;
+    protected DefaultHttpContext _context;
+    protected bool _nextCalled;
+    protected IAuthenticationService _authenticationService;
+    protected ICanonicalIdentityResolver _canonicalIdentityResolver;
+
+    void Establish()
+    {
+        _middleware = new IdentityForwardingGuardMiddleware(
+            _ =>
+            {
+                _nextCalled = true;
+                return Task.CompletedTask;
+            },
+            Substitute.For<ILogger<IdentityForwardingGuardMiddleware>>());
+
+        _context = new DefaultHttpContext();
+        _context.Request.Path = "/api/things";
+        _context.Response.Body = new MemoryStream();
+
+        _authenticationService = Substitute.For<IAuthenticationService>();
+        _canonicalIdentityResolver = Substitute.For<ICanonicalIdentityResolver>();
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IAuthenticationService)).Returns(_authenticationService);
+        serviceProvider.GetService(typeof(ICanonicalIdentityResolver)).Returns(_canonicalIdentityResolver);
+        _context.RequestServices = serviceProvider;
+
+        SetProxyRoute("default");
+    }
+
+    protected void SetProxyRoute(string authorizationPolicy)
+    {
+        var route = new RouteModel(
+            new RouteConfig
+            {
+                RouteId = "route",
+                ClusterId = "cluster",
+                AuthorizationPolicy = authorizationPolicy,
+                Match = new RouteMatch { Path = "/{**catch-all}" }
+            },
+            new ClusterState("cluster"),
+            HttpTransformer.Default);
+
+        _context.SetEndpoint(new Endpoint(null, new EndpointMetadataCollection(route), "proxied"));
+    }
+
+    protected void SetAuthenticatedUser() =>
+        _context.User = new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim("oid", "user-42"),
+            new Claim("email", "user@example.com")
+        ],
+        "AuthenticationTypes.Federation"));
+}

--- a/Source/AuthProxy.Specs/Identity/for_IdentityForwardingGuardMiddleware/when_an_authenticated_session_cannot_be_forwarded.cs
+++ b/Source/AuthProxy.Specs/Identity/for_IdentityForwardingGuardMiddleware/when_an_authenticated_session_cannot_be_forwarded.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Authentication;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+
+namespace Cratis.AuthProxy.Identity.for_IdentityForwardingGuardMiddleware;
+
+public class when_an_authenticated_session_cannot_be_forwarded : given.a_proxied_request
+{
+    void Establish()
+    {
+        SetAuthenticatedUser();
+        _canonicalIdentityResolver
+            .Resolve(Arg.Any<ClaimsPrincipal>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<bool>())
+            .Returns(CanonicalIdentityResolution.Failed());
+
+        // A browser navigating to a document — the caller a redirect to provider selection is an answer to.
+        _context.Request.Path = "/dashboard";
+        _context.Request.QueryString = new QueryString("?tab=activity");
+        _context.Request.Headers["Sec-Fetch-Dest"] = "document";
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_not_call_next() => _nextCalled.ShouldBeFalse();
+
+    [Fact] void should_sign_the_caller_out_of_the_cookie_scheme() =>
+        _authenticationService.Received(1).SignOutAsync(_context, CookieAuthenticationDefaults.AuthenticationScheme, Arg.Any<AuthenticationProperties?>());
+
+    [Fact] void should_delete_the_identity_cookie() =>
+        _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.Identity}=;");
+
+    [Fact] void should_delete_the_identity_authorization_cookie() =>
+        _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.IdentityAuthorization}=;");
+
+    [Fact] void should_redirect_to_provider_selection_with_the_reason_and_destination() =>
+        _context.Response.Headers.Location.ToString().ShouldEqual(
+            $"{WellKnownPaths.LoginPage}?{SignInFailureReason.QueryKey}={SignInFailureReason.InvalidSession}&returnUrl={Uri.EscapeDataString("/dashboard?tab=activity")}");
+}

--- a/Source/AuthProxy.Specs/Identity/for_IdentityForwardingGuardMiddleware/when_an_authenticated_session_cannot_be_forwarded_for_a_non_navigation_caller.cs
+++ b/Source/AuthProxy.Specs/Identity/for_IdentityForwardingGuardMiddleware/when_an_authenticated_session_cannot_be_forwarded_for_a_non_navigation_caller.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Authentication;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+
+namespace Cratis.AuthProxy.Identity.for_IdentityForwardingGuardMiddleware;
+
+public class when_an_authenticated_session_cannot_be_forwarded_for_a_non_navigation_caller : given.a_proxied_request
+{
+    void Establish()
+    {
+        SetAuthenticatedUser();
+        _canonicalIdentityResolver
+            .Resolve(Arg.Any<ClaimsPrincipal>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<bool>())
+            .Returns(CanonicalIdentityResolution.Failed());
+
+        // A fetch() issued by the application — a redirect to a page would read as success; a status is
+        // the answer it can act on.
+        _context.Request.Headers["Sec-Fetch-Dest"] = "empty";
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_not_call_next() => _nextCalled.ShouldBeFalse();
+    [Fact] void should_refuse_with_unauthorized() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status401Unauthorized);
+
+    [Fact] void should_sign_the_caller_out_of_the_cookie_scheme() =>
+        _authenticationService.Received(1).SignOutAsync(_context, CookieAuthenticationDefaults.AuthenticationScheme, Arg.Any<AuthenticationProperties?>());
+}

--- a/Source/AuthProxy.Specs/Identity/for_IdentityForwardingGuardMiddleware/when_authenticated_caller_has_a_forwardable_identity.cs
+++ b/Source/AuthProxy.Specs/Identity/for_IdentityForwardingGuardMiddleware/when_authenticated_caller_has_a_forwardable_identity.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Authentication;
+
+namespace Cratis.AuthProxy.Identity.for_IdentityForwardingGuardMiddleware;
+
+public class when_authenticated_caller_has_a_forwardable_identity : given.a_proxied_request
+{
+    void Establish()
+    {
+        SetAuthenticatedUser();
+        _canonicalIdentityResolver
+            .Resolve(Arg.Any<ClaimsPrincipal>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<bool>())
+            .Returns(CanonicalIdentityResolution.Legacy(_context.User));
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_call_next() => _nextCalled.ShouldBeTrue();
+    [Fact] void should_not_sign_the_caller_out() => _authenticationService.DidNotReceiveWithAnyArgs().SignOutAsync(default!, default, default);
+}

--- a/Source/AuthProxy.Specs/Identity/for_IdentityForwardingGuardMiddleware/when_proxied_route_is_anonymous.cs
+++ b/Source/AuthProxy.Specs/Identity/for_IdentityForwardingGuardMiddleware/when_proxied_route_is_anonymous.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Identity.for_IdentityForwardingGuardMiddleware;
+
+public class when_proxied_route_is_anonymous : given.a_proxied_request
+{
+    void Establish() => SetProxyRoute("anonymous");
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_call_next() => _nextCalled.ShouldBeTrue();
+    [Fact] void should_not_change_the_status_code() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status200OK);
+}

--- a/Source/AuthProxy.Specs/Identity/for_IdentityForwardingGuardMiddleware/when_request_is_not_proxied.cs
+++ b/Source/AuthProxy.Specs/Identity/for_IdentityForwardingGuardMiddleware/when_request_is_not_proxied.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Identity.for_IdentityForwardingGuardMiddleware;
+
+public class when_request_is_not_proxied : given.a_proxied_request
+{
+    void Establish() => _context.SetEndpoint(null);
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_call_next() => _nextCalled.ShouldBeTrue();
+}

--- a/Source/AuthProxy/Authentication/AuthenticationServiceCollectionExtensions.cs
+++ b/Source/AuthProxy/Authentication/AuthenticationServiceCollectionExtensions.cs
@@ -235,6 +235,8 @@ public static class AuthenticationServiceCollectionExtensions
                         context.Properties.Items[ValidatedIssuerStateKey] = context.SecurityToken.Issuer;
                         return Task.CompletedTask;
                     },
+                    OnRemoteFailure = RemoteAuthenticationFailureHandler.HandleRemoteFailure,
+                    OnAccessDenied = RemoteAuthenticationFailureHandler.HandleAccessDenied,
                     OnTicketReceived = context => HandleTicketReceived(
                         context,
                         () => CanonicalSessionRegistrationFingerprint.Create(
@@ -311,6 +313,8 @@ public static class AuthenticationServiceCollectionExtensions
                             await AddVerifiedOAuthEmail(ctx, capturedProvider);
                         }
                     },
+                    OnRemoteFailure = RemoteAuthenticationFailureHandler.HandleRemoteFailure,
+                    OnAccessDenied = RemoteAuthenticationFailureHandler.HandleAccessDenied,
                     OnTicketReceived = context => HandleTicketReceived(
                         context,
                         () => CanonicalSessionRegistrationFingerprint.Create(
@@ -381,6 +385,12 @@ public static class AuthenticationServiceCollectionExtensions
         C.CanonicalIdentity? canonicalIdentity,
         string protocolAssurance)
     {
+        // A completed handshake is the one moment every leftover transient sign-in cookie is both visible
+        // (this is the callback path, where legacy path-scoped stragglers still flow) and safe to remove —
+        // the handshake they belonged to is either this one, already consumed, or abandoned. Clearing them
+        // here means one successful sign-in heals a browser poisoned by earlier half-cleared sessions.
+        TransientAuthenticationCookies.Clear(context.HttpContext);
+
         var canonicalIdentityResolver = context.HttpContext.RequestServices.GetRequiredService<ICanonicalIdentityResolver>();
         string? validatedIssuer = null;
         context.Properties?.Items.TryGetValue(ValidatedIssuerStateKey, out validatedIssuer);

--- a/Source/AuthProxy/Authentication/RemoteAuthenticationFailureHandler.cs
+++ b/Source/AuthProxy/Authentication/RemoteAuthenticationFailureHandler.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.Authentication;
+
+/// <summary>
+/// Turns a failed identity-provider round-trip into an answer a person can act on, instead of the
+/// unhandled <see cref="Exception"/> the remote authentication handler would otherwise throw — which
+/// surfaces in the browser as a blank 500 page.
+/// </summary>
+/// <remarks>
+/// A remote sign-in fails for reasons the person in front of the browser cannot see: a correlation cookie
+/// that a previous half-cleared session left stale, an OAuth state that expired in another tab, a consent
+/// prompt they declined. Whatever the cause, the recovery is the same — start a fresh sign-in — so every
+/// failure clears the transient handshake cookies (removing the very state that poisons retries) and
+/// redirects to the provider-selection page with a <see cref="SignInFailureReason"/> the page can show.
+/// The failure itself is logged with its scheme and message, so the operator still sees what the browser
+/// no longer does.
+/// </remarks>
+public static class RemoteAuthenticationFailureHandler
+{
+    /// <summary>
+    /// Handles a failed remote authentication round-trip (correlation failure, invalid state, provider
+    /// error) by clearing the handshake cookies and redirecting to provider selection.
+    /// </summary>
+    /// <param name="context">The failure context raised by the remote authentication handler.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public static Task HandleRemoteFailure(RemoteFailureContext context)
+    {
+        GetLogger(context.HttpContext).RemoteSignInFailed(context.Scheme.Name, context.Failure?.Message ?? "(unknown)");
+        Handle(context, context.Properties, SignInFailureReason.RemoteFailure);
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Handles the identity provider reporting that access was denied — typically the person cancelling
+    /// the sign-in or declining consent — by clearing the handshake cookies and redirecting to provider
+    /// selection.
+    /// </summary>
+    /// <param name="context">The access-denied context raised by the remote authentication handler.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public static Task HandleAccessDenied(AccessDeniedContext context)
+    {
+        GetLogger(context.HttpContext).RemoteSignInAccessDenied(context.Scheme.Name);
+        Handle(context, context.Properties, SignInFailureReason.AccessDenied);
+        return Task.CompletedTask;
+    }
+
+    static void Handle(
+        HandleRequestContext<RemoteAuthenticationOptions> context,
+        AuthenticationProperties? properties,
+        string reason)
+    {
+        // The transient correlation/state cookies are what a retry trips over, and the provider callback is
+        // the one request where even legacy path-scoped stragglers are visible — clear them all here.
+        TransientAuthenticationCookies.Clear(context.HttpContext);
+
+        var location = $"{WellKnownPaths.LoginPage}?{SignInFailureReason.QueryKey}={reason}";
+
+        // Carry the original destination forward when the challenge recorded one, so a successful retry
+        // still lands where the person was heading. The value comes from protected authentication state,
+        // but it is validated as same-site relative all the same.
+        var returnUrl = RelativeRedirect.Resolve(properties?.RedirectUri);
+        if (returnUrl != RelativeRedirect.ApplicationRoot)
+        {
+            location += $"&returnUrl={Uri.EscapeDataString(returnUrl)}";
+        }
+
+        context.Response.Redirect(location);
+        context.HandleResponse();
+    }
+
+    static ILogger GetLogger(HttpContext context) =>
+        context.RequestServices
+            .GetRequiredService<ILoggerFactory>()
+            .CreateLogger(typeof(RemoteAuthenticationFailureHandler).FullName!);
+}

--- a/Source/AuthProxy/Authentication/RemoteAuthenticationFailureHandlerLogging.cs
+++ b/Source/AuthProxy/Authentication/RemoteAuthenticationFailureHandlerLogging.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authentication;
+
+internal static partial class RemoteAuthenticationFailureHandlerLogging
+{
+    [LoggerMessage(LogLevel.Warning, "Remote sign-in through scheme {Scheme} failed: {Reason}. Redirecting to provider selection")]
+    internal static partial void RemoteSignInFailed(this ILogger logger, string scheme, string reason);
+
+    [LoggerMessage(LogLevel.Information, "Remote sign-in through scheme {Scheme} was denied by the identity provider. Redirecting to provider selection")]
+    internal static partial void RemoteSignInAccessDenied(this ILogger logger, string scheme);
+}

--- a/Source/AuthProxy/Authentication/SelectProviderMiddleware.cs
+++ b/Source/AuthProxy/Authentication/SelectProviderMiddleware.cs
@@ -98,7 +98,11 @@ public class SelectProviderMiddleware(
             return;
         }
 
-        if (providers.Count > 1)
+        // A single configured provider is normally challenged directly — but not when the caller was just
+        // sent back here after a failed or denied sign-in. Re-challenging immediately would race straight
+        // back into the very handshake that failed (a redirect loop when the cause persists); serving the
+        // page instead shows the reason and leaves the retry to the person.
+        if (providers.Count > 1 || HasSignInFailureReason(context))
         {
             var providersJson = JsonSerializer.Serialize(providers, _serializerOptions);
             context.Response.Cookies.Append(Cookies.Providers, providersJson, new CookieOptions
@@ -148,6 +152,16 @@ public class SelectProviderMiddleware(
 
         return context.GetPathAndQuery();
     }
+
+    /// <summary>
+    /// Determines whether the caller landed on the selection page carrying a sign-in failure reason —
+    /// the redirect a failed, denied, or terminated sign-in produces.
+    /// </summary>
+    /// <param name="context">The current <see cref="HttpContext"/>.</param>
+    /// <returns><see langword="true"/> when a failure reason is present; otherwise <see langword="false"/>.</returns>
+    static bool HasSignInFailureReason(HttpContext context) =>
+        context.Request.Path.StartsWithSegments(WellKnownPaths.LoginPage)
+        && context.Request.Query.ContainsKey(SignInFailureReason.QueryKey);
 
     /// <summary>
     /// Refuses a caller that no page can answer, naming a credential it could come back with.

--- a/Source/AuthProxy/Authentication/SessionTermination.cs
+++ b/Source/AuthProxy/Authentication/SessionTermination.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+
+namespace Cratis.AuthProxy.Authentication;
+
+/// <summary>
+/// Ends the local session completely: signs the caller out of the cookie authentication scheme and deletes
+/// every cookie AuthProxy issues, so nothing of the session survives to confuse the next sign-in.
+/// </summary>
+/// <remarks>
+/// This is the single definition of "logged out locally". The logout endpoint uses it on both legs of an
+/// RP-initiated logout, and the identity forwarding guard uses it to terminate a session that can no longer
+/// be turned into a forwardable identity. A partial clear is precisely the production failure this exists
+/// to prevent: a surviving cookie makes the next visit half-signed-in, which surfaces as anything from a
+/// silent re-authentication to a failed provider handshake.
+/// </remarks>
+public static class SessionTermination
+{
+    /// <summary>
+    /// Signs the current caller out of the cookie scheme and deletes every AuthProxy-issued cookie.
+    /// </summary>
+    /// <param name="context">The <see cref="HttpContext"/> whose session to terminate.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public static async Task SignOutAndClearCookies(HttpContext context)
+    {
+        await context.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+        context.Response.Cookies.Delete(Cookies.Identity);
+        context.Response.Cookies.Delete(Cookies.IdentityAuthorization);
+        context.Response.Cookies.Delete(Cookies.Tenant);
+        context.Response.Cookies.Delete(Cookies.Tenants);
+        context.Response.Cookies.Delete(Cookies.InviteToken);
+        context.Response.Cookies.Delete(Cookies.InvitationEntryState);
+        context.Response.Cookies.Delete(Cookies.InviteToken, new CookieOptions { Path = "/" });
+        context.Response.Cookies.Delete(Cookies.InvitationEntryState, new CookieOptions { Path = "/" });
+        context.Response.Cookies.Delete(Cookies.Registration);
+        context.Response.Cookies.Delete(Cookies.Providers);
+        TransientAuthenticationCookies.Clear(context);
+    }
+}

--- a/Source/AuthProxy/Authentication/SignInFailureReason.cs
+++ b/Source/AuthProxy/Authentication/SignInFailureReason.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authentication;
+
+/// <summary>
+/// The well-known values AuthProxy uses to tell the provider-selection page why a caller landed on it,
+/// carried in the <see cref="QueryKey"/> query-string parameter.
+/// </summary>
+/// <remarks>
+/// A failed sign-in must never surface as a bare error page — the browser is redirected back to provider
+/// selection with one of these reasons so the page can show the person what happened and offer the way
+/// forward: trying again. The values are part of the page contract, so a custom
+/// <c>select-provider.html</c> can rely on them.
+/// </remarks>
+public static class SignInFailureReason
+{
+    /// <summary>
+    /// The query-string key the reason is carried in.
+    /// </summary>
+    public const string QueryKey = "reason";
+
+    /// <summary>
+    /// The identity-provider round-trip did not complete — the provider callback could not be validated
+    /// (a stale or missing correlation cookie, an invalid state, a replayed callback URL).
+    /// </summary>
+    public const string RemoteFailure = "remote-failure";
+
+    /// <summary>
+    /// The identity provider reported that access was denied — typically the person cancelled the sign-in
+    /// or declined the consent prompt.
+    /// </summary>
+    public const string AccessDenied = "access-denied";
+
+    /// <summary>
+    /// The session existed but could no longer be turned into a forwardable identity, so it was terminated
+    /// and a fresh sign-in is required.
+    /// </summary>
+    public const string InvalidSession = "invalid-session";
+}

--- a/Source/AuthProxy/Authentication/TransientAuthenticationCookies.cs
+++ b/Source/AuthProxy/Authentication/TransientAuthenticationCookies.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authentication;
+
+/// <summary>
+/// Clears the transient correlation and nonce cookies the ASP.NET Core OAuth/OIDC middleware writes for
+/// every sign-in handshake. They carry random per-attempt names, so they are matched by their well-known
+/// prefixes rather than by an exact name.
+/// </summary>
+/// <remarks>
+/// The provider registrations keep these cookies at the root path so they are sent — and can be cleared —
+/// everywhere. Cookies written by earlier AuthProxy versions were scoped to the provider's callback path
+/// instead, which makes them invisible to the logout endpoint and immortal from the browser's point of
+/// view: they accumulate from abandoned handshakes until the Cookie header itself becomes a liability.
+/// The one place they <em>are</em> visible is the callback path itself, so every deletion is issued for
+/// both the root path and the current request path — on a provider callback that reaches the legacy
+/// path-scoped stragglers too.
+/// </remarks>
+public static class TransientAuthenticationCookies
+{
+    /// <summary>
+    /// Deletes every transient sign-in handshake cookie the browser sent with the current request.
+    /// </summary>
+    /// <param name="context">The <see cref="HttpContext"/> whose response the delete cookies are written to.</param>
+    public static void Clear(HttpContext context)
+    {
+        var requestPath = context.Request.Path;
+        var alsoClearRequestPathScoped = requestPath.HasValue && requestPath.Value != "/";
+
+        foreach (var cookie in context.Request.Cookies.Keys.Where(IsTransient))
+        {
+            context.Response.Cookies.Delete(cookie, new CookieOptions { Path = "/" });
+            if (alsoClearRequestPathScoped)
+            {
+                context.Response.Cookies.Delete(cookie, new CookieOptions { Path = requestPath.Value });
+            }
+        }
+    }
+
+    static bool IsTransient(string name) =>
+        name.StartsWith(Cookies.CorrelationPrefix, StringComparison.Ordinal)
+        || name.StartsWith(Cookies.NoncePrefix, StringComparison.Ordinal);
+}

--- a/Source/AuthProxy/Identity/ClientPrincipalExtensions.cs
+++ b/Source/AuthProxy/Identity/ClientPrincipalExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Security.Claims;
 using Cratis.AuthProxy.Authentication;
+using Microsoft.AspNetCore.Authentication;
 
 namespace Cratis.AuthProxy.Identity;
 
@@ -30,8 +31,17 @@ public static class ClientPrincipalExtensions
             return null;
         }
 
+        // Resolve against the scheme that actually authenticated this request — the framework records it in
+        // the authenticate-result feature. The identity's AuthenticationType is NOT that scheme: an OIDC
+        // token-validated identity carries "AuthenticationTypes.Federation", which no provider is registered
+        // under, so resolving with it made every canonical OIDC session fail closed here — and the request
+        // was then proxied without identity headers while the cookie session itself stayed perfectly valid.
+        var authenticationScheme = context.Features.Get<IAuthenticateResultFeature>()?
+                .AuthenticateResult?.Ticket?.AuthenticationScheme
+            ?? user.Identity.AuthenticationType;
+
         var canonicalResolution = context.RequestServices is { } requestServices
-            ? requestServices.GetService<ICanonicalIdentityResolver>()?.Resolve(user, user.Identity.AuthenticationType)
+            ? requestServices.GetService<ICanonicalIdentityResolver>()?.Resolve(user, authenticationScheme)
             : null;
         if (canonicalResolution?.IsConfigured == true)
         {

--- a/Source/AuthProxy/Identity/IdentityForwardingGuardMiddleware.cs
+++ b/Source/AuthProxy/Identity/IdentityForwardingGuardMiddleware.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Authentication;
+using Cratis.AuthProxy.ReverseProxy;
+using Yarp.ReverseProxy.Model;
+
+namespace Cratis.AuthProxy.Identity;
+
+/// <summary>
+/// The last check before a request is handed to the reverse proxy: a proxied request either carries a
+/// forwardable identity or is not proxied at all. An authenticated session whose principal can no longer
+/// be built is terminated and sent back to provider selection instead of being forwarded without identity
+/// headers.
+/// </summary>
+/// <remarks>
+/// Authorization guarantees that a non-anonymous proxied route is only reached by an authenticated caller —
+/// but "authenticated" is the cookie's verdict, and building the forwardable <see cref="ClientPrincipal"/>
+/// can still fail closed (canonical identity resolution refuses the session, configuration changed under
+/// it). Without this guard such a request is proxied with <em>no</em> identity headers, the backend refuses
+/// everything, and the person stares at an application that renders nothing while being "signed in".
+/// Terminating the session is the honest answer: the very next navigation lands on provider selection with
+/// a reason the page can show, and a fresh sign-in produces a session that works. Routes the service
+/// declared anonymous are exempt — they are proxied without identity by design.
+/// </remarks>
+/// <param name="next">The next middleware in the pipeline.</param>
+/// <param name="logger">The logger.</param>
+public class IdentityForwardingGuardMiddleware(RequestDelegate next, ILogger<IdentityForwardingGuardMiddleware> logger)
+{
+    /// <inheritdoc cref="IMiddleware.InvokeAsync"/>
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (context.GetEndpoint()?.Metadata.GetMetadata<RouteModel>() is not { } route
+            || IsAnonymousRoute(route)
+            || context.User.Identity?.IsAuthenticated != true
+            || context.BuildClientPrincipal() is not null)
+        {
+            await next(context);
+            return;
+        }
+
+        logger.TerminatingUnforwardableSession(context.Request.Path);
+        await SessionTermination.SignOutAndClearCookies(context);
+
+        // A person navigating gets the provider-selection page with a reason and their destination
+        // preserved; every other caller gets a status it can act on — never a silently forwarded,
+        // identity-less request.
+        if (context.IsDocumentNavigation())
+        {
+            var returnUrl = RelativeRedirect.Resolve(context.GetPathAndQuery());
+            context.Response.Redirect(
+                $"{WellKnownPaths.LoginPage}?{SignInFailureReason.QueryKey}={SignInFailureReason.InvalidSession}&returnUrl={Uri.EscapeDataString(returnUrl)}");
+            return;
+        }
+
+        context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+    }
+
+    static bool IsAnonymousRoute(RouteModel route) =>
+        string.Equals(
+            route.Config.AuthorizationPolicy,
+            MicroserviceReverseProxyConfigProvider.AnonymousAuthorizationPolicy,
+            StringComparison.OrdinalIgnoreCase);
+}

--- a/Source/AuthProxy/Identity/IdentityForwardingGuardMiddlewareLogging.cs
+++ b/Source/AuthProxy/Identity/IdentityForwardingGuardMiddlewareLogging.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Identity;
+
+internal static partial class IdentityForwardingGuardMiddlewareLogging
+{
+    [LoggerMessage(LogLevel.Warning, "Authenticated session could not be turned into a forwardable identity for {Path}. Terminating the session instead of proxying without identity headers")]
+    internal static partial void TerminatingUnforwardableSession(this ILogger logger, PathString path);
+}

--- a/Source/AuthProxy/IngressExtensions.cs
+++ b/Source/AuthProxy/IngressExtensions.cs
@@ -101,6 +101,7 @@ public static class IngressExtensions
         app.UseMiddleware<RegistrationMiddleware>();
         app.UseMiddleware<IdentityMiddleware>();
         app.UseMiddleware<InviteRedirectMiddleware>();
+        app.UseMiddleware<IdentityForwardingGuardMiddleware>();
 
         app.MapIngressEndpoints();
         app.UseReverseProxy();

--- a/Source/AuthProxy/LogoutMiddleware.cs
+++ b/Source/AuthProxy/LogoutMiddleware.cs
@@ -76,7 +76,7 @@ public class LogoutMiddleware(
 
         // Always clear the local session immediately. Even when the identity provider cannot be reached the
         // user must end up logged out locally.
-        await SignOutAndClearCookies(context);
+        await SessionTermination.SignOutAndClearCookies(context);
 
         context.Response.StatusCode = StatusCodes.Status302Found;
 
@@ -100,7 +100,7 @@ public class LogoutMiddleware(
     {
         // The identity provider has redirected back after ending its own session. Clear every AuthProxy cookie
         // (idempotent with the initiation leg) and redirect to the validated final destination.
-        await SignOutAndClearCookies(context);
+        await SessionTermination.SignOutAndClearCookies(context);
 
         var target = PostLogoutRedirectPolicy.ApplicationRoot;
         if (context.Request.Cookies.TryGetValue(Cookies.LogoutRedirect, out var carried))
@@ -130,41 +130,6 @@ public class LogoutMiddleware(
         && properties.Items.TryGetValue(AuthState.AuthenticationSchemeStateKey, out var scheme)
             ? scheme
             : null;
-
-    static async Task SignOutAndClearCookies(HttpContext context)
-    {
-        await context.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
-        context.Response.Cookies.Delete(Cookies.Identity);
-        context.Response.Cookies.Delete(Cookies.IdentityAuthorization);
-        context.Response.Cookies.Delete(Cookies.Tenant);
-        context.Response.Cookies.Delete(Cookies.Tenants);
-        context.Response.Cookies.Delete(Cookies.InviteToken);
-        context.Response.Cookies.Delete(Cookies.InvitationEntryState);
-        context.Response.Cookies.Delete(Cookies.InviteToken, new CookieOptions { Path = "/" });
-        context.Response.Cookies.Delete(Cookies.InvitationEntryState, new CookieOptions { Path = "/" });
-        context.Response.Cookies.Delete(Cookies.Registration);
-        context.Response.Cookies.Delete(Cookies.Providers);
-        ClearTransientAuthenticationCookies(context);
-    }
-
-    /// <summary>
-    /// Deletes the correlation and nonce cookies the OAuth/OIDC middleware leaves behind when a sign-in
-    /// handshake is abandoned. They carry random per-attempt names, so they are matched by their well-known
-    /// prefixes rather than by an exact name; the provider registration keeps them at the root path so the
-    /// browser still sends them on the logout request and they can be enumerated and cleared here.
-    /// </summary>
-    /// <param name="context">The <see cref="HttpContext"/> whose response the delete cookies are written to.</param>
-    static void ClearTransientAuthenticationCookies(HttpContext context)
-    {
-        var transientCookies = context.Request.Cookies.Keys
-            .Where(name => name.StartsWith(Cookies.CorrelationPrefix, StringComparison.Ordinal)
-                || name.StartsWith(Cookies.NoncePrefix, StringComparison.Ordinal));
-
-        foreach (var cookie in transientCookies)
-        {
-            context.Response.Cookies.Delete(cookie, new CookieOptions { Path = "/" });
-        }
-    }
 
     static void SetLogoutRedirectCookie(HttpContext context, string target)
     {

--- a/Source/AuthProxy/Pages/select-provider.html
+++ b/Source/AuthProxy/Pages/select-provider.html
@@ -13,11 +13,13 @@
         .provider-btn { display: block; padding: .75rem 1.5rem; border-radius: 6px; background: #0078d4; color: #fff; text-decoration: none; font-size: 1rem; font-weight: 600; transition: background .15s; }
         .provider-btn:hover { background: #005a9e; }
         .error { color: #c00; font-size: .9rem; margin-top: 1rem; }
+        .reason { background: #fdf3e7; border: 1px solid #f0c893; border-radius: 6px; color: #8a5a00; font-size: .9rem; padding: .75rem 1rem; margin: 0 0 1.25rem; }
     </style>
 </head>
 <body>
     <div class="card">
         <h1>Sign In</h1>
+        <p id="reason" class="reason" style="display:none"></p>
         <p>Choose how you want to sign in:</p>
         <div id="providers" class="providers"></div>
         <p id="error" class="error" style="display:none">
@@ -29,6 +31,22 @@
             function getCookie(name) {
                 var match = document.cookie.match(new RegExp('(?:^|; )' + name.replace(/([.*+?^=!:${}()|[\]\/\\])/g, '\\$1') + '=([^;]*)'));
                 return match ? decodeURIComponent(match[1]) : null;
+            }
+
+            var query = new URLSearchParams(window.location.search);
+
+            // A failed, denied, or terminated sign-in redirects back here with a reason. Show the person
+            // what happened; the buttons below are the way forward.
+            var reasonMessages = {
+                'remote-failure': 'Signing in did not complete. Please try again.',
+                'access-denied': 'The sign-in was cancelled or not approved at the identity provider. Please try again.',
+                'invalid-session': 'Your session is no longer valid. Please sign in again.'
+            };
+            var reason = query.get('reason');
+            if (reason && reasonMessages[reason]) {
+                var reasonEl = document.getElementById('reason');
+                reasonEl.textContent = reasonMessages[reason];
+                reasonEl.style.display = '';
             }
 
             var providersJson = getCookie('.cratis-providers');
@@ -55,8 +73,18 @@
 
             // This page is served in place of the resource that was requested, so the current location is
             // where the user was heading. Carrying it as returnUrl is what brings them back after sign-in
-            // instead of dropping them at the site root.
-            var returnUrl = window.location.pathname + window.location.search;
+            // instead of dropping them at the site root. The exception is landing on the page's own path —
+            // a failed sign-in or an explicit redirect sends people here with the real destination in the
+            // returnUrl parameter, and carrying the page's own URL would loop back into it after sign-in.
+            var returnUrl;
+            if (window.location.pathname.indexOf('/.cratis/select-provider') === 0) {
+                var explicitReturnUrl = query.get('returnUrl');
+                returnUrl = explicitReturnUrl && explicitReturnUrl.charAt(0) === '/' && explicitReturnUrl.charAt(1) !== '/'
+                    ? explicitReturnUrl
+                    : '/';
+            } else {
+                returnUrl = window.location.pathname + window.location.search;
+            }
 
             providers.forEach(function (provider) {
                 var a = document.createElement('a');

--- a/Source/AuthProxy/ReverseProxy/MicroserviceReverseProxyConfigProvider.cs
+++ b/Source/AuthProxy/ReverseProxy/MicroserviceReverseProxyConfigProvider.cs
@@ -31,9 +31,11 @@ namespace Cratis.AuthProxy.ReverseProxy;
 public class MicroserviceReverseProxyConfigProvider : IProxyConfigProvider, IDisposable
 {
     /// <summary>
-    /// The YARP well-known authorization policy name that disables authorization for a route.
+    /// The YARP well-known authorization policy name that disables authorization for a route. Shared with
+    /// <see cref="Identity.IdentityForwardingGuardMiddleware"/>, which exempts routes carrying it from the
+    /// forwardable-identity requirement.
     /// </summary>
-    const string AnonymousAuthorizationPolicy = "anonymous";
+    internal const string AnonymousAuthorizationPolicy = "anonymous";
 
     /// <summary>
     /// The path prefix served by a service's backend rather than its frontend.

--- a/Source/Web/src/App.tsx
+++ b/Source/Web/src/App.tsx
@@ -4,12 +4,21 @@ import { ProgressSpinner } from 'primereact/progressspinner';
 import { ProviderButton } from './components/ProviderButton';
 import type { OidcProvider } from './types';
 
+const reasonMessages: Record<string, string> = {
+    'remote-failure': 'Signing in did not complete. Please try again.',
+    'access-denied': 'The sign-in was cancelled or not approved at the identity provider. Please try again.',
+    'invalid-session': 'Your session is no longer valid. Please sign in again.'
+};
+
 export default function App() {
     const [providers, setProviders] = useState<OidcProvider[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
 
-    const returnUrl = new URLSearchParams(window.location.search).get('returnUrl') ?? '/';
+    const query = new URLSearchParams(window.location.search);
+    const returnUrl = query.get('returnUrl') ?? '/';
+    const reason = query.get('reason');
+    const reasonMessage = reason ? reasonMessages[reason] : undefined;
 
     useEffect(() => {
         fetch('/.cratis/providers')
@@ -33,6 +42,9 @@ export default function App() {
                 title="Sign In"
                 className="w-full max-w-sm shadow-lg"
             >
+                {reasonMessage && (
+                    <p className="text-amber-600 text-sm text-center mb-4">{reasonMessage}</p>
+                )}
                 {loading && (
                     <div className="flex justify-center py-4">
                         <ProgressSpinner />


### PR DESCRIPTION
# Summary

Hardens the sign-in and logout chain after a production incident where failed Microsoft/Google logins surfaced as blank pages and sessions kept being proxied without identity headers.

## Added

- Failed remote sign-ins (correlation failure, invalid OAuth state, provider errors, cancelled consent) now redirect to the provider-selection page with a `reason` query parameter (`remote-failure` / `access-denied`) instead of surfacing as a blank 500 error page; the bundled selection pages show a matching message
- A guard in front of the reverse proxy that terminates an authenticated session that cannot be turned into a forwardable identity — the browser is sent to provider selection with `reason=invalid-session`, API callers get `401` — instead of proxying the request without identity headers
- A `Failed Sign-ins` documentation page covering the `reason` contract, handshake-cookie hygiene, and the forwardable-identity guard

## Changed

- A single-provider deployment serves the selection page instead of auto-challenging when a sign-in failure reason is present, so a persistent failure cannot become a redirect loop
- Every provider callback — failed or successful — now sweeps leftover `.AspNetCore.Correlation.*` / `.AspNetCore.OpenIdConnect.Nonce.*` handshake cookies, including legacy callback-path-scoped ones the logout endpoint can never reach, so one sign-in attempt heals a poisoned browser
- The provider-selection page carries the explicit `returnUrl` forward when served on its own path instead of looping back into itself after sign-in

## Fixed

- Canonical OIDC sessions are resolved against the scheme that authenticated the request instead of the identity's `AuthenticationTypes.Federation` authentication type — previously every proxied request on such a session went out without identity headers, leaving the application blank after a seemingly successful login
- Logout documentation now lists the complete set of cookies actually cleared, including `.cratis-identity-authorization`, `.cratis-invite-state`, and the transient handshake cookies
