### PR TITLE
Clear deployment-configured additional cookies on logout and sign-in

### DIFF
--- a/Documentation/configuration/logout.md
+++ b/Documentation/configuration/logout.md
@@ -66,6 +66,9 @@ Both the local logout and the post-logout callback:
 3. Delete every transient sign-in handshake cookie the browser sent (`.AspNetCore.Correlation.*`,
    `.AspNetCore.OpenIdConnect.Nonce.*`) — the leftovers of abandoned handshakes that would otherwise
    poison the next sign-in. See [Failed Sign-ins](failed-sign-ins.md#handshake-cookie-hygiene).
+4. Delete any **additional cookies** the deployment configured under
+   `Cratis:AuthProxy:Logout:AdditionalCookies` — cookies AuthProxy does not issue itself but that must
+   not survive a logout. See [Clearing additional cookies](#clearing-additional-cookies).
 
 The `.cratis-logout` carry cookie is deleted by the callback once the final target has been read from it.
 
@@ -131,6 +134,64 @@ Cratis__AuthProxy__Logout__AllowedRedirectOrigins__0=https://cratis.studio
 
 With the example above, `GET /.cratis/logout?redirect=https://cratis.studio` is permitted even when the
 app itself is served from a different host such as `https://app.cratis.studio`.
+
+---
+
+## Clearing additional cookies
+
+Logout clears every cookie *AuthProxy* issues — but a deployment often runs sibling authentication
+infrastructure whose cookies AuthProxy knows nothing about. The classic case is a separate
+[oauth2-proxy](https://oauth2-proxy.github.io/oauth2-proxy/) guarding an admin app whose session cookie
+was scoped to the **parent domain** (e.g. `_oauth2_proxy_admin` on `.cratis.studio`): every browser that
+ever signed in there sends it on every `*.cratis.studio` request, and it survives AuthProxy's logout —
+leaving the user half-signed-in from the application's point of view.
+
+List such cookies under `Cratis:AuthProxy:Logout:AdditionalCookies` and the session-termination sweep
+deletes them too. Each entry has:
+
+- **`Name`** *(required)* — the exact cookie name. Matching is by exact name only; there is no prefix or
+  wildcard support.
+- **`Domain`** *(optional)* — the domain the cookie was scoped to, e.g. `.cratis.studio`. When set, the
+  deletion is issued **for that domain as well as the request host** — necessary because a host-scoped
+  deletion cannot touch a parent-domain cookie. Deleting for a parent domain of the current host is legal,
+  which is exactly what makes this work. Leave it out for a cookie scoped to the request host itself.
+
+Deletions are issued at the root path (`Path=/`) with the `Secure` attribute mirroring the request scheme,
+so they reliably match how such cookies are typically written.
+
+```json
+{
+  "Cratis": {
+    "AuthProxy": {
+      "Logout": {
+        "AdditionalCookies": [
+          {
+            "Name": "_oauth2_proxy_admin",
+            "Domain": ".cratis.studio"
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+Equivalent environment variables (one indexed entry per cookie):
+
+```
+Cratis__AuthProxy__Logout__AdditionalCookies__0__Name=_oauth2_proxy_admin
+Cratis__AuthProxy__Logout__AdditionalCookies__0__Domain=.cratis.studio
+```
+
+The configured cookies are cleared everywhere the session is terminated:
+
+- the logout endpoint (both legs of a full-chain logout), and
+- the sign-in sweep that runs when a provider callback completes — so a **fresh sign-in also heals** a
+  browser still carrying the stale cookie, without requiring the user to log out first.
+
+This is a cleanup mechanism for cookies that linger after the owning deployment has been fixed (for
+example, until an old parent-domain cookie expires) — it does not log the user out of the system that
+issued the cookie.
 
 ---
 

--- a/Source/AuthProxy.Specs/Authentication/for_AdditionalLogoutCookies/when_clearing_a_cookie_with_a_domain.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_AdditionalLogoutCookies/when_clearing_a_cookie_with_a_domain.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authentication.for_AdditionalLogoutCookies;
+
+public class when_clearing_a_cookie_with_a_domain : Specification
+{
+    DefaultHttpContext _context;
+    string _setCookies;
+
+    void Establish()
+    {
+        _context = new DefaultHttpContext();
+        _context.Request.Scheme = "https";
+        _context.Request.Host = new HostString("app.cratis.studio");
+    }
+
+    void Because()
+    {
+        AdditionalLogoutCookies.Clear(_context, [new C.LogoutCookie { Name = "_oauth2_proxy_admin", Domain = ".cratis.studio" }]);
+        _setCookies = _context.Response.Headers.SetCookie.ToString();
+    }
+
+    [Fact] void should_delete_the_cookie_for_the_request_host() => _setCookies.ShouldContain("_oauth2_proxy_admin=; expires");
+    [Fact] void should_delete_the_cookie_for_the_configured_domain() => _setCookies.ShouldContain("domain=.cratis.studio");
+    [Fact] void should_delete_at_the_root_path() => _setCookies.ShouldContain("path=/");
+    [Fact] void should_mark_the_deletions_secure() => _setCookies.ShouldContain("secure");
+
+    [Fact]
+    void should_emit_a_host_scoped_and_a_domain_scoped_deletion() =>
+        _context.Response.Headers.SetCookie.Count.ShouldEqual(2);
+}

--- a/Source/AuthProxy.Specs/Authentication/for_AdditionalLogoutCookies/when_clearing_a_cookie_without_a_domain.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_AdditionalLogoutCookies/when_clearing_a_cookie_without_a_domain.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authentication.for_AdditionalLogoutCookies;
+
+public class when_clearing_a_cookie_without_a_domain : Specification
+{
+    DefaultHttpContext _context;
+    string _setCookies;
+
+    void Establish()
+    {
+        _context = new DefaultHttpContext();
+        _context.Request.Scheme = "https";
+        _context.Request.Host = new HostString("app.cratis.studio");
+    }
+
+    void Because()
+    {
+        AdditionalLogoutCookies.Clear(_context, [new C.LogoutCookie { Name = "_oauth2_proxy_admin" }]);
+        _setCookies = _context.Response.Headers.SetCookie.ToString();
+    }
+
+    [Fact] void should_delete_the_cookie() => _setCookies.ShouldContain("_oauth2_proxy_admin=; expires");
+    [Fact] void should_delete_at_the_root_path() => _setCookies.ShouldContain("path=/");
+    [Fact] void should_mark_the_deletion_secure() => _setCookies.ShouldContain("secure");
+    [Fact] void should_not_scope_the_deletion_to_a_domain() => _setCookies.ShouldNotContain("domain=");
+
+    [Fact]
+    void should_only_emit_a_single_deletion() =>
+        _context.Response.Headers.SetCookie.Count.ShouldEqual(1);
+}

--- a/Source/AuthProxy.Specs/Authentication/for_AdditionalLogoutCookies/when_no_additional_cookies_are_configured.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_AdditionalLogoutCookies/when_no_additional_cookies_are_configured.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authentication.for_AdditionalLogoutCookies;
+
+public class when_no_additional_cookies_are_configured : Specification
+{
+    DefaultHttpContext _context;
+
+    void Establish()
+    {
+        _context = new DefaultHttpContext();
+        _context.Request.Scheme = "https";
+        _context.Request.Host = new HostString("app.cratis.studio");
+    }
+
+    void Because() => AdditionalLogoutCookies.Clear(_context, new C.Logout().AdditionalCookies);
+
+    [Fact]
+    void should_not_delete_anything() =>
+        _context.Response.Headers.SetCookie.Count.ShouldEqual(0);
+}

--- a/Source/AuthProxy.Specs/Authentication/for_AuthenticationServiceCollectionExtensions/given/configured_canonical_provider_callbacks.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_AuthenticationServiceCollectionExtensions/given/configured_canonical_provider_callbacks.cs
@@ -21,6 +21,7 @@ public class configured_canonical_provider_callbacks : Specification
     protected OpenIdConnectOptions _oidcOptions;
     protected OAuthOptions _oauthOptions;
     protected IServiceProvider _services;
+    protected C.AuthProxy _rootConfiguration;
 
     void Establish()
     {
@@ -48,7 +49,7 @@ public class configured_canonical_provider_callbacks : Specification
             [$"{C.Authentication.SectionKey}:OAuthProviders:0:CanonicalIdentity:Issuer"] = "https://github.example.com"
         });
 
-        var rootConfiguration = new C.AuthProxy
+        _rootConfiguration = new C.AuthProxy
         {
             Authentication = new C.Authentication
             {
@@ -84,7 +85,7 @@ public class configured_canonical_provider_callbacks : Specification
             }
         };
         var rootOptions = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
-        rootOptions.CurrentValue.Returns(rootConfiguration);
+        rootOptions.CurrentValue.Returns(_ => _rootConfiguration);
         builder.Services.AddSingleton(rootOptions);
         builder.Services.AddSingleton<ISignInNotifier>(Substitute.For<ISignInNotifier>());
         builder.AddIngressConfiguration();

--- a/Source/AuthProxy.Specs/Authentication/for_AuthenticationServiceCollectionExtensions/when_a_configured_callback_sweeps_additional_cookies.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_AuthenticationServiceCollectionExtensions/when_a_configured_callback_sweeps_additional_cookies.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Authentication.for_AuthenticationServiceCollectionExtensions.given;
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.Authentication.for_AuthenticationServiceCollectionExtensions;
+
+/// <summary>
+/// Specifies that a completed sign-in sweeps the deployment-configured additional cookies alongside the
+/// transient handshake cookies, so a stale foreign session cookie does not survive a fresh sign-in.
+/// </summary>
+public class when_a_configured_callback_sweeps_additional_cookies : configured_canonical_provider_callbacks
+{
+    DefaultHttpContext _httpContext;
+
+    void Establish()
+    {
+        _rootConfiguration.Logout.AdditionalCookies.Add(new C.LogoutCookie { Name = "_oauth2_proxy_admin", Domain = ".cratis.studio" });
+
+        _httpContext = Context();
+        _httpContext.Request.Scheme = "https";
+        _httpContext.Request.Host = new HostString("app.cratis.studio");
+    }
+
+    async Task Because()
+    {
+        var principal = new ClaimsPrincipal(new ClaimsIdentity([new Claim("id", "github-subject")], "github"));
+        var ticketContext = TicketContext(_httpContext, "github", _oauthOptions, principal, new AuthenticationProperties());
+        await _oauthOptions.Events.OnTicketReceived(ticketContext);
+    }
+
+    [Fact]
+    void should_delete_the_additional_cookie_for_the_request_host_and_for_its_domain() =>
+        _httpContext.Response.Headers.SetCookie
+            .Count(_ => _?.StartsWith("_oauth2_proxy_admin=;", StringComparison.Ordinal) == true)
+            .ShouldEqual(2);
+
+    [Fact]
+    void should_scope_one_of_the_deletions_to_the_configured_domain() =>
+        _httpContext.Response.Headers.SetCookie.ToString().ShouldContain("domain=.cratis.studio");
+}

--- a/Source/AuthProxy.Specs/Identity/for_IdentityForwardingGuardMiddleware/given/a_proxied_request.cs
+++ b/Source/AuthProxy.Specs/Identity/for_IdentityForwardingGuardMiddleware/given/a_proxied_request.cs
@@ -22,12 +22,16 @@ public class a_proxied_request : Specification
 
     void Establish()
     {
+        var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        config.CurrentValue.Returns(new C.AuthProxy());
+
         _middleware = new IdentityForwardingGuardMiddleware(
             _ =>
             {
                 _nextCalled = true;
                 return Task.CompletedTask;
             },
+            config,
             _logger);
 
         _context = new DefaultHttpContext();

--- a/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_with_additional_cookies_configured.cs
+++ b/Source/AuthProxy.Specs/for_LogoutMiddleware/when_logging_out_with_additional_cookies_configured.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Authentication;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+
+namespace Cratis.AuthProxy.for_LogoutMiddleware;
+
+public class when_logging_out_with_additional_cookies_configured : Specification
+{
+    LogoutMiddleware _middleware;
+    DefaultHttpContext _context;
+
+    void Establish()
+    {
+        var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        config.CurrentValue.Returns(new C.AuthProxy
+        {
+            Logout = new C.Logout
+            {
+                AdditionalCookies =
+                [
+                    new C.LogoutCookie { Name = "_oauth2_proxy_admin", Domain = ".cratis.studio" },
+                    new C.LogoutCookie { Name = "_legacy_session" }
+                ]
+            }
+        });
+
+        var endSessionEndpointResolver = Substitute.For<IEndSessionEndpointResolver>();
+        endSessionEndpointResolver.Resolve(Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns((string?)null);
+
+        _middleware = new LogoutMiddleware(_ => Task.CompletedTask, config, endSessionEndpointResolver, Substitute.For<ILogger<LogoutMiddleware>>());
+
+        _context = new DefaultHttpContext();
+        _context.Request.Scheme = "https";
+        _context.Request.Host = new HostString("app.cratis.studio");
+        _context.Request.Path = WellKnownPaths.Logout;
+        _context.Response.Body = new MemoryStream();
+
+        var properties = new AuthenticationProperties();
+        properties.Items[AuthenticationServiceCollectionExtensions.AuthenticationSchemeStateKey] = "github";
+        var ticket = new AuthenticationTicket(new ClaimsPrincipal(new ClaimsIdentity("test")), properties, CookieAuthenticationDefaults.AuthenticationScheme);
+
+        var authenticationService = Substitute.For<IAuthenticationService>();
+        authenticationService.AuthenticateAsync(Arg.Any<HttpContext>(), CookieAuthenticationDefaults.AuthenticationScheme)
+            .Returns(AuthenticateResult.Success(ticket));
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IAuthenticationService)).Returns(authenticationService);
+        _context.RequestServices = serviceProvider;
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact]
+    void should_delete_the_domain_cookie_for_the_request_host_and_for_its_domain() =>
+        _context.Response.Headers.SetCookie
+            .Count(_ => _?.StartsWith("_oauth2_proxy_admin=;", StringComparison.Ordinal) == true)
+            .ShouldEqual(2);
+
+    [Fact]
+    void should_scope_one_of_the_deletions_to_the_configured_domain() =>
+        _context.Response.Headers.SetCookie.ToString().ShouldContain("domain=.cratis.studio");
+
+    [Fact]
+    void should_delete_the_host_only_cookie_once() =>
+        _context.Response.Headers.SetCookie
+            .Count(_ => _?.StartsWith("_legacy_session=;", StringComparison.Ordinal) == true)
+            .ShouldEqual(1);
+}

--- a/Source/AuthProxy/Authentication/AdditionalLogoutCookies.cs
+++ b/Source/AuthProxy/Authentication/AdditionalLogoutCookies.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using C = Cratis.AuthProxy.Configuration;
+
+namespace Cratis.AuthProxy.Authentication;
+
+/// <summary>
+/// Deletes the deployment-configured additional cookies (<see cref="C.Logout.AdditionalCookies"/>) —
+/// cookies AuthProxy does not issue itself but that must not survive a session termination, such as a
+/// session cookie another proxy scoped to a parent domain. Matching is by exact name only.
+/// </summary>
+/// <remarks>
+/// Every deletion is issued at the root path with the Secure attribute mirroring the request scheme, so it
+/// matches how such cookies are typically written and is not discarded by the browser. A cookie scoped to
+/// a parent domain (e.g. <c>.cratis.studio</c>) is invisible to a host-scoped deletion, so when an entry
+/// carries a domain the deletion is issued for that domain as well — deleting for a parent domain of the
+/// current host is legal, which is exactly what makes it possible to kill such a straggler from here.
+/// </remarks>
+public static class AdditionalLogoutCookies
+{
+    /// <summary>
+    /// Deletes every configured additional cookie, for the request host and, when configured, its domain.
+    /// </summary>
+    /// <param name="context">The <see cref="HttpContext"/> whose response the delete cookies are written to.</param>
+    /// <param name="cookies">The configured cookies to delete.</param>
+    public static void Clear(HttpContext context, IEnumerable<C.LogoutCookie> cookies)
+    {
+        foreach (var cookie in cookies.Where(_ => !string.IsNullOrWhiteSpace(_.Name)))
+        {
+            context.Response.Cookies.Delete(cookie.Name, DeletionOptions(context));
+
+            if (!string.IsNullOrWhiteSpace(cookie.Domain))
+            {
+                var domainScoped = DeletionOptions(context);
+                domainScoped.Domain = cookie.Domain;
+                context.Response.Cookies.Delete(cookie.Name, domainScoped);
+            }
+        }
+    }
+
+    static CookieOptions DeletionOptions(HttpContext context) => new()
+    {
+        Path = "/",
+        Secure = context.Request.IsHttps
+    };
+}

--- a/Source/AuthProxy/Authentication/AuthenticationServiceCollectionExtensions.cs
+++ b/Source/AuthProxy/Authentication/AuthenticationServiceCollectionExtensions.cs
@@ -389,7 +389,12 @@ public static class AuthenticationServiceCollectionExtensions
         // (this is the callback path, where legacy path-scoped stragglers still flow) and safe to remove —
         // the handshake they belonged to is either this one, already consumed, or abandoned. Clearing them
         // here means one successful sign-in heals a browser poisoned by earlier half-cleared sessions.
+        // The deployment-configured additional cookies ride the same sweep: a stale foreign session cookie
+        // (say, one another proxy scoped to the parent domain) is just as poisonous as a leftover handshake
+        // cookie, so a successful sign-in heals the browser of those too.
         TransientAuthenticationCookies.Clear(context.HttpContext);
+        var logout = context.HttpContext.RequestServices.GetRequiredService<IOptionsMonitor<C.AuthProxy>>().CurrentValue.Logout;
+        AdditionalLogoutCookies.Clear(context.HttpContext, logout.AdditionalCookies);
 
         var canonicalIdentityResolver = context.HttpContext.RequestServices.GetRequiredService<ICanonicalIdentityResolver>();
         string? validatedIssuer = null;

--- a/Source/AuthProxy/Authentication/SessionTermination.cs
+++ b/Source/AuthProxy/Authentication/SessionTermination.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using C = Cratis.AuthProxy.Configuration;
 
 namespace Cratis.AuthProxy.Authentication;
 
@@ -20,11 +21,13 @@ namespace Cratis.AuthProxy.Authentication;
 public static class SessionTermination
 {
     /// <summary>
-    /// Signs the current caller out of the cookie scheme and deletes every AuthProxy-issued cookie.
+    /// Signs the current caller out of the cookie scheme and deletes every AuthProxy-issued cookie, plus
+    /// any additional cookies the deployment configured (<see cref="C.Logout.AdditionalCookies"/>).
     /// </summary>
     /// <param name="context">The <see cref="HttpContext"/> whose session to terminate.</param>
+    /// <param name="logout">The logout configuration naming the additional cookies to delete.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    public static async Task SignOutAndClearCookies(HttpContext context)
+    public static async Task SignOutAndClearCookies(HttpContext context, C.Logout logout)
     {
         await context.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
         context.Response.Cookies.Delete(Cookies.Identity);
@@ -38,5 +41,6 @@ public static class SessionTermination
         context.Response.Cookies.Delete(Cookies.Registration);
         context.Response.Cookies.Delete(Cookies.Providers);
         TransientAuthenticationCookies.Clear(context);
+        AdditionalLogoutCookies.Clear(context, logout.AdditionalCookies);
     }
 }

--- a/Source/AuthProxy/Configuration/Logout.cs
+++ b/Source/AuthProxy/Configuration/Logout.cs
@@ -15,4 +15,11 @@ public class Logout
     /// service frontends and lobby frontend. Malformed or non-HTTP(S) entries are ignored.
     /// </summary>
     public IList<string> AllowedRedirectOrigins { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets additional cookies to delete whenever the session is terminated — cookies AuthProxy
+    /// does not issue itself but that must not survive a logout, such as a session cookie written by
+    /// sibling authentication infrastructure on a parent domain. See <see cref="LogoutCookie"/>.
+    /// </summary>
+    public IList<LogoutCookie> AdditionalCookies { get; set; } = [];
 }

--- a/Source/AuthProxy/Configuration/LogoutCookie.cs
+++ b/Source/AuthProxy/Configuration/LogoutCookie.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Configuration;
+
+/// <summary>
+/// Represents one additional cookie the logout flow deletes on top of the cookies AuthProxy issues itself.
+/// </summary>
+/// <remarks>
+/// This exists for cookies AuthProxy does not own but that must not survive a logout — typically a cookie
+/// written by sibling authentication infrastructure (another proxy on the same or a parent domain) that
+/// would otherwise keep the browser half-signed-in. Matching is by exact name only.
+/// </remarks>
+public class LogoutCookie
+{
+    /// <summary>
+    /// Gets or sets the exact name of the cookie to delete, e.g. <c>_oauth2_proxy_admin</c>.
+    /// Entries with an empty name are ignored.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the domain the cookie was scoped to, e.g. <c>.cratis.studio</c>.
+    /// When set, the deletion is issued for this domain in addition to the request host — required to kill
+    /// a cookie that was written for a parent domain, since a host-scoped deletion cannot touch it.
+    /// Leave empty for a cookie scoped to the request host itself.
+    /// </summary>
+    public string Domain { get; set; } = string.Empty;
+}

--- a/Source/AuthProxy/Identity/IdentityForwardingGuardMiddleware.cs
+++ b/Source/AuthProxy/Identity/IdentityForwardingGuardMiddleware.cs
@@ -3,7 +3,9 @@
 
 using Cratis.AuthProxy.Authentication;
 using Cratis.AuthProxy.ReverseProxy;
+using Microsoft.Extensions.Options;
 using Yarp.ReverseProxy.Model;
+using C = Cratis.AuthProxy.Configuration;
 
 namespace Cratis.AuthProxy.Identity;
 
@@ -24,8 +26,12 @@ namespace Cratis.AuthProxy.Identity;
 /// declared anonymous are exempt — they are proxied without identity by design.
 /// </remarks>
 /// <param name="next">The next middleware in the pipeline.</param>
+/// <param name="config">The auth proxy configuration monitor.</param>
 /// <param name="logger">The logger.</param>
-public class IdentityForwardingGuardMiddleware(RequestDelegate next, ILogger<IdentityForwardingGuardMiddleware> logger)
+public class IdentityForwardingGuardMiddleware(
+    RequestDelegate next,
+    IOptionsMonitor<C.AuthProxy> config,
+    ILogger<IdentityForwardingGuardMiddleware> logger)
 {
     /// <inheritdoc cref="IMiddleware.InvokeAsync"/>
     public async Task InvokeAsync(HttpContext context)
@@ -40,7 +46,7 @@ public class IdentityForwardingGuardMiddleware(RequestDelegate next, ILogger<Ide
         }
 
         logger.TerminatingUnforwardableSession(RequestPathRedaction.Redact(context.Request.Path));
-        await SessionTermination.SignOutAndClearCookies(context);
+        await SessionTermination.SignOutAndClearCookies(context, config.CurrentValue.Logout);
 
         // A person navigating gets the provider-selection page with a reason and their destination
         // preserved; every other caller gets a status it can act on — never a silently forwarded,

--- a/Source/AuthProxy/LogoutMiddleware.cs
+++ b/Source/AuthProxy/LogoutMiddleware.cs
@@ -76,7 +76,7 @@ public class LogoutMiddleware(
 
         // Always clear the local session immediately. Even when the identity provider cannot be reached the
         // user must end up logged out locally.
-        await SessionTermination.SignOutAndClearCookies(context);
+        await SessionTermination.SignOutAndClearCookies(context, authProxyConfig.Logout);
 
         context.Response.StatusCode = StatusCodes.Status302Found;
 
@@ -100,7 +100,7 @@ public class LogoutMiddleware(
     {
         // The identity provider has redirected back after ending its own session. Clear every AuthProxy cookie
         // (idempotent with the initiation leg) and redirect to the validated final destination.
-        await SessionTermination.SignOutAndClearCookies(context);
+        await SessionTermination.SignOutAndClearCookies(context, authProxyConfig.Logout);
 
         var target = PostLogoutRedirectPolicy.ApplicationRoot;
         if (context.Request.Cookies.TryGetValue(Cookies.LogoutRedirect, out var carried))


### PR DESCRIPTION
## Added

- `Cratis:AuthProxy:Logout:AdditionalCookies` — a list of additional cookies the session-termination sweep deletes on top of the cookies AuthProxy issues itself. Each entry names a cookie exactly (`Name`) and may carry the `Domain` it was scoped to (e.g. `.cratis.studio`); when set, the deletion is issued for that domain as well as the request host, which is what it takes to kill a cookie another proxy scoped to a parent domain. Deletions go out with `Path=/` and the `Secure` attribute mirroring the request scheme, and happen on the logout endpoint (both legs of a full-chain logout) and on the sign-in sweep when a provider callback completes — so a fresh sign-in also heals a browser still carrying the stale cookie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)