### PR TITLE
Fix the OIDC sign-in loop and make the credential-link flow embeddable

### DIFF
--- a/Documentation/configuration/authentication.md
+++ b/Documentation/configuration/authentication.md
@@ -105,6 +105,20 @@ This allows a common callback endpoint while still restoring tenant-specific beh
 | `ClientId` | `string` | OAuth 2.0 client ID. |
 | `ClientSecret` | `string` | OAuth 2.0 client secret. |
 | `Scopes` | `string[]` | Additional scopes to request (beyond `openid`, `profile`, `email`). |
+| `ResponseMode` | `string` | How the provider returns the authorization code: `Query` (default) or `FormPost`. See below. |
+
+#### Response mode and the handshake cookies
+
+The handshake only completes when the provider callback carries the correlation cookie, and that cookie is
+`SameSite=Lax` — which a browser attaches to a top-level GET and withholds from a cross-site POST. The
+default `Query` response mode therefore has the provider return the authorization code in a top-level GET
+redirect, and the handshake cookies stay `Lax`.
+
+Some providers mandate a form POST callback — Apple whenever the `name` or `email` scopes are requested.
+Setting `ResponseMode` to `FormPost` opts that provider into it, which also switches that provider's
+correlation and nonce cookies to `SameSite=None; Secure` — a cross-site POST only ever carries `None`
+cookies, and `None` requires HTTPS. Do not choose `FormPost` for providers that support `Query`; it trades
+away the `Lax` hardening for nothing.
 
 ### Canonical federated identity
 

--- a/Documentation/configuration/link.md
+++ b/Documentation/configuration/link.md
@@ -5,7 +5,9 @@ associate it with their existing account — without ever replacing their curren
 proof-of-control building block behind an application's "add a credential" feature.
 
 ```
-GET /.cratis/link/{scheme}?returnUrl=<relative-url>&token=<one-time-link-token>
+GET /.cratis/link?token=<one-time-link-token>                                  → embeddable provider-selection page
+GET /.cratis/link/{scheme}?returnUrl=<relative-url>&token=<one-time-link-token> → challenge for one provider
+GET /.cratis/link/complete                                                     → completion page
 ```
 
 It is deliberately **not** the same as `/.cratis/login/{scheme}`: login signs the authenticated identity into
@@ -15,12 +17,42 @@ and hands that subject to the application, all while leaving the primary session
 
 ---
 
-## Why a popup, not an iframe
+## Embedding the flow in the application
 
-The application opens `/.cratis/link/{scheme}` in a **popup** (or a top-level redirect), never a nested
-iframe. Provider consent pages send `X-Frame-Options: DENY`, and AuthProxy's authentication and OAuth
-correlation/nonce cookies are `SameSite=Lax`, so a cross-site iframe cannot complete the flow. A same-origin
-popup avoids both problems.
+The flow is designed to run inside a **modal iframe** on the application's own page. There is one hard
+constraint it is built around: the provider leg cannot be framed. External identity providers
+(`login.microsoftonline.com`, `accounts.google.com`, …) send `X-Frame-Options: DENY` /
+`frame-ancestors 'none'` on their sign-in pages, so any challenge honored inside an iframe leaves a dead
+frame. The flow is therefore split:
+
+- **The iframe shows AuthProxy pages only.** The application embeds `/.cratis/link?token=…` — the
+  provider-selection page. It lists the configured providers and, on a click, opens
+  `/.cratis/link/{scheme}` with `window.open` — a separate **top-level** window where the provider
+  authenticates. AuthProxy enforces this shape server-side: a navigation to `/.cratis/link/{scheme}` whose
+  `Sec-Fetch-Dest` says it is framed is answered with the selection page instead of a challenge.
+- **The provider window reports back over a `BroadcastChannel`.** The completion page
+  (`/.cratis/link/complete`, where the flow ends by default) and the failure page broadcast
+  `{ type: 'cratis:credential-link-complete' }` / `{ type: 'cratis:credential-link-failed' }` on the
+  same-origin channel `cratis.credential-link` — deliberately not `window.opener`, which an identity
+  provider's `Cross-Origin-Opener-Policy` can sever mid-flow. The completion window then closes itself.
+- **The framed page signals the parent with `postMessage`.** On either outcome the selection page forwards
+  the message to `window.parent`, targeted at the configured embed ancestor origins (never `*`), so the
+  application can close its modal and refresh — or leave the modal open for a retry after a failure.
+
+Embedding is **off by default**. The link pages send `Content-Security-Policy: frame-ancestors 'none'`
+(plus `X-Frame-Options: DENY`) until the deployment names the origins allowed to frame them:
+
+```
+Cratis__AuthProxy__Link__EmbedAncestors__0=self
+```
+
+`self` means the proxy's own origin — the common case, where the application is served through the proxy.
+Additional entries may name other origins (e.g. `https://app.example.com`). This setting opens the **link
+pages only**; sign-in and selection pages always refuse framing, and proxied application responses are
+never touched.
+
+Opening `/.cratis/link/{scheme}` directly in a popup or top-level redirect — the pre-embedding shape —
+still works exactly as before.
 
 ---
 
@@ -39,14 +71,17 @@ popup avoids both problems.
    `POST`s them to the configured [`ExchangeUrl`](#configuration), authenticated with the link token as the
    bearer credential — exactly mirroring the [invite exchange](./lobby/invitation-to-organization.md). The
    user's original session is preserved.
-4. **AuthProxy returns to the application — but only when the exchange succeeded.** On success the browser is
-   redirected to the supplied `returnUrl`, where the application correlates the token back to the signed-in
-   user, records the association, and closes the popup. If the exchange did not succeed — the endpoint is not
-   configured, the link token or the provider subject could not be resolved, the endpoint was unreachable, or
-   the application answered with a non-2xx status — the browser receives a generic link-failure page with
-   HTTP `403` instead, and never the completion redirect. The page is the same for every cause, so it reveals
-   nothing about which one occurred; the cause is logged for the operator. In every case the user's primary
-   session is left exactly as it was.
+4. **AuthProxy ends the flow — completion only when the exchange succeeded.** On success the browser is
+   redirected to the supplied `returnUrl`, or to the flow's own completion page (`/.cratis/link/complete`)
+   when none was supplied — which broadcasts the outcome and closes the window. If the exchange did not
+   succeed — the endpoint is not configured, the link token or the provider subject could not be resolved,
+   the endpoint was unreachable, or the application answered with a non-2xx status — the browser receives a
+   generic link-failure page with HTTP `403` instead, and never the completion redirect. The page is the
+   same for every cause, so it reveals nothing about which one occurred; the cause is logged for the
+   operator. A failed provider round-trip (correlation failure, provider error, the person cancelling)
+   ends on the same failure page — never on the sign-in selection page, whose full sign-ins would offer to
+   replace the very session the link was preserving. In every case the user's primary session is left
+   exactly as it was.
 
 The request body posted to `ExchangeUrl` depends on whether the selected provider opts into
 [canonical federated identity](authentication.md#canonical-federated-identity).
@@ -82,7 +117,9 @@ may link a credential to the current account.
 
 `returnUrl` is echoed back to the browser after the link completes, so it is constrained to a **same-site
 relative path** (a single leading `/`, but not `//`). Anything else — including an absolute URL to another
-origin — falls back to the application root (`/`), so the endpoint can never be turned into an open redirect.
+origin — falls back to the flow's own completion page (`/.cratis/link/complete`), so the endpoint can never
+be turned into an open redirect. Omitting `returnUrl` lands on the completion page too, which is the right
+default for the embedded flow.
 
 ---
 
@@ -96,18 +133,24 @@ Set the application endpoint that records the freshly authenticated subject unde
   "Cratis": {
     "AuthProxy": {
       "Link": {
-        "ExchangeUrl": "https://studio.example.com/api/internal/identity-providers/link"
+        "ExchangeUrl": "https://studio.example.com/api/internal/identity-providers/link",
+        "EmbedAncestors": ["self"]
       }
     }
   }
 }
 ```
 
-Equivalent environment variable:
+Equivalent environment variables:
 
 ```
 Cratis__AuthProxy__Link__ExchangeUrl=https://studio.example.com/api/internal/identity-providers/link
+Cratis__AuthProxy__Link__EmbedAncestors__0=self
 ```
+
+`EmbedAncestors` names the origins allowed to embed the link pages in an iframe (see
+[Embedding the flow in the application](#embedding-the-flow-in-the-application)); when empty — the default —
+the link pages refuse framing entirely.
 
 When `ExchangeUrl` is empty or the `Link` section is absent, there is nowhere to post the subject, so the link
 callback cannot complete: the browser receives the generic link-failure page (HTTP `403`) rather than the

--- a/Documentation/configuration/well-known-pages.md
+++ b/Documentation/configuration/well-known-pages.md
@@ -25,6 +25,9 @@ condition is detected:
 | `invitation-subject-already-exists.html` | The authenticated user's subject is already associated with an existing account during invite exchange (Phase 2). | 409 |
 | `invitation-email-unavailable.html` | Gateway email binding is enabled (`Invite.EmailClaim`), but the identity provider supplied no authenticated-session email address (Phase 2). | 403 |
 | `invitation-email-mismatch.html` | Gateway email binding is enabled (`Invite.EmailClaim`), and the identity provider supplied another address or explicitly reported `email_verified=false` (Phase 2). | 403 |
+| `link-select-provider.html` | The embeddable provider-selection page of the [credential-link flow](link.md), served at `/.cratis/link`. Lists providers, opens the chosen provider's link challenge in a top-level window, and reports the outcome to its embedding parent. | 200 |
+| `link-complete.html` | A credential link completed, at `/.cratis/link/complete`. Broadcasts the completion on the link flow's `BroadcastChannel` and closes its window. | 200 |
+| `link-failed.html` | A credential link did not complete — the provider round-trip failed or the exchange was refused (see [Credential Linking](link.md)). Broadcasts the failure so an embedding selection page can offer a retry. | 403 |
 
 ---
 

--- a/Source/AuthProxy.Specs/Authentication/for_AuthenticationServiceCollectionExtensions/given/an_ingress_authentication_builder.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_AuthenticationServiceCollectionExtensions/given/an_ingress_authentication_builder.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.AuthProxy.Authentication.for_AuthenticationServiceCollectionExtensions.given;
+
+public class an_ingress_authentication_builder : Specification
+{
+    protected OpenIdConnectOptions _options;
+
+    protected virtual IDictionary<string, string?> Configuration => new Dictionary<string, string?>();
+
+    protected OpenIdConnectOptions ResolveOidcOptions(string scheme)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Configuration.AddInMemoryCollection(Configuration);
+        builder.AddIngressAuthentication();
+
+        using var services = builder.Services.BuildServiceProvider();
+        return services.GetRequiredService<IOptionsMonitor<OpenIdConnectOptions>>().Get(scheme);
+    }
+}

--- a/Source/AuthProxy.Specs/Authentication/for_AuthenticationServiceCollectionExtensions/when_an_oidc_provider_is_registered.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_AuthenticationServiceCollectionExtensions/when_an_oidc_provider_is_registered.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+
+namespace Cratis.AuthProxy.Authentication.for_AuthenticationServiceCollectionExtensions;
+
+/// <summary>
+/// The handshake only completes when the provider's callback carries the correlation cookie, and that
+/// cookie is SameSite=Lax — which a browser attaches to a top-level GET and withholds from a cross-site
+/// POST. The handler's own default response mode is form_post, exactly the callback shape the cookie can
+/// never accompany: every OIDC sign-in and credential link died with "Correlation failed" and looped back
+/// to provider selection. The registration must therefore pin the code flow's query response mode.
+/// </summary>
+public class when_an_oidc_provider_is_registered : given.an_ingress_authentication_builder
+{
+    protected override IDictionary<string, string?> Configuration => new Dictionary<string, string?>
+    {
+        [$"{C.Authentication.SectionKey}:OidcProviders:0:Name"] = "Microsoft",
+        [$"{C.Authentication.SectionKey}:OidcProviders:0:Authority"] = "https://login.microsoftonline.com/common/v2.0",
+        [$"{C.Authentication.SectionKey}:OidcProviders:0:ClientId"] = "client-id",
+    };
+
+    void Because() => _options = ResolveOidcOptions("microsoft");
+
+    [Fact] void should_return_the_authorization_code_in_a_top_level_get() => _options.ResponseMode.ShouldEqual(OpenIdConnectResponseMode.Query);
+    [Fact] void should_keep_the_correlation_cookie_lax() => _options.CorrelationCookie.SameSite.ShouldEqual(SameSiteMode.Lax);
+    [Fact] void should_keep_the_nonce_cookie_lax() => _options.NonceCookie.SameSite.ShouldEqual(SameSiteMode.Lax);
+    [Fact] void should_keep_the_correlation_cookie_at_the_root_path() => _options.CorrelationCookie.Path.ShouldEqual("/");
+    [Fact] void should_sign_in_through_the_cookie_scheme() => _options.SignInScheme.ShouldEqual(CookieAuthenticationDefaults.AuthenticationScheme);
+}

--- a/Source/AuthProxy.Specs/Authentication/for_AuthenticationServiceCollectionExtensions/when_an_oidc_provider_opts_into_form_post.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_AuthenticationServiceCollectionExtensions/when_an_oidc_provider_opts_into_form_post.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+
+namespace Cratis.AuthProxy.Authentication.for_AuthenticationServiceCollectionExtensions;
+
+/// <summary>
+/// Some providers mandate a form POST callback — Apple whenever the name or email scopes are requested. A
+/// cross-site POST only ever carries SameSite=None cookies, so opting a provider into form_post must also
+/// switch that provider's handshake cookies to None+Secure or its callbacks would fail exactly the way the
+/// default used to.
+/// </summary>
+public class when_an_oidc_provider_opts_into_form_post : given.an_ingress_authentication_builder
+{
+    protected override IDictionary<string, string?> Configuration => new Dictionary<string, string?>
+    {
+        [$"{C.Authentication.SectionKey}:OidcProviders:0:Name"] = "Apple",
+        [$"{C.Authentication.SectionKey}:OidcProviders:0:Authority"] = "https://appleid.apple.com",
+        [$"{C.Authentication.SectionKey}:OidcProviders:0:ClientId"] = "client-id",
+        [$"{C.Authentication.SectionKey}:OidcProviders:0:ResponseMode"] = nameof(C.OidcResponseMode.FormPost),
+    };
+
+    void Because() => _options = ResolveOidcOptions("apple");
+
+    [Fact] void should_return_the_authorization_code_in_a_form_post() => _options.ResponseMode.ShouldEqual(OpenIdConnectResponseMode.FormPost);
+    [Fact] void should_send_the_correlation_cookie_cross_site() => _options.CorrelationCookie.SameSite.ShouldEqual(SameSiteMode.None);
+    [Fact] void should_require_https_for_the_correlation_cookie() => _options.CorrelationCookie.SecurePolicy.ShouldEqual(CookieSecurePolicy.Always);
+    [Fact] void should_send_the_nonce_cookie_cross_site() => _options.NonceCookie.SameSite.ShouldEqual(SameSiteMode.None);
+    [Fact] void should_require_https_for_the_nonce_cookie() => _options.NonceCookie.SecurePolicy.ShouldEqual(CookieSecurePolicy.Always);
+    [Fact] void should_sign_in_through_the_cookie_scheme() => _options.SignInScheme.ShouldEqual(CookieAuthenticationDefaults.AuthenticationScheme);
+}

--- a/Source/AuthProxy.Specs/Authentication/for_RemoteAuthenticationFailureHandler/when_a_link_challenge_fails.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_RemoteAuthenticationFailureHandler/when_a_link_challenge_fails.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text;
+using Cratis.AuthProxy.Links;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Cratis.AuthProxy.Authentication.for_RemoteAuthenticationFailureHandler;
+
+/// <summary>
+/// A failed link challenge must not fall back to the sign-in machinery: the person still holds their
+/// primary session, and the provider-selection page answers with full sign-ins — offering to replace the
+/// very session the link was preserving, and looping straight back into whatever failed (#104). The link
+/// flow ends on its own failure page instead.
+/// </summary>
+public class when_a_link_challenge_fails : given.a_remote_authentication_failure_context
+{
+    RemoteFailureContext _failureContext;
+
+    void Establish()
+    {
+        _context.Request.Headers.Cookie = $"{Cookies.CorrelationPrefix}abc=one; {Cookies.NoncePrefix}def=two";
+        _context.RequestServices = ServicesWithErrorPages();
+
+        var properties = new AuthenticationProperties { RedirectUri = "/settings/credentials" };
+        properties.Items[LinkMiddleware.LinkModePropertyKey] = "true";
+        properties.Items[LinkMiddleware.LinkTokenPropertyKey] = "the-one-time-link-token";
+
+        _failureContext = new RemoteFailureContext(_context, _scheme, _options, new InvalidOperationException("Correlation failed."))
+        {
+            Properties = properties
+        };
+    }
+
+    async Task Because() => await RemoteAuthenticationFailureHandler.HandleRemoteFailure(_failureContext);
+
+    [Fact] void should_handle_the_response() => _failureContext.Result.Handled.ShouldBeTrue();
+    [Fact] void should_answer_with_a_non_success_status() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status403Forbidden);
+    [Fact] void should_not_redirect() => _context.Response.Headers.Location.ToString().ShouldBeEmpty();
+
+    [Fact] void should_not_fall_back_to_provider_selection() =>
+        _context.Response.Headers.Location.ToString().ShouldNotContain(WellKnownPaths.LoginPage);
+
+    [Fact] void should_write_the_link_failure_page() =>
+        Encoding.UTF8.GetString(((MemoryStream)_context.Response.Body).ToArray()).ShouldContain("Link Not Completed");
+
+    [Fact] void should_clear_the_correlation_cookie() =>
+        _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.CorrelationPrefix}abc=; expires");
+
+    [Fact] void should_clear_the_nonce_cookie() =>
+        _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.NoncePrefix}def=; expires");
+
+    [Fact] void should_forbid_framing_by_default() =>
+        _context.Response.Headers.ContentSecurityPolicy.ToString().ShouldEqual("frame-ancestors 'none'");
+
+    IServiceProvider ServicesWithErrorPages()
+    {
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        loggerFactory.CreateLogger(Arg.Any<string>()).Returns(Substitute.For<ILogger>());
+
+        var environment = Substitute.For<IWebHostEnvironment>();
+        environment.ContentRootPath.Returns(AppContext.BaseDirectory);
+
+        var config = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        config.CurrentValue.Returns(new C.AuthProxy());
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(ILoggerFactory)).Returns(loggerFactory);
+        serviceProvider.GetService(typeof(IErrorPageProvider)).Returns(new ErrorPageProvider(environment, config));
+        serviceProvider.GetService(typeof(IOptionsMonitor<C.AuthProxy>)).Returns(config);
+        return serviceProvider;
+    }
+}

--- a/Source/AuthProxy.Specs/Links/for_LinkCallbackCompletion/given/a_link_callback_context.cs
+++ b/Source/AuthProxy.Specs/Links/for_LinkCallbackCompletion/given/a_link_callback_context.cs
@@ -49,11 +49,15 @@ public class a_link_callback_context : Specification
         // the call NSubstitute is waiting to configure.
         var errorPageProvider = CreateErrorPageProvider();
 
+        var proxyConfig = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        proxyConfig.CurrentValue.Returns(new C.AuthProxy());
+
         var serviceProvider = Substitute.For<IServiceProvider>();
         serviceProvider.GetService(typeof(ILoggerFactory)).Returns(loggerFactory);
         serviceProvider.GetService(typeof(ILinkSubjectExchanger)).Returns(_exchanger);
         serviceProvider.GetService(typeof(IErrorPageProvider)).Returns(errorPageProvider);
         serviceProvider.GetService(typeof(ISignInNotifier)).Returns(_signInNotifier);
+        serviceProvider.GetService(typeof(IOptionsMonitor<C.AuthProxy>)).Returns(proxyConfig);
         _context.RequestServices = serviceProvider;
 
         _properties = new AuthenticationProperties { RedirectUri = RecordedReturnUrl };

--- a/Source/AuthProxy.Specs/Links/for_LinkCallbackCompletion/when_the_exchange_fails/and_the_failure_mode_varies.cs
+++ b/Source/AuthProxy.Specs/Links/for_LinkCallbackCompletion/when_the_exchange_fails/and_the_failure_mode_varies.cs
@@ -176,6 +176,7 @@ public class and_the_failure_mode_varies : Specification
         services.GetService(typeof(ILoggerFactory)).Returns(loggerFactory);
         services.GetService(typeof(IErrorPageProvider)).Returns(errorPageProvider);
         services.GetService(typeof(ILinkSubjectExchanger)).Returns(exchanger);
+        services.GetService(typeof(IOptionsMonitor<C.AuthProxy>)).Returns(config);
 
         return services;
     }

--- a/Source/AuthProxy.Specs/Links/for_LinkCallbackCompletion/when_the_exchange_succeeds/and_no_return_url_was_recorded.cs
+++ b/Source/AuthProxy.Specs/Links/for_LinkCallbackCompletion/when_the_exchange_succeeds/and_no_return_url_was_recorded.cs
@@ -12,6 +12,6 @@ public class and_no_return_url_was_recorded : a_link_callback_context
     async Task Because() => await LinkCallbackCompletion.Complete(_ticketContext, _properties);
 
     [Fact] void should_redirect() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status302Found);
-    [Fact] void should_redirect_to_the_application_root() =>
-        _context.Response.Headers.Location.ToString().ShouldEqual(RelativeRedirect.ApplicationRoot);
+    [Fact] void should_redirect_to_the_completion_page() =>
+        _context.Response.Headers.Location.ToString().ShouldEqual(WellKnownPaths.LinkComplete);
 }

--- a/Source/AuthProxy.Specs/Links/for_LinkCallbackCompletion/when_the_exchange_succeeds/and_the_return_url_is_hostile.cs
+++ b/Source/AuthProxy.Specs/Links/for_LinkCallbackCompletion/when_the_exchange_succeeds/and_the_return_url_is_hostile.cs
@@ -17,8 +17,8 @@ public class and_the_return_url_is_hostile : a_link_callback_context
 
     async Task Because() => await LinkCallbackCompletion.Complete(_ticketContext, _properties);
 
-    [Fact] void should_redirect_to_the_application_root() =>
-        _context.Response.Headers.Location.ToString().ShouldEqual(RelativeRedirect.ApplicationRoot);
+    [Fact] void should_redirect_to_the_completion_page() =>
+        _context.Response.Headers.Location.ToString().ShouldEqual(WellKnownPaths.LinkComplete);
     [Fact] void should_not_send_the_browser_off_site() =>
         _context.Response.Headers.Location.ToString().ShouldNotContain("evil.test");
 }

--- a/Source/AuthProxy.Specs/for_LinkMiddleware/given/a_link_page_context.cs
+++ b/Source/AuthProxy.Specs/for_LinkMiddleware/given/a_link_page_context.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text;
+using Cratis.AuthProxy.Links;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Cratis.AuthProxy.for_LinkMiddleware.given;
+
+public class a_link_page_context : Specification
+{
+    protected LinkMiddleware _middleware;
+    protected DefaultHttpContext _context;
+    protected IAuthenticationService _authenticationService;
+    protected bool _nextCalled;
+
+    protected virtual C.AuthProxy ProxyConfiguration => new();
+
+    protected string ResponseBody() => Encoding.UTF8.GetString(((MemoryStream)_context.Response.Body).ToArray());
+
+    void Establish()
+    {
+        var authConfig = Substitute.For<IOptionsMonitor<C.Authentication>>();
+        authConfig.CurrentValue.Returns(new C.Authentication
+        {
+            OAuthProviders = [new C.OAuthProvider { Name = "GitHub" }],
+        });
+
+        _middleware = new LinkMiddleware(
+            _ =>
+            {
+                _nextCalled = true;
+                return Task.CompletedTask;
+            },
+            authConfig,
+            Substitute.For<ILogger<LinkMiddleware>>());
+
+        _context = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity("test")),
+        };
+        _context.Request.Scheme = "https";
+        _context.Request.Host = new HostString("app.cratis.studio");
+        _context.Response.Body = new MemoryStream();
+
+        var environment = Substitute.For<IWebHostEnvironment>();
+        environment.ContentRootPath.Returns(AppContext.BaseDirectory);
+
+        var proxyConfig = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        proxyConfig.CurrentValue.Returns(ProxyConfiguration);
+
+        _authenticationService = Substitute.For<IAuthenticationService>();
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IAuthenticationService)).Returns(_authenticationService);
+        serviceProvider.GetService(typeof(IErrorPageProvider)).Returns(new ErrorPageProvider(environment, proxyConfig));
+        serviceProvider.GetService(typeof(IOptionsMonitor<C.AuthProxy>)).Returns(proxyConfig);
+        _context.RequestServices = serviceProvider;
+    }
+}

--- a/Source/AuthProxy.Specs/for_LinkMiddleware/when_a_framed_navigation_requests_a_challenge.cs
+++ b/Source/AuthProxy.Specs/for_LinkMiddleware/when_a_framed_navigation_requests_a_challenge.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.for_LinkMiddleware;
+
+/// <summary>
+/// A challenge honored inside a frame redirects the frame to the external identity provider, whose pages
+/// refuse to render framed — leaving a dead iframe. A framed navigation to a provider's link path is
+/// answered with the selection page instead, which opens the provider leg in its own top-level window.
+/// </summary>
+public class when_a_framed_navigation_requests_a_challenge : given.a_link_page_context
+{
+    protected override C.AuthProxy ProxyConfiguration => new()
+    {
+        Link = new C.Link { EmbedAncestors = ["self"] },
+    };
+
+    void Establish()
+    {
+        _context.Request.Path = $"{WellKnownPaths.Link}/github";
+        _context.Request.QueryString = QueryString.Create("token", "the-link-token");
+        _context.Request.Headers["Sec-Fetch-Dest"] = "iframe";
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_not_challenge() => _authenticationService.DidNotReceiveWithAnyArgs().ChallengeAsync(default!, default, default);
+    [Fact] void should_answer_with_the_selection_page() => ResponseBody().ShouldContain("Add a Sign-In Method");
+    [Fact] void should_answer_ok() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status200OK);
+}

--- a/Source/AuthProxy.Specs/for_LinkMiddleware/when_requesting_the_completion_page.cs
+++ b/Source/AuthProxy.Specs/for_LinkMiddleware/when_requesting_the_completion_page.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.for_LinkMiddleware;
+
+/// <summary>
+/// The completion page ends the provider window of a successful link: it broadcasts the outcome to the
+/// embedding selection page and closes. A completed link ends here — no further challenge, no sign-in
+/// machinery, no loop.
+/// </summary>
+public class when_requesting_the_completion_page : given.a_link_page_context
+{
+    void Establish() => _context.Request.Path = WellKnownPaths.LinkComplete;
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_answer_with_the_completion_page() => ResponseBody().ShouldContain("Sign-In Method Added");
+    [Fact] void should_answer_ok() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status200OK);
+    [Fact] void should_not_challenge() => _authenticationService.DidNotReceiveWithAnyArgs().ChallengeAsync(default!, default, default);
+    [Fact] void should_not_call_next() => _nextCalled.ShouldBeFalse();
+}

--- a/Source/AuthProxy.Specs/for_LinkMiddleware/when_requesting_the_selection_page.cs
+++ b/Source/AuthProxy.Specs/for_LinkMiddleware/when_requesting_the_selection_page.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.for_LinkMiddleware;
+
+/// <summary>
+/// The bare link path is the flow's embeddable front door: the provider-selection page the product frames
+/// in its modal. It never challenges — the provider leg belongs in its own top-level window — and it only
+/// answers a signed-in caller holding a link token, exactly like the challenge itself.
+/// </summary>
+public class when_requesting_the_selection_page : given.a_link_page_context
+{
+    protected override C.AuthProxy ProxyConfiguration => new()
+    {
+        Link = new C.Link { EmbedAncestors = ["self"] },
+    };
+
+    void Establish()
+    {
+        _context.Request.Path = WellKnownPaths.Link;
+        _context.Request.QueryString = QueryString.Create("token", "the-link-token");
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_answer_with_the_selection_page() => ResponseBody().ShouldContain("Add a Sign-In Method");
+    [Fact] void should_answer_ok() => _context.Response.StatusCode.ShouldEqual(StatusCodes.Status200OK);
+    [Fact] void should_not_challenge() => _authenticationService.DidNotReceiveWithAnyArgs().ChallengeAsync(default!, default, default);
+    [Fact] void should_not_call_next() => _nextCalled.ShouldBeFalse();
+
+    [Fact] void should_allow_the_configured_ancestor_to_frame_it() =>
+        _context.Response.Headers.ContentSecurityPolicy.ToString().ShouldEqual("frame-ancestors 'self'");
+
+    [Fact] void should_not_send_x_frame_options_when_embeddable() =>
+        _context.Response.Headers.XFrameOptions.ToString().ShouldBeEmpty();
+
+    [Fact] void should_resolve_the_own_origin_as_message_target() =>
+        ResponseBody().ShouldContain("https://app.cratis.studio");
+}

--- a/Source/AuthProxy.Specs/for_LinkMiddleware/when_requesting_the_selection_page_without_embedding_configured.cs
+++ b/Source/AuthProxy.Specs/for_LinkMiddleware/when_requesting_the_selection_page_without_embedding_configured.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.for_LinkMiddleware;
+
+/// <summary>
+/// Embedding is opt-in per deployment: until an allowed ancestor origin is configured, the link pages
+/// refuse to be framed at all — the proxy never opens itself to framing by default.
+/// </summary>
+public class when_requesting_the_selection_page_without_embedding_configured : given.a_link_page_context
+{
+    void Establish()
+    {
+        _context.Request.Path = WellKnownPaths.Link;
+        _context.Request.QueryString = QueryString.Create("token", "the-link-token");
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_forbid_framing_through_content_security_policy() =>
+        _context.Response.Headers.ContentSecurityPolicy.ToString().ShouldEqual("frame-ancestors 'none'");
+
+    [Fact] void should_forbid_framing_through_x_frame_options() =>
+        _context.Response.Headers.XFrameOptions.ToString().ShouldEqual("DENY");
+}

--- a/Source/AuthProxy.Specs/for_LinkMiddleware/when_the_return_url_is_not_relative.cs
+++ b/Source/AuthProxy.Specs/for_LinkMiddleware/when_the_return_url_is_not_relative.cs
@@ -44,9 +44,9 @@ public class when_the_return_url_is_not_relative : Specification
 
     async Task Because() => await _middleware.InvokeAsync(_context);
 
-    [Fact] void should_fall_back_to_the_application_root() =>
+    [Fact] void should_fall_back_to_the_completion_page() =>
         _authenticationService.Received(1).ChallengeAsync(
             _context,
             "github",
-            Arg.Is<AuthenticationProperties>(properties => properties.RedirectUri == "/"));
+            Arg.Is<AuthenticationProperties>(properties => properties.RedirectUri == WellKnownPaths.LinkComplete));
 }

--- a/Source/AuthProxy/Authentication/AuthenticationServiceCollectionExtensions.cs
+++ b/Source/AuthProxy/Authentication/AuthenticationServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using C = Cratis.AuthProxy.Configuration;
 
 namespace Cratis.AuthProxy.Authentication;
@@ -194,7 +195,16 @@ public static class AuthenticationServiceCollectionExtensions
                 options.ClientId = capturedProvider.ClientId;
                 options.ClientSecret = capturedProvider.ClientSecret;
                 options.ResponseType = "code";
-                options.SaveTokens = true;
+
+                // The handler's default response mode is form_post, which has the provider hand the
+                // authorization code back in a cross-site POST — and browsers do not attach SameSite=Lax
+                // cookies to a cross-site POST, so the callback arrived without its correlation cookie and
+                // every OIDC handshake died with "Correlation failed" (the #104 sign-in loop). The code
+                // flow's standard query response mode returns the code in a top-level GET redirect, which
+                // Lax cookies do accompany — the handshake completes without weakening the cookies to
+                // SameSite=None. Providers that mandate form_post (e.g. Apple with name/email scopes) opt
+                // back in per provider, which also switches their handshake cookies to None+Secure below.
+                options.ResponseMode = OpenIdConnectResponseMode.Query;
                 options.GetClaimsFromUserInfoEndpoint = true;
                 if (capturedProvider.CanonicalIdentity is not null)
                 {
@@ -227,6 +237,18 @@ public static class AuthenticationServiceCollectionExtensions
                 // there instead of accumulating from abandoned sign-in attempts.
                 options.CorrelationCookie.Path = "/";
                 options.NonceCookie.Path = "/";
+
+                if (capturedProvider.ResponseMode == C.OidcResponseMode.FormPost)
+                {
+                    // A form_post callback is a cross-site POST, and only SameSite=None cookies travel with
+                    // one — which in turn requires Secure. A provider configured for form_post therefore
+                    // trades the Lax hardening for a working handshake; the default query mode keeps Lax.
+                    options.ResponseMode = OpenIdConnectResponseMode.FormPost;
+                    options.CorrelationCookie.SameSite = SameSiteMode.None;
+                    options.CorrelationCookie.SecurePolicy = CookieSecurePolicy.Always;
+                    options.NonceCookie.SameSite = SameSiteMode.None;
+                    options.NonceCookie.SecurePolicy = CookieSecurePolicy.Always;
+                }
 
                 options.Events = new OpenIdConnectEvents
                 {

--- a/Source/AuthProxy/Authentication/RemoteAuthenticationFailureHandler.cs
+++ b/Source/AuthProxy/Authentication/RemoteAuthenticationFailureHandler.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.AuthProxy.Links;
 using Microsoft.AspNetCore.Authentication;
 
 namespace Cratis.AuthProxy.Authentication;
@@ -30,8 +31,7 @@ public static class RemoteAuthenticationFailureHandler
     public static Task HandleRemoteFailure(RemoteFailureContext context)
     {
         GetLogger(context.HttpContext).RemoteSignInFailed(context.Scheme.Name, context.Failure?.Message ?? "(unknown)");
-        Handle(context, context.Properties, SignInFailureReason.RemoteFailure);
-        return Task.CompletedTask;
+        return Handle(context, context.Properties, SignInFailureReason.RemoteFailure);
     }
 
     /// <summary>
@@ -44,11 +44,10 @@ public static class RemoteAuthenticationFailureHandler
     public static Task HandleAccessDenied(AccessDeniedContext context)
     {
         GetLogger(context.HttpContext).RemoteSignInAccessDenied(context.Scheme.Name);
-        Handle(context, context.Properties, SignInFailureReason.AccessDenied);
-        return Task.CompletedTask;
+        return Handle(context, context.Properties, SignInFailureReason.AccessDenied);
     }
 
-    static void Handle(
+    static async Task Handle(
         HandleRequestContext<RemoteAuthenticationOptions> context,
         AuthenticationProperties? properties,
         string reason)
@@ -56,6 +55,20 @@ public static class RemoteAuthenticationFailureHandler
         // The transient correlation/state cookies are what a retry trips over, and the provider callback is
         // the one request where even legacy path-scoped stragglers are visible — clear them all here.
         TransientAuthenticationCookies.Clear(context.HttpContext);
+
+        // A failed link challenge is not a failed sign-in. The person still holds their primary session,
+        // and the provider-selection page would answer with full sign-ins — offering to *replace* the very
+        // session the link was preserving, and looping straight back into whatever failed. The link flow
+        // ends here instead, on its failure page, which also tells an embedding selection page the attempt
+        // is over so it can offer a retry.
+        if (properties?.Items.TryGetValue(LinkMiddleware.LinkModePropertyKey, out var linkMode) == true
+            && linkMode == "true")
+        {
+            GetLogger(context.HttpContext).LinkChallengeFailed(context.Scheme.Name);
+            await LinkFlowPages.WriteFailed(context.HttpContext);
+            context.HandleResponse();
+            return;
+        }
 
         var location = $"{WellKnownPaths.LoginPage}?{SignInFailureReason.QueryKey}={reason}";
 

--- a/Source/AuthProxy/Authentication/RemoteAuthenticationFailureHandlerLogging.cs
+++ b/Source/AuthProxy/Authentication/RemoteAuthenticationFailureHandlerLogging.cs
@@ -10,4 +10,7 @@ internal static partial class RemoteAuthenticationFailureHandlerLogging
 
     [LoggerMessage(LogLevel.Information, "Remote sign-in through scheme {Scheme} was denied by the identity provider. Redirecting to provider selection")]
     internal static partial void RemoteSignInAccessDenied(this ILogger logger, string scheme);
+
+    [LoggerMessage(LogLevel.Warning, "Credential-link challenge through scheme {Scheme} failed. Ending the link flow on the failure page")]
+    internal static partial void LinkChallengeFailed(this ILogger logger, string scheme);
 }

--- a/Source/AuthProxy/Authentication/SelectProviderMiddleware.cs
+++ b/Source/AuthProxy/Authentication/SelectProviderMiddleware.cs
@@ -113,6 +113,9 @@ public class SelectProviderMiddleware(
                 MaxAge = TimeSpan.FromMinutes(15),
             });
 
+            // A sign-in page rendered inside somebody's frame is clickjacking bait — selection pages are
+            // never embeddable, unlike the credential-link pages whose embedding is configured explicitly.
+            FrameEmbedding.Deny(context);
             await errorPageProvider.WriteErrorPageAsync(
                 context,
                 WellKnownPageNames.SelectProvider,

--- a/Source/AuthProxy/Configuration/Link.cs
+++ b/Source/AuthProxy/Configuration/Link.cs
@@ -23,4 +23,12 @@ public class Link
     /// Leave empty to disable the link callback.
     /// </summary>
     public string ExchangeUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the origins allowed to embed the link-flow pages in an <c>iframe</c>. The literal
+    /// <c>"self"</c> names the proxy's own origin — the common case, where the product is served through
+    /// the proxy. Empty by default, which forbids framing the link pages entirely; nothing else the proxy
+    /// serves is ever opened to framing by this setting.
+    /// </summary>
+    public IList<string> EmbedAncestors { get; set; } = [];
 }

--- a/Source/AuthProxy/Configuration/OidcProvider.cs
+++ b/Source/AuthProxy/Configuration/OidcProvider.cs
@@ -45,6 +45,13 @@ public class OidcProvider
     public IList<string> Scopes { get; set; } = [];
 
     /// <summary>
+    /// Gets or sets how the provider returns the authorization code to the callback endpoint.
+    /// Defaults to <see cref="OidcResponseMode.Query"/>, which keeps the handshake cookies SameSite=Lax;
+    /// see <see cref="OidcResponseMode.FormPost"/> for providers that mandate a form POST callback.
+    /// </summary>
+    public OidcResponseMode ResponseMode { get; set; } = OidcResponseMode.Query;
+
+    /// <summary>
     /// Gets or sets the optional canonical federated identity contract for this provider.
     /// When absent, the provider retains the legacy claim-selection and forwarding behavior.
     /// </summary>

--- a/Source/AuthProxy/Configuration/OidcResponseMode.cs
+++ b/Source/AuthProxy/Configuration/OidcResponseMode.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Configuration;
+
+/// <summary>
+/// Defines how an OIDC provider returns the authorization code to the callback endpoint.
+/// </summary>
+public enum OidcResponseMode
+{
+    /// <summary>
+    /// The code comes back in the query string of a top-level GET redirect. This is the default: the
+    /// handshake's SameSite=Lax correlation and nonce cookies accompany a top-level GET, so the callback
+    /// can always complete without weakening the cookies.
+    /// </summary>
+    Query = 0,
+
+    /// <summary>
+    /// The code comes back in the body of a cross-site form POST. Browsers do not attach SameSite=Lax
+    /// cookies to a cross-site POST, so choosing this switches the provider's handshake cookies to
+    /// SameSite=None + Secure. Reserve it for providers that mandate form_post, such as Apple when the
+    /// name or email scopes are requested.
+    /// </summary>
+    FormPost = 1,
+}

--- a/Source/AuthProxy/ErrorPages/ErrorPageProvider.cs
+++ b/Source/AuthProxy/ErrorPages/ErrorPageProvider.cs
@@ -22,7 +22,7 @@ namespace Cratis.AuthProxy.ErrorPages;
 public class ErrorPageProvider(IWebHostEnvironment environment, IOptionsMonitor<C.AuthProxy> config) : IErrorPageProvider
 {
     /// <inheritdoc/>
-    public async Task WriteErrorPageAsync(HttpContext context, string pageName, int statusCode)
+    public async Task WriteErrorPageAsync(HttpContext context, string pageName, int statusCode, IReadOnlyDictionary<string, string>? substitutions = null)
     {
         context.Response.StatusCode = statusCode;
         context.Response.ContentType = "text/html; charset=utf-8";
@@ -31,6 +31,11 @@ public class ErrorPageProvider(IWebHostEnvironment environment, IOptionsMonitor<
         if (pagePath is not null)
         {
             var html = await File.ReadAllTextAsync(pagePath);
+            foreach (var (token, value) in substitutions ?? new Dictionary<string, string>())
+            {
+                html = html.Replace(token, value, StringComparison.Ordinal);
+            }
+
             await context.Response.WriteAsync(InjectBaseHref(html, WellKnownPaths.Pages + "/"));
             return;
         }

--- a/Source/AuthProxy/ErrorPages/IErrorPageProvider.cs
+++ b/Source/AuthProxy/ErrorPages/IErrorPageProvider.cs
@@ -16,6 +16,11 @@ public interface IErrorPageProvider
     /// <param name="context">The current <see cref="HttpContext"/>.</param>
     /// <param name="pageName">The file name of the page, e.g. <c>"404.html"</c> or <c>"invitation-expired.html"</c>.</param>
     /// <param name="statusCode">The HTTP status code to set on the response.</param>
+    /// <param name="substitutions">
+    /// Optional literal tokens to replace in the page content before it is written — how a page that must
+    /// know something only the server knows (e.g. the origins a framed page may post to) receives it while
+    /// remaining a static, deployment-replaceable file.
+    /// </param>
     /// <returns>A <see cref="Task"/> representing the asynchronous write operation.</returns>
-    Task WriteErrorPageAsync(HttpContext context, string pageName, int statusCode);
+    Task WriteErrorPageAsync(HttpContext context, string pageName, int statusCode, IReadOnlyDictionary<string, string>? substitutions = null);
 }

--- a/Source/AuthProxy/FrameEmbedding.cs
+++ b/Source/AuthProxy/FrameEmbedding.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy;
+
+/// <summary>
+/// Declares whether a page the proxy serves may be embedded in a frame, via
+/// <c>Content-Security-Policy: frame-ancestors</c> (with <c>X-Frame-Options</c> for the deny case).
+/// </summary>
+/// <remarks>
+/// The proxy's own pages fall in two classes. Sign-in pages (provider selection, invitation selection)
+/// must never render framed — a framed login is clickjacking bait — so they always
+/// <see cref="Deny"/>. The credential-link pages exist to be framed by the product
+/// (see <see cref="Configuration.Link.EmbedAncestors"/>), so they <see cref="Apply"/> the configured
+/// ancestor list — which is empty, and therefore a deny, unless a deployment opts in. Nothing here touches
+/// proxied application responses; the application keeps authority over its own headers.
+/// </remarks>
+public static class FrameEmbedding
+{
+    /// <summary>
+    /// The configuration value naming the proxy's own origin as an allowed ancestor — the common case,
+    /// where the product is served through the proxy itself.
+    /// </summary>
+    public const string SelfAncestor = "self";
+
+    /// <summary>
+    /// Forbids framing the current response outright.
+    /// </summary>
+    /// <param name="context">The current <see cref="HttpContext"/>.</param>
+    public static void Deny(HttpContext context)
+    {
+        context.Response.Headers.XFrameOptions = "DENY";
+        context.Response.Headers.ContentSecurityPolicy = "frame-ancestors 'none'";
+    }
+
+    /// <summary>
+    /// Applies the configured allowed frame ancestors to the current response — a deny when none are
+    /// configured.
+    /// </summary>
+    /// <param name="context">The current <see cref="HttpContext"/>.</param>
+    /// <param name="ancestors">The configured allowed ancestor origins; <c>"self"</c> names the proxy's own origin.</param>
+    public static void Apply(HttpContext context, IEnumerable<string> ancestors)
+    {
+        var sources = ancestors
+            .Where(ancestor => !string.IsNullOrWhiteSpace(ancestor))
+            .Select(ancestor => string.Equals(ancestor, SelfAncestor, StringComparison.OrdinalIgnoreCase) ? "'self'" : ancestor.Trim())
+            .ToArray();
+
+        if (sources.Length == 0)
+        {
+            Deny(context);
+            return;
+        }
+
+        // X-Frame-Options cannot express an origin allow-list and would override the policy in browsers
+        // that honor it over CSP, so only the CSP header is sent when embedding is allowed.
+        context.Response.Headers.ContentSecurityPolicy = $"frame-ancestors {string.Join(' ', sources)}";
+    }
+
+    /// <summary>
+    /// Resolves the configured ancestors to the concrete origins a framed page may post messages to,
+    /// translating <c>"self"</c> to the origin of the current request.
+    /// </summary>
+    /// <param name="context">The current <see cref="HttpContext"/>.</param>
+    /// <param name="ancestors">The configured allowed ancestor origins.</param>
+    /// <returns>The concrete target origins.</returns>
+    public static IReadOnlyList<string> ResolveAncestorOrigins(HttpContext context, IEnumerable<string> ancestors) =>
+        [.. ancestors
+            .Where(ancestor => !string.IsNullOrWhiteSpace(ancestor))
+            .Select(ancestor => string.Equals(ancestor, SelfAncestor, StringComparison.OrdinalIgnoreCase)
+                ? $"{context.Request.Scheme}://{context.Request.Host}"
+                : ancestor.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)];
+}

--- a/Source/AuthProxy/IngressExtensions.cs
+++ b/Source/AuthProxy/IngressExtensions.cs
@@ -259,11 +259,13 @@ public static class IngressExtensions
         })
         .AllowAnonymous();
 
-        // Serves the bundled React login-selection SPA.
+        // Serves the bundled React login-selection SPA. Like every sign-in selection surface it refuses
+        // to render framed — a framed login is clickjacking bait.
         var webRootPath = app.Environment.WebRootPath ?? Path.Combine(app.Environment.ContentRootPath, "wwwroot");
         var indexHtmlPath = Path.Combine(webRootPath, "index.html");
         app.MapGet($"{WellKnownPaths.LoginPage}/{{**path}}", async context =>
         {
+            FrameEmbedding.Deny(context);
             context.Response.ContentType = "text/html";
             await context.Response.SendFileAsync(indexHtmlPath);
         })

--- a/Source/AuthProxy/Invites/InviteMiddleware.cs
+++ b/Source/AuthProxy/Invites/InviteMiddleware.cs
@@ -334,6 +334,9 @@ public class InviteMiddleware(
                     MaxAge = TimeSpan.FromMinutes(15),
                 });
 
+                // A sign-in page rendered inside somebody's frame is clickjacking bait — selection pages
+                // are never embeddable.
+                FrameEmbedding.Deny(context);
                 await errorPageProvider.WriteErrorPageAsync(
                     context,
                     WellKnownPageNames.InvitationSelectProvider,

--- a/Source/AuthProxy/Links/LinkCallbackCompletion.cs
+++ b/Source/AuthProxy/Links/LinkCallbackCompletion.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Cratis.AuthProxy.ErrorPages;
 using Microsoft.AspNetCore.Authentication;
 
 namespace Cratis.AuthProxy.Links;
@@ -45,15 +44,16 @@ public static class LinkCallbackCompletion
         if (result == LinkExchangeResult.Success)
         {
             // The return URL comes from protected authentication state, but it is validated as same-site
-            // relative all the same — the link callback must never become an open redirect.
-            context.Response.Redirect(RelativeRedirect.Resolve(properties.RedirectUri));
+            // relative all the same — the link callback must never become an open redirect. When no target
+            // was recorded (or it did not survive validation) the flow ends on its own completion page
+            // rather than booting the whole application into the link window.
+            var target = RelativeRedirect.Resolve(properties.RedirectUri);
+            context.Response.Redirect(target == RelativeRedirect.ApplicationRoot ? WellKnownPaths.LinkComplete : target);
         }
         else
         {
             GetLogger(context.HttpContext).LinkCallbackFailed(context.Scheme.Name);
-            await context.HttpContext.RequestServices
-                .GetRequiredService<IErrorPageProvider>()
-                .WriteErrorPageAsync(context.HttpContext, WellKnownPageNames.LinkFailed, StatusCodes.Status403Forbidden);
+            await LinkFlowPages.WriteFailed(context.HttpContext);
         }
 
         // Short-circuit before the RemoteAuthenticationHandler signs the ticket into the cookie scheme:

--- a/Source/AuthProxy/Links/LinkFlowPages.cs
+++ b/Source/AuthProxy/Links/LinkFlowPages.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.ErrorPages;
+using Microsoft.Extensions.Options;
+using C = Cratis.AuthProxy.Configuration;
+
+namespace Cratis.AuthProxy.Links;
+
+/// <summary>
+/// Writes the pages of the credential-link flow — provider selection, completion, and failure — with the
+/// embedding posture the flow requires.
+/// </summary>
+/// <remarks>
+/// The link flow is designed to run inside an <c>iframe</c> on the product's page (see
+/// <see cref="C.Link.EmbedAncestors"/>): the framed selection page opens the provider leg in a separate
+/// top-level window — external identity providers refuse to render framed — and the completion and failure
+/// pages report back over a <c>BroadcastChannel</c> so the framed page can tell its parent the outcome.
+/// Every page is served through <see cref="IErrorPageProvider"/> so a deployment can restyle it, and every
+/// page carries the frame-ancestors policy resolved from configuration — none by default.
+/// </remarks>
+public static class LinkFlowPages
+{
+    /// <summary>
+    /// The substitution token in the link pages that receives the JSON array of origins the framed page
+    /// may post the flow's outcome to.
+    /// </summary>
+    public const string EmbedTargetOriginsToken = "__CRATIS_LINK_EMBED_TARGET_ORIGINS__";
+
+    /// <summary>
+    /// Writes the provider-selection page of the link flow.
+    /// </summary>
+    /// <param name="context">The current <see cref="HttpContext"/>.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public static Task WriteSelection(HttpContext context) =>
+        Write(context, WellKnownPageNames.LinkSelectProvider, StatusCodes.Status200OK);
+
+    /// <summary>
+    /// Writes the completion page a successful link ends on.
+    /// </summary>
+    /// <param name="context">The current <see cref="HttpContext"/>.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public static Task WriteComplete(HttpContext context) =>
+        Write(context, WellKnownPageNames.LinkComplete, StatusCodes.Status200OK);
+
+    /// <summary>
+    /// Writes the failure page every unsuccessful link ends on.
+    /// </summary>
+    /// <param name="context">The current <see cref="HttpContext"/>.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public static Task WriteFailed(HttpContext context) =>
+        Write(context, WellKnownPageNames.LinkFailed, StatusCodes.Status403Forbidden);
+
+    static Task Write(HttpContext context, string pageName, int statusCode)
+    {
+        var ancestors = context.RequestServices
+            .GetRequiredService<IOptionsMonitor<C.AuthProxy>>()
+            .CurrentValue.Link?.EmbedAncestors ?? [];
+
+        FrameEmbedding.Apply(context, ancestors);
+
+        var targetOrigins = JsonSerializer.Serialize(FrameEmbedding.ResolveAncestorOrigins(context, ancestors));
+        return context.RequestServices
+            .GetRequiredService<IErrorPageProvider>()
+            .WriteErrorPageAsync(
+                context,
+                pageName,
+                statusCode,
+                new Dictionary<string, string> { [EmbedTargetOriginsToken] = targetOrigins });
+    }
+}

--- a/Source/AuthProxy/Links/LinkMiddleware.cs
+++ b/Source/AuthProxy/Links/LinkMiddleware.cs
@@ -9,7 +9,7 @@ using C = Cratis.AuthProxy.Configuration;
 namespace Cratis.AuthProxy.Links;
 
 /// <summary>
-/// Middleware that initiates the session-preserving credential-linking flow.
+/// Middleware that serves the session-preserving credential-linking flow.
 /// <para>
 /// A request to <c>/.cratis/link/{scheme}?returnUrl=…&amp;token=…</c> triggers an OAuth/OIDC challenge for
 /// the requested provider — but, unlike the login flow, the resulting authentication does <em>not</em>
@@ -18,6 +18,12 @@ namespace Cratis.AuthProxy.Links;
 /// <see cref="AuthenticationServiceCollectionExtensions"/> <c>OnTicketReceived</c> and
 /// <see cref="ILinkSubjectExchanger"/>). The link mode marker and the one-time link token travel through
 /// the challenge's <see cref="AuthenticationProperties"/> so the callback can recognize the flow.
+/// </para>
+/// <para>
+/// The bare <c>/.cratis/link?token=…</c> path serves the flow's embeddable provider-selection page, and
+/// <c>/.cratis/link/complete</c> the completion page a successful link ends on — see
+/// <see cref="LinkFlowPages"/> for how the pages, the embedding product, and the provider window talk to
+/// each other.
 /// </para>
 /// <para>
 /// Linking only makes sense for an already signed-in user, so an unauthenticated request is rejected
@@ -43,6 +49,10 @@ public class LinkMiddleware(
     /// </summary>
     public const string LinkTokenPropertyKey = "Cratis.AuthProxy.LinkToken";
 
+    const string CompleteSegment = "complete";
+
+    static readonly HashSet<string> _framedDestinations = new(StringComparer.Ordinal) { "iframe", "frame", "embed", "object" };
+
     /// <inheritdoc cref="IMiddleware.InvokeAsync"/>
     public async Task InvokeAsync(HttpContext context)
     {
@@ -52,10 +62,20 @@ public class LinkMiddleware(
             return;
         }
 
-        var scheme = remaining.Value?.TrimStart('/') ?? string.Empty;
-        if (string.IsNullOrWhiteSpace(scheme) || !SchemeExists(scheme))
+        var segment = remaining.Value?.Trim('/') ?? string.Empty;
+
+        // The completion page ends the provider window: it broadcasts the outcome to the embedding
+        // selection page and closes. It carries no state and grants nothing, so whoever the callback
+        // redirects here simply gets the page.
+        if (string.Equals(segment, CompleteSegment, StringComparison.OrdinalIgnoreCase))
         {
-            logger.LinkProviderNotConfigured(scheme);
+            await LinkFlowPages.WriteComplete(context);
+            return;
+        }
+
+        if (segment.Length > 0 && !SchemeExists(segment))
+        {
+            logger.LinkProviderNotConfigured(segment);
             context.Response.StatusCode = StatusCodes.Status404NotFound;
             return;
         }
@@ -75,6 +95,17 @@ public class LinkMiddleware(
             return;
         }
 
+        // The bare link path is the flow's embeddable front door: the provider-selection page, which opens
+        // the chosen provider's challenge in its own top-level window. A *framed* navigation to a specific
+        // provider gets the same page instead of a challenge — the challenge redirects to the external
+        // identity provider, whose pages refuse to render inside a frame, so honoring it would leave the
+        // frame dead. Serving the selection page keeps the provider leg top-level by construction.
+        if (segment.Length == 0 || IsFramedNavigation(context.Request))
+        {
+            await LinkFlowPages.WriteSelection(context);
+            return;
+        }
+
         var properties = new AuthenticationProperties
         {
             RedirectUri = ResolveReturnUrl(context.Request.Query["returnUrl"].FirstOrDefault()),
@@ -82,19 +113,41 @@ public class LinkMiddleware(
         properties.Items[LinkModePropertyKey] = "true";
         properties.Items[LinkTokenPropertyKey] = token;
 
-        logger.InitiatingLink(scheme);
-        await context.ChallengeAsync(scheme, properties);
+        logger.InitiatingLink(segment);
+        await context.ChallengeAsync(segment, properties);
     }
 
     /// <summary>
-    /// Resolves the return URL echoed back to the browser once the link completes.
+    /// Resolves the return URL echoed back to the browser once the link completes — the flow's own
+    /// completion page unless the caller asked for somewhere else.
     /// </summary>
     /// <param name="returnUrl">The caller-supplied return URL.</param>
-    /// <returns>The requested target when it is same-site relative; otherwise the application root.</returns>
+    /// <returns>The requested target when it is same-site relative; otherwise the completion page.</returns>
     /// <remarks>
     /// See <see cref="RelativeRedirect"/> for why a single leading slash is not the whole test.
     /// </remarks>
-    static string ResolveReturnUrl(string? returnUrl) => RelativeRedirect.Resolve(returnUrl);
+    static string ResolveReturnUrl(string? returnUrl)
+    {
+        if (string.IsNullOrWhiteSpace(returnUrl))
+        {
+            return WellKnownPaths.LinkComplete;
+        }
+
+        var resolved = RelativeRedirect.Resolve(returnUrl);
+        return resolved == RelativeRedirect.ApplicationRoot ? WellKnownPaths.LinkComplete : resolved;
+    }
+
+    /// <summary>
+    /// Determines whether the request is a navigation inside a frame, going by the browser-set
+    /// <c>Sec-Fetch-Dest</c> fetch metadata header.
+    /// </summary>
+    /// <param name="request">The current <see cref="HttpRequest"/>.</param>
+    /// <returns><see langword="true"/> when the navigation targets a frame; otherwise <see langword="false"/>.</returns>
+    static bool IsFramedNavigation(HttpRequest request)
+    {
+        var destination = request.Headers["Sec-Fetch-Dest"].FirstOrDefault();
+        return destination is not null && _framedDestinations.Contains(destination);
+    }
 
     bool SchemeExists(string scheme)
     {

--- a/Source/AuthProxy/Pages/link-complete.html
+++ b/Source/AuthProxy/Pages/link-complete.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sign-In Method Added</title>
+    <style>
+        body { font-family: system-ui, sans-serif; display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; background: #f5f5f5; }
+        .card { background: #fff; border-radius: 8px; box-shadow: 0 2px 8px rgba(0,0,0,.12); padding: 2.5rem 3rem; text-align: center; max-width: 480px; }
+        h1 { font-size: 1.5rem; font-weight: 700; margin: 0 0 .75rem; color: #333; }
+        p  { color: #666; margin: 0; }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <h1>Sign-In Method Added</h1>
+        <p>The additional sign-in was added to your account. You can close this window.</p>
+    </div>
+    <script>
+        (function () {
+            // Tell the selection page — waiting in the product's iframe — that the flow completed, then
+            // get out of the way. window.close() only succeeds for script-opened windows; when the flow
+            // ran top-level the message above stays on screen instead.
+            if ('BroadcastChannel' in window) {
+                new BroadcastChannel('cratis.credential-link').postMessage({ type: 'cratis:credential-link-complete' });
+            }
+
+            window.close();
+        }());
+    </script>
+</body>
+</html>

--- a/Source/AuthProxy/Pages/link-failed.html
+++ b/Source/AuthProxy/Pages/link-failed.html
@@ -9,7 +9,8 @@
         .card { background: #fff; border-radius: 8px; box-shadow: 0 2px 8px rgba(0,0,0,.12); padding: 2.5rem 3rem; text-align: center; max-width: 480px; }
         h1 { font-size: 1.5rem; font-weight: 700; margin: 0 0 .75rem; color: #333; }
         p  { color: #666; margin: 0 0 1rem; }
-        p:last-child { margin: 0; }
+        .close-btn { display: inline-block; padding: .6rem 1.5rem; border: none; border-radius: 6px; background: #0078d4; color: #fff; font-size: .95rem; font-weight: 600; cursor: pointer; transition: background .15s; }
+        .close-btn:hover { background: #005a9e; }
     </style>
 </head>
 <body>
@@ -17,6 +18,17 @@
         <h1>Link Not Completed</h1>
         <p>The additional sign-in was not added to your account.</p>
         <p>You are still signed in as before. Close this window and try again, or contact your administrator if it keeps happening.</p>
+        <button type="button" class="close-btn" onclick="window.close()">Close</button>
     </div>
+    <script>
+        (function () {
+            // Tell the selection page — waiting in the product's iframe — that the attempt is over, so it
+            // can offer a retry. The window stays open for the person to read; the Close button works for
+            // script-opened windows and is a no-op when the flow ran top-level.
+            if ('BroadcastChannel' in window) {
+                new BroadcastChannel('cratis.credential-link').postMessage({ type: 'cratis:credential-link-failed' });
+            }
+        }());
+    </script>
 </body>
 </html>

--- a/Source/AuthProxy/Pages/link-select-provider.html
+++ b/Source/AuthProxy/Pages/link-select-provider.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Add a Sign-In Method</title>
+    <style>
+        body { font-family: system-ui, sans-serif; display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; background: #f5f5f5; }
+        .card { background: #fff; border-radius: 8px; box-shadow: 0 2px 8px rgba(0,0,0,.12); padding: 2.5rem 3rem; text-align: center; max-width: 480px; width: 100%; }
+        h1 { font-size: 1.5rem; font-weight: 700; margin: 0 0 .75rem; color: #333; }
+        p  { color: #666; margin: 0 0 1.5rem; }
+        .providers { display: flex; flex-direction: column; gap: .75rem; }
+        .provider-btn { display: block; width: 100%; box-sizing: border-box; padding: .75rem 1.5rem; border: none; border-radius: 6px; background: #0078d4; color: #fff; text-decoration: none; font-size: 1rem; font-weight: 600; cursor: pointer; transition: background .15s; }
+        .provider-btn:hover { background: #005a9e; }
+        .error { color: #c00; font-size: .9rem; margin-top: 1rem; }
+        .notice { background: #fdf3e7; border: 1px solid #f0c893; border-radius: 6px; color: #8a5a00; font-size: .9rem; padding: .75rem 1rem; margin: 0 0 1.25rem; }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <h1>Add a Sign-In Method</h1>
+        <p id="failed" class="notice" style="display:none">The sign-in was not added. Please try again.</p>
+        <p id="intro">Choose the provider you want to add to your account:</p>
+        <div id="providers" class="providers"></div>
+        <p id="waiting" style="display:none">Finish adding the sign-in in the window that just opened.</p>
+        <p id="done" style="display:none">The sign-in method was added. You can close this window.</p>
+        <p id="error" class="error" style="display:none">Unable to load the available providers. Please refresh and try again.</p>
+        <p id="blocked" class="error" style="display:none">Your browser blocked the sign-in window. Allow pop-ups for this site and try again.</p>
+    </div>
+    <script>
+        (function () {
+            // The provider leg must run in its own top-level window: external identity providers refuse to
+            // render framed, so this page — designed to live in the product's iframe — opens the challenge
+            // with window.open and hears the outcome back over a same-origin BroadcastChannel. The parent
+            // is only ever notified across the origins the proxy resolved from its embedding configuration.
+            var completeType = 'cratis:credential-link-complete';
+            var failedType = 'cratis:credential-link-failed';
+            var targetOrigins = __CRATIS_LINK_EMBED_TARGET_ORIGINS__;
+
+            var token = new URLSearchParams(window.location.search).get('token');
+            var providersEl = document.getElementById('providers');
+
+            function show(states) {
+                ['failed', 'intro', 'waiting', 'done', 'error', 'blocked'].forEach(function (id) {
+                    document.getElementById(id).style.display = states.indexOf(id) >= 0 ? '' : 'none';
+                });
+                providersEl.style.display = states.indexOf('providers') >= 0 ? '' : 'none';
+            }
+
+            function notifyParent(type) {
+                if (window.parent === window) {
+                    return;
+                }
+
+                targetOrigins.forEach(function (origin) {
+                    window.parent.postMessage({ type: type }, origin);
+                });
+            }
+
+            if (!token) {
+                show(['error']);
+                return;
+            }
+
+            var channel = 'BroadcastChannel' in window ? new BroadcastChannel('cratis.credential-link') : null;
+            if (channel) {
+                channel.onmessage = function (event) {
+                    if (!event.data) {
+                        return;
+                    }
+
+                    if (event.data.type === completeType) {
+                        show(['done']);
+                        notifyParent(completeType);
+                    } else if (event.data.type === failedType) {
+                        show(['failed', 'intro', 'providers']);
+                        notifyParent(failedType);
+                    }
+                };
+            }
+
+            function openProviderWindow(linkUrl) {
+                var opened = window.open(linkUrl, 'cratis-credential-link', 'width=520,height=680');
+                if (!opened) {
+                    show(['blocked', 'intro', 'providers']);
+                    return;
+                }
+
+                show(['waiting']);
+            }
+
+            fetch('/.cratis/providers', { headers: { Accept: 'application/json' } })
+                .then(function (response) {
+                    if (!response.ok) {
+                        throw new Error('HTTP ' + response.status);
+                    }
+
+                    return response.json();
+                })
+                .then(function (providers) {
+                    if (!providers || providers.length === 0) {
+                        show(['error']);
+                        return;
+                    }
+
+                    providers.forEach(function (provider) {
+                        var button = document.createElement('button');
+                        button.type = 'button';
+                        button.className = 'provider-btn';
+                        button.textContent = 'Add ' + provider.name;
+                        button.addEventListener('click', function () {
+                            var linkUrl = provider.loginUrl.replace('/.cratis/login/', '/.cratis/link/')
+                                + '?token=' + encodeURIComponent(token);
+                            openProviderWindow(linkUrl);
+                        });
+                        providersEl.appendChild(button);
+                    });
+
+                    show(['intro', 'providers']);
+                })
+                .catch(function () {
+                    show(['error']);
+                });
+        }());
+    </script>
+</body>
+</html>

--- a/Source/AuthProxy/WellKnownPageNames.cs
+++ b/Source/AuthProxy/WellKnownPageNames.cs
@@ -97,7 +97,9 @@ public static class WellKnownPageNames
 
     /// <summary>
     /// The page returned when a credential-link callback completes without the application having recorded
-    /// the link — the exchange could not be performed, or the application refused it.
+    /// the link — the exchange could not be performed, or the application refused it — and when the
+    /// provider round-trip of a link challenge fails. It broadcasts the failure on the link flow's
+    /// <c>BroadcastChannel</c> so an embedding selection page can offer a retry.
     /// </summary>
     /// <remarks>
     /// Deliberately generic: the same page answers every cause, so a caller cannot tell "the provider
@@ -105,4 +107,19 @@ public static class WellKnownPageNames
     /// is logged for the operator instead.
     /// </remarks>
     public const string LinkFailed = "link-failed.html";
+
+    /// <summary>
+    /// The provider-selection page of the credential-link flow, served at <c>/.cratis/link</c> for the
+    /// product to embed in a modal <c>iframe</c>. It lists the configured providers, opens the chosen
+    /// provider's link challenge in a separate top-level window — external identity providers refuse to
+    /// render framed — and reports the outcome to its parent once the flow's <c>BroadcastChannel</c>
+    /// delivers it.
+    /// </summary>
+    public const string LinkSelectProvider = "link-select-provider.html";
+
+    /// <summary>
+    /// The page a completed credential link ends on, served at <c>/.cratis/link/complete</c>. It
+    /// broadcasts the completion on the link flow's <c>BroadcastChannel</c> and closes its window.
+    /// </summary>
+    public const string LinkComplete = "link-complete.html";
 }

--- a/Source/AuthProxy/WellKnownPaths.cs
+++ b/Source/AuthProxy/WellKnownPaths.cs
@@ -74,8 +74,16 @@ public static class WellKnownPaths
     /// Append the scheme name to complete the URL (e.g. <c>/.cratis/link/github</c>).
     /// Unlike <see cref="LoginPrefix"/>, the link flow authenticates a second provider identity for the
     /// already signed-in user <em>without</em> replacing the primary authentication cookie/session.
+    /// The bare path (no scheme) serves the flow's embeddable provider-selection page.
     /// </summary>
     public const string Link = "/.cratis/link";
+
+    /// <summary>
+    /// The well-known path a completed credential link lands on. It serves the flow's completion page,
+    /// which broadcasts the outcome to the embedding selection page and closes its window. The segment is
+    /// reserved — a provider scheme can never be named <c>complete</c>.
+    /// </summary>
+    public const string LinkComplete = "/.cratis/link/complete";
 
     /// <summary>
     /// The well-known path prefix that triggers invite-token handling.

--- a/Source/Web/src/App.tsx
+++ b/Source/Web/src/App.tsx
@@ -1,6 +1,4 @@
 import { useEffect, useState } from 'react';
-import { Card } from 'primereact/card';
-import { ProgressSpinner } from 'primereact/progressspinner';
 import { ProviderButton } from './components/ProviderButton';
 import type { OidcProvider } from './types';
 
@@ -13,7 +11,7 @@ const reasonMessages: Record<string, string> = {
 export default function App() {
     const [providers, setProviders] = useState<OidcProvider[]>([]);
     const [loading, setLoading] = useState(true);
-    const [error, setError] = useState<string | null>(null);
+    const [error, setError] = useState(false);
 
     const query = new URLSearchParams(window.location.search);
     const returnUrl = query.get('returnUrl') ?? '/';
@@ -22,48 +20,37 @@ export default function App() {
 
     useEffect(() => {
         fetch('/.cratis/providers')
-            .then(r => {
-                if (!r.ok) throw new Error(`HTTP ${r.status}`);
-                return r.json() as Promise<OidcProvider[]>;
+            .then(response => {
+                if (!response.ok) throw new Error(`HTTP ${response.status}`);
+                return response.json() as Promise<OidcProvider[]>;
             })
             .then(data => {
                 setProviders(data);
                 setLoading(false);
             })
-            .catch(err => {
-                setError(String(err));
+            .catch(() => {
+                setError(true);
                 setLoading(false);
             });
     }, []);
 
+    const showError = error || (!loading && providers.length === 0);
+
     return (
-        <div className="flex min-h-screen items-center justify-center">
-            <Card
-                title="Sign In"
-                className="w-full max-w-sm shadow-lg"
-            >
-                {reasonMessage && (
-                    <p className="text-amber-600 text-sm text-center mb-4">{reasonMessage}</p>
-                )}
-                {loading && (
-                    <div className="flex justify-center py-4">
-                        <ProgressSpinner />
-                    </div>
-                )}
-                {error && (
-                    <p className="text-red-400 text-sm text-center">{error}</p>
-                )}
-                {!loading && !error && providers.length === 0 && (
-                    <p className="text-center text-sm opacity-70">No providers configured.</p>
-                )}
-                {!loading && !error && providers.length > 0 && (
-                    <div className="flex flex-col gap-3">
-                        {providers.map(p => (
-                            <ProviderButton key={p.name} provider={p} returnUrl={returnUrl} />
-                        ))}
-                    </div>
-                )}
-            </Card>
+        <div className="card">
+            <h1>Sign In</h1>
+            {reasonMessage && <p className="reason">{reasonMessage}</p>}
+            {!loading && !showError && <p>Choose how you want to sign in:</p>}
+            {!loading && !showError && (
+                <div className="providers">
+                    {providers.map(provider => (
+                        <ProviderButton key={provider.name} provider={provider} returnUrl={returnUrl} />
+                    ))}
+                </div>
+            )}
+            {showError && (
+                <p className="error">Unable to load sign-in options. Please refresh the page.</p>
+            )}
         </div>
     );
 }

--- a/Source/Web/src/components/ProviderButton.tsx
+++ b/Source/Web/src/components/ProviderButton.tsx
@@ -1,4 +1,3 @@
-import { Button } from 'primereact/button';
 import type { OidcProvider } from '../types';
 
 interface ProviderButtonProps {
@@ -6,27 +5,14 @@ interface ProviderButtonProps {
     returnUrl: string;
 }
 
-const providerIconClass: Record<string, string> = {
-    Microsoft: 'pi pi-microsoft',
-    Google: 'pi pi-google',
-    GitHub: 'pi pi-github',
-    Apple: 'pi pi-apple',
-    Custom: 'pi pi-sign-in',
-};
-
 export const ProviderButton = ({ provider, returnUrl }: ProviderButtonProps) => {
-    const iconClass = providerIconClass[provider.type] ?? providerIconClass.Custom;
     const loginUrl = returnUrl
         ? `${provider.loginUrl}?returnUrl=${encodeURIComponent(returnUrl)}`
         : provider.loginUrl;
 
     return (
-        <a href={loginUrl} className="block w-full">
-            <Button
-                label={`Sign in with ${provider.name}`}
-                icon={iconClass}
-                className="w-full p-button-outlined"
-            />
+        <a href={loginUrl} className="provider-btn">
+            Sign in with {provider.name}
         </a>
     );
 };

--- a/Source/Web/src/index.css
+++ b/Source/Web/src/index.css
@@ -1,8 +1,75 @@
-@import "tailwindcss";
+/*
+ * The one styling source for the selection SPA, mirroring the static selection pages
+ * (Pages/select-provider.html and friends) so every AuthProxy-served selection surface
+ * shares one design.
+ */
 
 body {
+    font-family: system-ui, sans-serif;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
     margin: 0;
-    background-color: var(--surface-ground);
-    color: var(--text-color);
-    font-family: var(--font-family);
+    background: #f5f5f5;
+}
+
+.card {
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, .12);
+    padding: 2.5rem 3rem;
+    text-align: center;
+    max-width: 480px;
+    width: 100%;
+}
+
+.card h1 {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin: 0 0 .75rem;
+    color: #333;
+}
+
+.card p {
+    color: #666;
+    margin: 0 0 1.5rem;
+}
+
+.providers {
+    display: flex;
+    flex-direction: column;
+    gap: .75rem;
+}
+
+.provider-btn {
+    display: block;
+    padding: .75rem 1.5rem;
+    border-radius: 6px;
+    background: #0078d4;
+    color: #fff;
+    text-decoration: none;
+    font-size: 1rem;
+    font-weight: 600;
+    transition: background .15s;
+}
+
+.provider-btn:hover {
+    background: #005a9e;
+}
+
+.error {
+    color: #c00;
+    font-size: .9rem;
+    margin-top: 1rem;
+}
+
+.reason {
+    background: #fdf3e7;
+    border: 1px solid #f0c893;
+    border-radius: 6px;
+    color: #8a5a00;
+    font-size: .9rem;
+    padding: .75rem 1rem;
+    margin: 0 0 1.25rem;
 }

--- a/Source/Web/src/main.tsx
+++ b/Source/Web/src/main.tsx
@@ -1,7 +1,5 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import 'primereact/resources/themes/lara-dark-blue/theme.css';
-import 'primeicons/primeicons.css';
 import './index.css';
 import App from './App';
 


### PR DESCRIPTION
# Summary

Every OIDC handshake (Microsoft, Google) failed with "Correlation failed" and looped back to provider selection, because the handler's default `form_post` response mode returns the authorization code in a cross-site POST — which browsers never attach the `SameSite=Lax` correlation cookie to. This surfaced hardest in the credential-link flow (Cratis/StudioIssues#104), where the failure additionally landed on the sign-in selection page, offering to replace the very session the link was preserving. The link flow is now also embeddable in the product's modal iframe, with the provider leg in its own top-level window.

## Added

- `ResponseMode` setting per OIDC provider (`Query` default, `FormPost` for providers that mandate it, such as Apple) — choosing `FormPost` switches that provider's handshake cookies to `SameSite=None; Secure`
- Embeddable credential-link flow: `/.cratis/link` serves a provider-selection page for the product to frame, `/.cratis/link/complete` ends a successful link, and the pages report the outcome over a `BroadcastChannel` and an origin-checked `postMessage` to the embedding page
- `Link:EmbedAncestors` setting naming the origins allowed to frame the link pages (`self` for the proxy's own origin); when empty — the default — the link pages send `frame-ancestors 'none'` and `X-Frame-Options: DENY`
- `link-select-provider.html` and `link-complete.html` well-known pages, deployment-replaceable like every other page

## Changed

- OIDC providers request the code flow's standard `query` response mode, so the provider callback is a top-level GET the `SameSite=Lax` handshake cookies accompany (Cratis/StudioIssues#104)
- A credential link with no (or an invalid) `returnUrl` ends on the flow's own completion page instead of the application root
- Sign-in selection pages (provider selection, its SPA, invitation selection) always refuse framing
- The selection SPA served at `/.cratis/select-provider` now matches the static selection pages' design instead of its own dark theme (Cratis/StudioIssues#104)
- A challenge navigation identified as framed (`Sec-Fetch-Dest`) is answered with the link selection page instead of a redirect the external identity provider would refuse to render framed

## Fixed

- OIDC sign-ins and credential links no longer fail with "Correlation failed" and loop through provider selection (Cratis/StudioIssues#104)
- A failed link challenge ends on the link-failed page instead of the sign-in selection page, which offered full sign-ins that would replace the preserved session (Cratis/StudioIssues#104)

🤖 Generated with [Claude Code](https://claude.com/claude-code)