### PR TITLE
Accept Microsoft multi-tenant sign-ins and attribute providers by scheme

### DIFF
--- a/Source/AuthProxy.Specs/Authentication/for_AadMultiTenantIssuer/given/a_token_carrying_a_tenant.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_AadMultiTenantIssuer/given/a_token_carrying_a_tenant.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Cratis.AuthProxy.Authentication.for_AadMultiTenantIssuer.given;
+
+public class a_token_carrying_a_tenant : Specification
+{
+    protected const string TenantId = "9188040d-6c67-4c5b-b112-36a304b66dad";
+
+    protected TokenValidationParameters _parameters = new();
+
+    protected static JsonWebToken TokenWithTenant(string tenantId) =>
+        new("{\"alg\":\"none\"}", $"{{\"tid\":\"{tenantId}\"}}");
+
+    protected static JsonWebToken TokenWithoutTenant() =>
+        new("{\"alg\":\"none\"}", "{}");
+}

--- a/Source/AuthProxy.Specs/Authentication/for_AadMultiTenantIssuer/when_checking_for_a_multi_tenant_authority.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_AadMultiTenantIssuer/when_checking_for_a_multi_tenant_authority.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Authentication.for_AadMultiTenantIssuer;
+
+public class when_checking_for_a_multi_tenant_authority : Specification
+{
+    [Fact] void should_recognize_common() => AadMultiTenantIssuer.IsMultiTenantAuthority("https://login.microsoftonline.com/common/v2.0").ShouldBeTrue();
+    [Fact] void should_recognize_organizations() => AadMultiTenantIssuer.IsMultiTenantAuthority("https://login.microsoftonline.com/organizations/v2.0").ShouldBeTrue();
+    [Fact] void should_recognize_consumers() => AadMultiTenantIssuer.IsMultiTenantAuthority("https://login.microsoftonline.com/consumers/v2.0").ShouldBeTrue();
+    [Fact] void should_not_treat_a_single_tenant_authority_as_multi_tenant() => AadMultiTenantIssuer.IsMultiTenantAuthority("https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0").ShouldBeFalse();
+    [Fact] void should_not_treat_another_host_as_multi_tenant() => AadMultiTenantIssuer.IsMultiTenantAuthority("https://accounts.google.com").ShouldBeFalse();
+    [Fact] void should_not_treat_a_missing_authority_as_multi_tenant() => AadMultiTenantIssuer.IsMultiTenantAuthority(null).ShouldBeFalse();
+}

--- a/Source/AuthProxy.Specs/Authentication/for_AadMultiTenantIssuer/when_validating_an_issuer/and_it_is_the_v1_issuer_for_the_tokens_tenant.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_AadMultiTenantIssuer/when_validating_an_issuer/and_it_is_the_v1_issuer_for_the_tokens_tenant.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Authentication.for_AadMultiTenantIssuer.given;
+
+namespace Cratis.AuthProxy.Authentication.for_AadMultiTenantIssuer.when_validating_an_issuer;
+
+public class and_it_is_the_v1_issuer_for_the_tokens_tenant : a_token_carrying_a_tenant
+{
+    const string Issuer = $"https://sts.windows.net/{TenantId}/";
+    string _result;
+
+    void Because() => _result = AadMultiTenantIssuer.Validate(Issuer, TokenWithTenant(TenantId), _parameters);
+
+    [Fact] void should_accept_the_issuer() => _result.ShouldEqual(Issuer);
+}

--- a/Source/AuthProxy.Specs/Authentication/for_AadMultiTenantIssuer/when_validating_an_issuer/and_it_is_the_v2_issuer_for_the_tokens_tenant.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_AadMultiTenantIssuer/when_validating_an_issuer/and_it_is_the_v2_issuer_for_the_tokens_tenant.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Authentication.for_AadMultiTenantIssuer.given;
+
+namespace Cratis.AuthProxy.Authentication.for_AadMultiTenantIssuer.when_validating_an_issuer;
+
+public class and_it_is_the_v2_issuer_for_the_tokens_tenant : a_token_carrying_a_tenant
+{
+    const string Issuer = $"https://login.microsoftonline.com/{TenantId}/v2.0";
+    string _result;
+
+    void Because() => _result = AadMultiTenantIssuer.Validate(Issuer, TokenWithTenant(TenantId), _parameters);
+
+    [Fact] void should_accept_the_issuer() => _result.ShouldEqual(Issuer);
+}

--- a/Source/AuthProxy.Specs/Authentication/for_AadMultiTenantIssuer/when_validating_an_issuer/and_it_names_a_different_tenant.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_AadMultiTenantIssuer/when_validating_an_issuer/and_it_names_a_different_tenant.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Authentication.for_AadMultiTenantIssuer.given;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Cratis.AuthProxy.Authentication.for_AadMultiTenantIssuer.when_validating_an_issuer;
+
+public class and_it_names_a_different_tenant : a_token_carrying_a_tenant
+{
+    Exception _result;
+
+    void Because() => _result = Catch.Exception(() =>
+        AadMultiTenantIssuer.Validate(
+            "https://login.microsoftonline.com/11111111-2222-3333-4444-555555555555/v2.0",
+            TokenWithTenant(TenantId),
+            _parameters));
+
+    [Fact] void should_reject_the_issuer() => _result.ShouldBeOfExactType<SecurityTokenInvalidIssuerException>();
+}

--- a/Source/AuthProxy.Specs/Authentication/for_AadMultiTenantIssuer/when_validating_an_issuer/and_the_token_carries_no_tenant.cs
+++ b/Source/AuthProxy.Specs/Authentication/for_AadMultiTenantIssuer/when_validating_an_issuer/and_the_token_carries_no_tenant.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Authentication.for_AadMultiTenantIssuer.given;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Cratis.AuthProxy.Authentication.for_AadMultiTenantIssuer.when_validating_an_issuer;
+
+public class and_the_token_carries_no_tenant : a_token_carrying_a_tenant
+{
+    Exception _result;
+
+    void Because() => _result = Catch.Exception(() =>
+        AadMultiTenantIssuer.Validate(
+            $"https://login.microsoftonline.com/{TenantId}/v2.0",
+            TokenWithoutTenant(),
+            _parameters));
+
+    [Fact] void should_reject_the_issuer() => _result.ShouldBeOfExactType<SecurityTokenInvalidIssuerException>();
+}

--- a/Source/AuthProxy.Specs/Links/for_LinkCallbackCompletion/given/a_link_callback_context.cs
+++ b/Source/AuthProxy.Specs/Links/for_LinkCallbackCompletion/given/a_link_callback_context.cs
@@ -37,7 +37,7 @@ public class a_link_callback_context : Specification
 
         _exchanger = Substitute.For<ILinkSubjectExchanger>();
         _exchanger
-            .Exchange(Arg.Any<ClaimsPrincipal>(), Arg.Any<AuthenticationProperties>())
+            .Exchange(Arg.Any<ClaimsPrincipal>(), Arg.Any<AuthenticationProperties>(), Arg.Any<string?>())
             .Returns(ExchangeResult);
         _signInNotifier = Substitute.For<ISignInNotifier>();
 

--- a/Source/AuthProxy.Specs/Links/for_LinkCallbackCompletion/when_the_exchange_succeeds/and_a_return_url_was_recorded.cs
+++ b/Source/AuthProxy.Specs/Links/for_LinkCallbackCompletion/when_the_exchange_succeeds/and_a_return_url_was_recorded.cs
@@ -18,5 +18,5 @@ public class and_a_return_url_was_recorded : a_link_callback_context
     [Fact] void should_not_write_a_body() => ResponseBody().ShouldEqual(string.Empty);
     [Fact] void should_handle_the_response() => _ticketContext.Result.Handled.ShouldBeTrue();
     [Fact] async Task should_exchange_the_subject_with_the_application() =>
-        await _exchanger.Received(1).Exchange(Arg.Any<ClaimsPrincipal>(), _properties);
+        await _exchanger.Received(1).Exchange(Arg.Any<ClaimsPrincipal>(), _properties, Arg.Any<string?>());
 }

--- a/Source/AuthProxy.Specs/Links/for_LinkSubjectExchanger/when_the_scheme_names_the_provider.cs
+++ b/Source/AuthProxy.Specs/Links/for_LinkSubjectExchanger/when_the_scheme_names_the_provider.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Links.for_LinkSubjectExchanger.given;
+
+namespace Cratis.AuthProxy.Links.for_LinkSubjectExchanger;
+
+/// <summary>
+/// Some providers hand back a principal that names no provider at all — no issuer claim, and an identity
+/// whose authentication type is the meaningless "AuthenticationTypes.Federation". The scheme that was
+/// challenged names the provider authoritatively, so the exchange attributes the link to the configured
+/// provider behind that scheme.
+/// </summary>
+public class when_the_scheme_names_the_provider : a_link_subject_exchanger
+{
+    LinkExchangeResult _result;
+
+    protected override C.AuthProxy CreateConfig()
+    {
+        var config = base.CreateConfig();
+        config.Authentication.OidcProviders.Add(new C.OidcProvider { Name = "Google", Authority = "https://accounts.google.com" });
+        return config;
+    }
+
+    protected override ClaimsPrincipal CreatePrincipal() => new(new ClaimsIdentity(
+        [new Claim("sub", "google-subject-456")],
+        "AuthenticationTypes.Federation"));
+
+    async Task Because() => _result = await _exchanger.Exchange(_principal, _properties, "google");
+
+    [Fact] void should_succeed() => _result.ShouldEqual(LinkExchangeResult.Success);
+    [Fact] void should_attribute_the_configured_provider_behind_the_scheme() => _handler.LastRequestBody!.ShouldContain("Google");
+    [Fact] void should_not_leak_the_authentication_type() => _handler.LastRequestBody!.ShouldNotContain("AuthenticationTypes.Federation");
+}

--- a/Source/AuthProxy.Specs/SignIns/for_SignInNotifier/when_the_scheme_names_the_provider.cs
+++ b/Source/AuthProxy.Specs/SignIns/for_SignInNotifier/when_the_scheme_names_the_provider.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.SignIns.for_SignInNotifier.given;
+
+namespace Cratis.AuthProxy.SignIns.for_SignInNotifier;
+
+/// <summary>
+/// Some providers hand back a principal that names no provider at all — no issuer claim, and an identity
+/// whose authentication type is the meaningless "AuthenticationTypes.Federation". The scheme that was
+/// challenged names the provider authoritatively, so the notification attributes the sign-in to the
+/// configured provider behind that scheme.
+/// </summary>
+public class when_the_scheme_names_the_provider : a_sign_in_notifier
+{
+    SignInNotificationResult _result;
+
+    protected override C.AuthProxy CreateConfig()
+    {
+        var config = base.CreateConfig();
+        config.Authentication.OidcProviders.Add(new C.OidcProvider { Name = "Google", Authority = "https://accounts.google.com" });
+        return config;
+    }
+
+    protected override ClaimsPrincipal CreatePrincipal() => new(new ClaimsIdentity(
+        [new Claim("sub", "google-subject-456")],
+        "AuthenticationTypes.Federation"));
+
+    async Task Because() => _result = await _notifier.Notify(_httpContext, _principal, "google");
+
+    [Fact] void should_succeed() => _result.ShouldEqual(SignInNotificationResult.Notified);
+    [Fact] void should_attribute_the_configured_provider_behind_the_scheme() => _handler.LastRequestBody!.ShouldContain("Google");
+    [Fact] void should_not_leak_the_authentication_type() => _handler.LastRequestBody!.ShouldNotContain("AuthenticationTypes.Federation");
+}

--- a/Source/AuthProxy/Authentication/AadMultiTenantIssuer.cs
+++ b/Source/AuthProxy/Authentication/AadMultiTenantIssuer.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Cratis.AuthProxy.Authentication;
+
+/// <summary>
+/// Validates token issuers for the multi-tenant Microsoft Entra authorities (<c>common</c>,
+/// <c>organizations</c>, <c>consumers</c>).
+/// </summary>
+/// <remarks>
+/// A multi-tenant authority's discovery metadata declares its issuer as the literal template
+/// <c>https://login.microsoftonline.com/{tenantid}/v2.0</c>, while every issued token carries the signing
+/// tenant's real issuer — so the default comparison rejects every token (IDX10205), for organizational and
+/// personal accounts alike. The fix Microsoft documents is a tenant-aware validator: substitute the token's
+/// own <c>tid</c> claim into the template and require the issuer to match. The tenant is not an open
+/// wildcard — the issuer must be exactly the Microsoft issuer for the tenant that the token itself claims,
+/// with the signing key already validated against Microsoft's metadata before this runs.
+/// </remarks>
+public static class AadMultiTenantIssuer
+{
+    static readonly string[] _multiTenantSegments = ["common", "organizations", "consumers"];
+
+    /// <summary>
+    /// Checks whether an authority is one of the multi-tenant Microsoft Entra authorities that needs
+    /// tenant-aware issuer validation.
+    /// </summary>
+    /// <param name="authority">The configured authority URL.</param>
+    /// <returns><see langword="true"/> when the authority is a multi-tenant Microsoft authority; otherwise <see langword="false"/>.</returns>
+    public static bool IsMultiTenantAuthority(string? authority) =>
+        !string.IsNullOrWhiteSpace(authority)
+        && Uri.TryCreate(authority, UriKind.Absolute, out var uri)
+        && uri.Host.Equals("login.microsoftonline.com", StringComparison.OrdinalIgnoreCase)
+        && _multiTenantSegments.Any(segment =>
+            uri.AbsolutePath.Contains($"/{segment}/", StringComparison.OrdinalIgnoreCase)
+            || uri.AbsolutePath.TrimEnd('/').EndsWith($"/{segment}", StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// Validates that a token's issuer is the Microsoft issuer for the tenant the token itself names in its
+    /// <c>tid</c> claim. Assign to <see cref="TokenValidationParameters.IssuerValidator"/>.
+    /// </summary>
+    /// <param name="issuer">The issuer from the token being validated.</param>
+    /// <param name="token">The token being validated.</param>
+    /// <param name="_">Unused; the parameter is part of the <see cref="IssuerValidator"/> delegate contract.</param>
+    /// <returns>The validated issuer.</returns>
+    /// <exception cref="SecurityTokenInvalidIssuerException">
+    /// Thrown when the token carries no tenant or the issuer is not that tenant's Microsoft issuer. The
+    /// built-in exception type is required here — it is the contract
+    /// <see cref="TokenValidationParameters.IssuerValidator"/> expects for a rejected issuer.
+    /// </exception>
+    public static string Validate(string issuer, SecurityToken token, TokenValidationParameters _)
+    {
+        var tenantId = token is JsonWebToken jsonWebToken && jsonWebToken.TryGetPayloadValue<string>("tid", out var tid)
+            ? tid
+            : null;
+
+        if (!string.IsNullOrWhiteSpace(tenantId)
+            && (issuer.Equals($"https://login.microsoftonline.com/{tenantId}/v2.0", StringComparison.OrdinalIgnoreCase)
+                || issuer.Equals($"https://sts.windows.net/{tenantId}/", StringComparison.OrdinalIgnoreCase)))
+        {
+            return issuer;
+        }
+
+        throw new SecurityTokenInvalidIssuerException(
+            $"Issuer '{issuer}' is not the Microsoft issuer for the tenant the token names ('{tenantId ?? "<none>"}').")
+        {
+            InvalidIssuer = issuer,
+        };
+    }
+}

--- a/Source/AuthProxy/Authentication/AuthenticationServiceCollectionExtensions.cs
+++ b/Source/AuthProxy/Authentication/AuthenticationServiceCollectionExtensions.cs
@@ -196,6 +196,14 @@ public static class AuthenticationServiceCollectionExtensions
                 options.ClientSecret = capturedProvider.ClientSecret;
                 options.ResponseType = "code";
 
+                if (AadMultiTenantIssuer.IsMultiTenantAuthority(capturedProvider.Authority))
+                {
+                    // A multi-tenant Microsoft authority publishes the literal issuer template
+                    // "{tenantid}/v2.0" in its metadata, so the default issuer comparison rejects every
+                    // token. Validate against the tenant the token itself names instead.
+                    options.TokenValidationParameters.IssuerValidator = AadMultiTenantIssuer.Validate;
+                }
+
                 // The handler's default response mode is form_post, which has the provider hand the
                 // authorization code back in a cross-site POST — and browsers do not attach SameSite=Lax
                 // cookies to a cross-site POST, so the callback arrived without its correlation cookie and
@@ -465,7 +473,7 @@ public static class AuthenticationServiceCollectionExtensions
         // proxied request. The notification never throws, so a notification failure can never break the sign-in.
         context.Properties?.Items.TryAdd(AuthenticationSchemeStateKey, context.Scheme.Name);
         var notifier = context.HttpContext.RequestServices.GetRequiredService<ISignInNotifier>();
-        await notifier.Notify(context.HttpContext, context.Principal);
+        await notifier.Notify(context.HttpContext, context.Principal, context.Scheme.Name);
 
         if (context.Properties is not null
             && TenantAuthenticationState.TryResolvePostAuthenticationRedirectUri(

--- a/Source/AuthProxy/Links/ILinkSubjectExchanger.cs
+++ b/Source/AuthProxy/Links/ILinkSubjectExchanger.cs
@@ -18,6 +18,7 @@ public interface ILinkSubjectExchanger
     /// </summary>
     /// <param name="principal">The principal produced by the second provider authentication.</param>
     /// <param name="properties">The round-tripped challenge properties holding the link token.</param>
+    /// <param name="scheme">The authentication scheme that produced the principal, naming the provider that was challenged.</param>
     /// <returns>The <see cref="LinkExchangeResult"/> describing the outcome.</returns>
-    Task<LinkExchangeResult> Exchange(ClaimsPrincipal? principal, AuthenticationProperties properties);
+    Task<LinkExchangeResult> Exchange(ClaimsPrincipal? principal, AuthenticationProperties properties, string? scheme = null);
 }

--- a/Source/AuthProxy/Links/LinkCallbackCompletion.cs
+++ b/Source/AuthProxy/Links/LinkCallbackCompletion.cs
@@ -39,7 +39,7 @@ public static class LinkCallbackCompletion
     public static async Task Complete(TicketReceivedContext context, AuthenticationProperties properties)
     {
         var exchanger = context.HttpContext.RequestServices.GetRequiredService<ILinkSubjectExchanger>();
-        var result = await exchanger.Exchange(context.Principal, properties);
+        var result = await exchanger.Exchange(context.Principal, properties, context.Scheme.Name);
 
         if (result == LinkExchangeResult.Success)
         {

--- a/Source/AuthProxy/Links/LinkSubjectExchanger.cs
+++ b/Source/AuthProxy/Links/LinkSubjectExchanger.cs
@@ -42,7 +42,7 @@ public class LinkSubjectExchanger(
     }
 
     /// <inheritdoc/>
-    public async Task<LinkExchangeResult> Exchange(ClaimsPrincipal? principal, AuthenticationProperties properties)
+    public async Task<LinkExchangeResult> Exchange(ClaimsPrincipal? principal, AuthenticationProperties properties, string? scheme = null)
     {
         var exchangeUrl = config.CurrentValue.Link?.ExchangeUrl;
         if (string.IsNullOrWhiteSpace(exchangeUrl))
@@ -72,7 +72,10 @@ public class LinkSubjectExchanger(
             ?? principal?.FindFirst("id")?.Value
             ?? string.Empty;
 
+        // The scheme names the provider that was actually challenged — authoritative over anything sniffed
+        // from claims, which for some providers bottoms out in the meaningless "AuthenticationTypes.Federation".
         var identityProvider = canonicalResolution.Identity?.ProviderKey
+            ?? OidcProviderScheme.NameFromScheme(config.CurrentValue.Authentication, scheme)
             ?? principal?.FindFirst("iss")?.Value
             ?? principal?.FindFirst("identity_provider")?.Value
             ?? principal?.FindFirst("http://schemas.microsoft.com/accesscontrolservice/2010/07/claims/identityprovider")?.Value

--- a/Source/AuthProxy/OidcProviderScheme.cs
+++ b/Source/AuthProxy/OidcProviderScheme.cs
@@ -20,6 +20,22 @@ public static class OidcProviderScheme
         providerName.ToLowerInvariant().Replace(" ", "-", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
+    /// Resolves the configured provider display name behind an authentication scheme — the reverse of
+    /// <see cref="FromName"/>. This is the authoritative answer to "which provider authenticated here":
+    /// the scheme was chosen when the challenge was issued, unlike anything sniffed from the resulting
+    /// principal's claims.
+    /// </summary>
+    /// <param name="authentication">The authentication configuration holding the providers.</param>
+    /// <param name="scheme">The authentication scheme name.</param>
+    /// <returns>The provider's display name, or <see langword="null"/> when no configured provider matches.</returns>
+    public static string? NameFromScheme(C.Authentication authentication, string? scheme) =>
+        string.IsNullOrWhiteSpace(scheme)
+            ? null
+            : authentication.OidcProviders.Select(provider => provider.Name)
+                .Concat(authentication.OAuthProviders.Select(provider => provider.Name))
+                .FirstOrDefault(name => FromName(name).Equals(scheme, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
     /// Builds the <see cref="OidcProviderInfo"/> for a given <see cref="C.OidcProvider"/>,
     /// computing the login URL based on the scheme name.
     /// </summary>

--- a/Source/AuthProxy/SignIns/ISignInNotifier.cs
+++ b/Source/AuthProxy/SignIns/ISignInNotifier.cs
@@ -18,10 +18,11 @@ public interface ISignInNotifier
     /// </summary>
     /// <param name="context">The provider-callback request, used to derive the client's location and browser.</param>
     /// <param name="principal">The principal established by the identity-provider authentication.</param>
+    /// <param name="scheme">The authentication scheme that produced the principal, naming the provider that was challenged.</param>
     /// <returns>The <see cref="SignInNotificationResult"/> describing the outcome.</returns>
     /// <remarks>
     /// Recording a sign-in must never break the sign-in itself, so an implementation is expected to be fully
     /// resilient — it reports failures through the returned result rather than throwing.
     /// </remarks>
-    Task<SignInNotificationResult> Notify(HttpContext context, ClaimsPrincipal? principal);
+    Task<SignInNotificationResult> Notify(HttpContext context, ClaimsPrincipal? principal, string? scheme = null);
 }

--- a/Source/AuthProxy/SignIns/SignInNotifier.cs
+++ b/Source/AuthProxy/SignIns/SignInNotifier.cs
@@ -45,7 +45,7 @@ public class SignInNotifier(
     }
 
     /// <inheritdoc/>
-    public async Task<SignInNotificationResult> Notify(HttpContext context, ClaimsPrincipal? principal)
+    public async Task<SignInNotificationResult> Notify(HttpContext context, ClaimsPrincipal? principal, string? scheme = null)
     {
         var notifyUrl = config.CurrentValue.SignIn?.NotifyUrl;
         if (string.IsNullOrWhiteSpace(notifyUrl))
@@ -73,7 +73,10 @@ public class SignInNotifier(
             return SignInNotificationResult.Failed;
         }
 
+        // The scheme names the provider that was actually challenged — authoritative over anything sniffed
+        // from claims, which for some providers bottoms out in the meaningless "AuthenticationTypes.Federation".
         var identityProvider = canonicalResolution.Identity?.ProviderKey
+            ?? OidcProviderScheme.NameFromScheme(config.CurrentValue.Authentication, scheme)
             ?? principal?.FindFirst("iss")?.Value
             ?? principal?.FindFirst("identity_provider")?.Value
             ?? principal?.FindFirst("http://schemas.microsoft.com/accesscontrolservice/2010/07/claims/identityprovider")?.Value


### PR DESCRIPTION
## Fixed

- Microsoft sign-ins and credential links through a multi-tenant authority (`common`, `organizations`, `consumers`) no longer fail issuer validation (IDX10205) — the issuer is validated against the tenant the token itself names, for both organizational and personal accounts.
- Sign-ins and credential links are now attributed to the identity provider that was actually challenged, instead of falling back to the meaningless `AuthenticationTypes.Federation` some providers leave as the principal's authentication type.