### PR TITLE
Bind invitation completion to the identity authenticated for it

### DIFF
--- a/Documentation/configuration/invitation-provider-selection.md
+++ b/Documentation/configuration/invitation-provider-selection.md
@@ -235,9 +235,9 @@ GET /invite/<token>
         │
         └─ Token valid
                 │
-                ├─ Single provider ──► redirect to /.cratis/login/<scheme>
+                ├─ Single provider, not signed in ──► redirect to /.cratis/login/<scheme>
                 │
-                └─ Multiple providers
+                └─ Multiple providers, or already signed in
                         │
                         ▼
           Set .cratis-providers cookie
@@ -256,3 +256,18 @@ GET /invite/<token>
                         ▼
               Redirect to lobby / application
 ```
+
+### Callers who are already signed in
+
+An invitation is completed only with the identity that authenticated **for that invitation**. A session the
+browser was already carrying — from an earlier sign-in, possibly with a different provider — never completes
+one, even though it is a perfectly valid session: the organization would be bound permanently to an account
+the person did not choose for it.
+
+Such a caller is therefore always shown `invitation-select-provider.html`, even where only one provider is
+configured, and the invitation completes with whatever identity comes back from the provider they pick.
+Picking the provider they are already signed in with normally costs no more than a redirect, because the
+identity provider still has its own session.
+
+The pending invitation is left in place while this happens, so nothing is lost — it stays valid for the
+lifetime of the `.cratis-invite` cookie.

--- a/Source/AuthProxy.Specs/Invites/InvitationSessionFixture.cs
+++ b/Source/AuthProxy.Specs/Invites/InvitationSessionFixture.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.Invites;
+
+/// <summary>
+/// Establishes, on a specification's HTTP context, the authentication result the request is running as.
+/// </summary>
+/// <remarks>
+/// That result is the evidence <see cref="InviteMiddleware"/> reads to tell a session established by an
+/// invitation's own challenge apart from one the browser was already carrying, so a specification that
+/// exercises the post-login exchange has to say which of the two it is modeling. In a running proxy the
+/// authentication middleware publishes it after the provider handshake signs a ticket in.
+/// </remarks>
+static class InvitationSessionFixture
+{
+    /// <summary>
+    /// Establishes a session that answered the provider challenge started for one exact invitation.
+    /// </summary>
+    /// <param name="context">The context to establish the session on.</param>
+    /// <param name="invitationToken">The invitation capability the challenge was started for.</param>
+    public static void GivenSessionEstablishedByTheInvitation(HttpContext context, string invitationToken) =>
+        GivenSession(context, properties => InvitationAuthenticationState.BindCapability(properties, invitationToken));
+
+    /// <summary>
+    /// Establishes a session that predates the invitation — signed in earlier, for something else, and
+    /// therefore carrying no invitation binding at all.
+    /// </summary>
+    /// <param name="context">The context to establish the session on.</param>
+    public static void GivenSessionEstablishedBeforeTheInvitation(HttpContext context) =>
+        GivenSession(context, _ => { });
+
+    static void GivenSession(HttpContext context, Action<AuthenticationProperties> bind)
+    {
+        var properties = new AuthenticationProperties { IssuedUtc = DateTimeOffset.UtcNow };
+        bind(properties);
+
+        var scheme = context.User.Identity?.AuthenticationType ?? "test-scheme";
+        context.Features.Set<IAuthenticateResultFeature>(new EstablishedSession(
+            AuthenticateResult.Success(new AuthenticationTicket(context.User, properties, scheme))));
+    }
+
+    sealed class EstablishedSession(AuthenticateResult result) : IAuthenticateResultFeature
+    {
+        public AuthenticateResult? AuthenticateResult { get; set; } = result;
+    }
+}

--- a/Source/AuthProxy.Specs/Invites/for_InvitationAuthenticationState/when_binding_a_pending_invitation/and_no_invitation_is_pending.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InvitationAuthenticationState/when_binding_a_pending_invitation/and_no_invitation_is_pending.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.Invites.for_InvitationAuthenticationState.when_binding_a_pending_invitation;
+
+/// <summary>
+/// An ordinary sign-in has no invitation behind it, so nothing is added to the challenge — and it still
+/// proceeds. Binding a capability here would attach invitation meaning to a session that has none.
+/// </summary>
+public class and_no_invitation_is_pending : Specification
+{
+    DefaultHttpContext _context;
+    AuthenticationProperties _properties;
+    bool _result;
+
+    void Establish()
+    {
+        _context = new DefaultHttpContext();
+        _properties = new AuthenticationProperties();
+    }
+
+    void Because() => _result = InvitationAuthenticationState.TryBindPendingInvitation(_context, _properties);
+
+    [Fact] void should_allow_the_challenge() => _result.ShouldBeTrue();
+    [Fact] void should_bind_nothing() => _properties.Items.ShouldBeEmpty();
+}

--- a/Source/AuthProxy.Specs/Invites/for_InvitationAuthenticationState/when_binding_a_pending_invitation/and_nothing_was_staged.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InvitationAuthenticationState/when_binding_a_pending_invitation/and_nothing_was_staged.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.Invites.for_InvitationAuthenticationState.when_binding_a_pending_invitation;
+
+/// <summary>
+/// A deployment that has not enabled the attested protocol stages nothing, so there is no transaction to
+/// bind — but the capability is still bound. It is what the provider returns with the session it
+/// establishes, and the only evidence that session answered this invitation rather than predating it.
+/// </summary>
+public class and_nothing_was_staged : Specification
+{
+    const string Capability = "pending-capability";
+
+    DefaultHttpContext _context;
+    AuthenticationProperties _properties;
+    bool _result;
+
+    void Establish()
+    {
+        _context = new DefaultHttpContext();
+        _context.Request.Headers.Cookie = $"{Cookies.InviteToken}={Capability}";
+        _properties = new AuthenticationProperties();
+    }
+
+    void Because() => _result = InvitationAuthenticationState.TryBindPendingInvitation(_context, _properties);
+
+    [Fact] void should_bind() => _result.ShouldBeTrue();
+    [Fact]
+    void should_bind_the_pending_capability() =>
+        _properties.Items[InvitationAuthenticationState.CapabilityHashStateKey]
+            .ShouldEqual(InvitationAuthenticationState.ComputeCapabilityHash(Capability));
+}

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/given/an_attested_invite_completion.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/given/an_attested_invite_completion.cs
@@ -125,6 +125,7 @@ public class an_attested_invite_completion : Specification
             ]);
         properties.Items[InvitationAuthenticationState.CapabilityHashStateKey] = ComputeHash(token);
         _context.Request.Headers.Cookie = $"{Cookies.InviteToken}={token}; {Cookies.InvitationEntryState}=protected-state";
+        InvitationSessionFixture.GivenSessionEstablishedByTheInvitation(_context, token);
 
         var protector = Substitute.For<IInvitationEntryStateProtector>();
         protector.TryUnprotect("protected-state", out Arg.Any<InvitationEntryState>())

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/given/an_invitation_entry.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/given/an_invitation_entry.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.Invites.for_InviteMiddleware.given;
+
+/// <summary>
+/// Reusable context that drives <see cref="InviteMiddleware"/> through Phase 1 — the invitation link itself
+/// arriving on <c>/invite/{token}</c> — with identity providers configured, so a specification can say what
+/// the caller is offered before any provider handshake has happened.
+/// </summary>
+public class an_invitation_entry : Specification
+{
+    protected const string Capability = "some-token";
+
+    protected InviteMiddleware _middleware;
+    protected DefaultHttpContext _context;
+    protected IErrorPageProvider _errorPageProvider;
+    protected IAuthenticationService _authenticationService;
+    protected bool _nextCalled;
+
+    /// <summary>
+    /// Gets the identity providers the deployment has configured.
+    /// </summary>
+    protected virtual IReadOnlyList<C.OidcProvider> Providers =>
+    [
+        new() { Name = "GitHub", Authority = "https://github.test", ClientId = "github-id", ClientSecret = "github-secret" },
+        new() { Name = "Google", Authority = "https://accounts.google.com", ClientId = "google-id", ClientSecret = "google-secret" }
+    ];
+
+    void Establish()
+    {
+        var tokenValidator = Substitute.For<IInviteTokenValidator>();
+        tokenValidator.ValidateDetailed(Arg.Any<string>()).Returns(InviteTokenValidationResult.Valid);
+
+        var config = new C.AuthProxy
+        {
+            Invite = new C.Invite { ExchangeUrl = "http://studio/internal/invites/exchange" }
+        };
+        var optionsMonitor = Substitute.For<IOptionsMonitor<C.AuthProxy>>();
+        optionsMonitor.CurrentValue.Returns(config);
+
+        var authConfigMonitor = Substitute.For<IOptionsMonitor<C.Authentication>>();
+        authConfigMonitor.CurrentValue.Returns(new C.Authentication { OidcProviders = [.. Providers] });
+
+        _errorPageProvider = Substitute.For<IErrorPageProvider>();
+
+        _middleware = new InviteMiddleware(
+            _ =>
+            {
+                _nextCalled = true;
+                return Task.CompletedTask;
+            },
+            tokenValidator,
+            optionsMonitor,
+            authConfigMonitor,
+            Substitute.For<ITenantResolver>(),
+            Substitute.For<IHttpClientFactory>(),
+            _errorPageProvider,
+            Substitute.For<ILogger<InviteMiddleware>>());
+
+        _authenticationService = Substitute.For<IAuthenticationService>();
+        _authenticationService
+            .ChallengeAsync(Arg.Any<HttpContext>(), Arg.Any<string>(), Arg.Any<AuthenticationProperties>())
+            .Returns(Task.CompletedTask);
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IAuthenticationService)).Returns(_authenticationService);
+
+        _context = new DefaultHttpContext { RequestServices = serviceProvider };
+        _context.Request.Path = $"{WellKnownPaths.InvitePathPrefix}/{Capability}";
+    }
+
+    /// <summary>
+    /// Signs the caller in the way the browser already was when the invitation link was opened — a real
+    /// session, established earlier and for something else, carrying no invitation binding.
+    /// </summary>
+    protected void GivenAPreExistingSession()
+    {
+        _context.User = new ClaimsPrincipal(new ClaimsIdentity([new Claim("sub", "134365")], "github"));
+        InvitationSessionFixture.GivenSessionEstablishedBeforeTheInvitation(_context);
+    }
+}

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/given/an_invite_exchange.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/given/an_invite_exchange.cs
@@ -119,11 +119,27 @@ public class an_invite_exchange : Specification
         _context.User = new ClaimsPrincipal(new ClaimsIdentity(claims.Prepend(new Claim("sub", "user-123")), "aad"));
 
     /// <summary>
-    /// Places the given token in the pending invite cookie, as it would arrive on the Phase-2 request.
+    /// Places the given token in the pending invite cookie and establishes the session that answered this
+    /// invitation's own challenge, exactly as a Phase-2 request arrives once the provider has signed the
+    /// caller in for the invitation.
     /// </summary>
     /// <param name="token">The token to carry in the <c>.cratis-invite</c> cookie.</param>
-    protected void GivenPendingInviteCookie(string token) =>
+    protected void GivenPendingInviteCookie(string token)
+    {
         _context.Request.Headers.Cookie = $"{Cookies.InviteToken}={token}";
+        InvitationSessionFixture.GivenSessionEstablishedByTheInvitation(_context, token);
+    }
+
+    /// <summary>
+    /// Places the given token in the pending invite cookie while the caller is signed in from before the
+    /// invitation was ever opened — the browser that already had a session with another provider.
+    /// </summary>
+    /// <param name="token">The token to carry in the <c>.cratis-invite</c> cookie.</param>
+    protected void GivenPendingInviteCookieOnAPreExistingSession(string token)
+    {
+        _context.Request.Headers.Cookie = $"{Cookies.InviteToken}={token}";
+        InvitationSessionFixture.GivenSessionEstablishedBeforeTheInvitation(_context);
+    }
 
     static IOptionsMonitor<C.Authentication> EmptyAuthConfig()
     {

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite/and_exchange_call_throws.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite/and_exchange_call_throws.cs
@@ -50,6 +50,7 @@ public class and_exchange_call_throws : Specification
         var identity = new ClaimsIdentity([new Claim("sub", "user-123")], "aad");
         _context.User = new ClaimsPrincipal(identity);
         _context.Request.Headers.Cookie = $"{Cookies.InviteToken}=pending-invite-token";
+        InvitationSessionFixture.GivenSessionEstablishedByTheInvitation(_context, "pending-invite-token");
     }
 
     async Task Because() => await _middleware.InvokeAsync(_context);

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite/and_exchange_returns_duplicate_subject_status.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite/and_exchange_returns_duplicate_subject_status.cs
@@ -52,6 +52,7 @@ public class and_exchange_returns_duplicate_subject_status : Specification
         var identity = new ClaimsIdentity([new Claim("sub", "user-123")], "aad");
         _context.User = new ClaimsPrincipal(identity);
         _context.Request.Headers.Cookie = $"{Cookies.InviteToken}=pending-invite-token";
+        InvitationSessionFixture.GivenSessionEstablishedByTheInvitation(_context, "pending-invite-token");
     }
 
     async Task Because() => await _middleware.InvokeAsync(_context);

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite/and_exchange_returns_duplicate_subject_status_with_configured_url.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite/and_exchange_returns_duplicate_subject_status_with_configured_url.cs
@@ -55,6 +55,7 @@ public class and_exchange_returns_duplicate_subject_status_with_configured_url :
         var identity = new ClaimsIdentity([new Claim("sub", "user-123")], "aad");
         _context.User = new ClaimsPrincipal(identity);
         _context.Request.Headers.Cookie = $"{Cookies.InviteToken}=pending-invite-token";
+        InvitationSessionFixture.GivenSessionEstablishedByTheInvitation(_context, "pending-invite-token");
     }
 
     async Task Because() => await _middleware.InvokeAsync(_context);

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite/and_exchange_returns_non_success_status.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite/and_exchange_returns_non_success_status.cs
@@ -53,6 +53,7 @@ public class and_exchange_returns_non_success_status : Specification
         var identity = new ClaimsIdentity([new Claim("sub", "user-123")], "aad");
         _context.User = new ClaimsPrincipal(identity);
         _context.Request.Headers.Cookie = $"{Cookies.InviteToken}=pending-invite-token";
+        InvitationSessionFixture.GivenSessionEstablishedByTheInvitation(_context, "pending-invite-token");
     }
 
     async Task Because() => await _middleware.InvokeAsync(_context);

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite/and_exchange_url_is_missing.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite/and_exchange_url_is_missing.cs
@@ -43,6 +43,7 @@ public class and_exchange_url_is_missing : Specification
         var identity = new ClaimsIdentity([new Claim("sub", "user-123")], "aad");
         _context.User = new ClaimsPrincipal(identity);
         _context.Request.Headers.Cookie = $"{Cookies.InviteToken}=pending-invite-token";
+        InvitationSessionFixture.GivenSessionEstablishedByTheInvitation(_context, "pending-invite-token");
     }
 
     async Task Because() => await _middleware.InvokeAsync(_context);

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite/and_lobby_is_configured.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite/and_lobby_is_configured.cs
@@ -57,6 +57,7 @@ public class and_lobby_is_configured : Specification
         _context.User = new ClaimsPrincipal(identity);
 
         _context.Request.Headers.Cookie = $"{Cookies.InviteToken}=pending-invite-token";
+        InvitationSessionFixture.GivenSessionEstablishedByTheInvitation(_context, "pending-invite-token");
     }
 
     async Task Because() => await _middleware.InvokeAsync(_context);

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite/and_lobby_query_append_is_enabled.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite/and_lobby_query_append_is_enabled.cs
@@ -61,6 +61,7 @@ public class and_lobby_query_append_is_enabled : Specification
         _context.User = new ClaimsPrincipal(identity);
 
         _context.Request.Headers.Cookie = $"{Cookies.InviteToken}=pending-invite-token";
+        InvitationSessionFixture.GivenSessionEstablishedByTheInvitation(_context, "pending-invite-token");
     }
 
     async Task Because() => await _middleware.InvokeAsync(_context);

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite/and_lobby_url_already_has_query.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite/and_lobby_url_already_has_query.cs
@@ -61,6 +61,7 @@ public class and_lobby_url_already_has_query : Specification
         _context.User = new ClaimsPrincipal(identity);
 
         _context.Request.Headers.Cookie = $"{Cookies.InviteToken}=pending-invite-token";
+        InvitationSessionFixture.GivenSessionEstablishedByTheInvitation(_context, "pending-invite-token");
     }
 
     async Task Because() => await _middleware.InvokeAsync(_context);

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite/when_authenticated_user_has_pending_invite.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite/when_authenticated_user_has_pending_invite.cs
@@ -50,6 +50,7 @@ public class when_authenticated_user_has_pending_invite : Specification
 
         // Simulate pending invite cookie.
         _context.Request.Headers.Cookie = $"{Cookies.InviteToken}=pending-invite-token";
+        InvitationSessionFixture.GivenSessionEstablishedByTheInvitation(_context, "pending-invite-token");
     }
 
     async Task Because() => await _middleware.InvokeAsync(_context);

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite_with_fallback_claims.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_invite_with_fallback_claims.cs
@@ -49,6 +49,7 @@ public class when_authenticated_user_has_pending_invite_with_fallback_claims : S
                 [new Claim(ClaimTypes.NameIdentifier, "user-123")],
                 "aad"));
         _context.Request.Headers.Cookie = $"{Cookies.InviteToken}=pending-invite-token";
+        InvitationSessionFixture.GivenSessionEstablishedByTheInvitation(_context, "pending-invite-token");
     }
 
     async Task Because() => await _middleware.InvokeAsync(_context);

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_tenant_invite/and_tenant_does_not_match.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_tenant_invite/and_tenant_does_not_match.cs
@@ -67,6 +67,7 @@ public class and_tenant_does_not_match : Specification
         _context.User = new ClaimsPrincipal(identity);
 
         _context.Request.Headers.Cookie = $"{Cookies.InviteToken}=pending-invite-token";
+        InvitationSessionFixture.GivenSessionEstablishedByTheInvitation(_context, "pending-invite-token");
         _context.Items[TenancyMiddleware.TenantIdItemKey] = ResolvedTenantId;
     }
 

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_tenant_invite/and_tenant_matches.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_has_pending_tenant_invite/and_tenant_matches.cs
@@ -66,6 +66,7 @@ public class and_tenant_matches : Specification
         _context.User = new ClaimsPrincipal(identity);
 
         _context.Request.Headers.Cookie = $"{Cookies.InviteToken}=pending-invite-token";
+        InvitationSessionFixture.GivenSessionEstablishedByTheInvitation(_context, "pending-invite-token");
         _context.Items[TenancyMiddleware.TenantIdItemKey] = TenantId;
     }
 

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_returns_to_invite_path_with_pending_invite.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_authenticated_user_returns_to_invite_path_with_pending_invite.cs
@@ -5,6 +5,11 @@ using System.Net;
 
 namespace Cratis.AuthProxy.Invites.for_InviteMiddleware;
 
+/// <summary>
+/// The provider callback lands back on the invitation path with the session it just established. That
+/// session answered this invitation's challenge, so the exchange runs here and now — re-entering the
+/// invitation entry instead would send the caller back to the provider that had just returned them.
+/// </summary>
 public class when_authenticated_user_returns_to_invite_path_with_pending_invite : Specification
 {
     InviteMiddleware _middleware;
@@ -50,10 +55,11 @@ public class when_authenticated_user_returns_to_invite_path_with_pending_invite 
         _context.User = new ClaimsPrincipal(identity);
 
         _context.Request.Headers.Cookie = $"{Cookies.InviteToken}=pending-invite-token";
+        InvitationSessionFixture.GivenSessionEstablishedByTheInvitation(_context, "pending-invite-token");
     }
 
     async Task Because() => await _middleware.InvokeAsync(_context);
 
     [Fact] void should_call_next() => _nextCalled.ShouldBeTrue();
-    [Fact] void should_delete_invite_cookie() => _context.Response.Headers.SetCookie.ToString().ShouldContain(Cookies.InviteToken);
+    [Fact] void should_delete_invite_cookie() => _context.Response.Headers.SetCookie.ToString().ShouldContain($"{Cookies.InviteToken}=;");
 }

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_deciding_which_identity_completes_an_invitation/and_a_pre_existing_session_carries_a_forged_capability.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_deciding_which_identity_completes_an_invitation/and_a_pre_existing_session_carries_a_forged_capability.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Invites.for_InviteMiddleware.when_deciding_which_identity_completes_an_invitation;
+
+/// <summary>
+/// Which identity may complete an invitation is a question about a capability that validates, so the
+/// capability is still re-validated first and a forged one is still answered with the invalid page and
+/// cleared from the browser. Deciding the identity question first would turn a forged capability into a
+/// silently pending one.
+/// </summary>
+public class and_a_pre_existing_session_carries_a_forged_capability : given.an_invite_exchange
+{
+    void Establish()
+    {
+        GivenAuthenticatedUserWith();
+        GivenPendingInviteCookieOnAPreExistingSession(
+            CreateSignedToken(signingKey: TokenFixture.GenerateKeyPair().PrivateKey));
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_not_forward_to_the_exchange_endpoint() => _exchangeCalled.ShouldBeFalse();
+    [Fact] void should_not_continue_the_pipeline() => _nextCalled.ShouldBeFalse();
+    [Fact] void should_clear_the_pending_invitation() => _context.Response.Headers.SetCookie.ToString().ShouldContain(Cookies.InviteToken);
+    [Fact]
+    void should_serve_the_invitation_invalid_page() =>
+        _errorPageProvider.Received(1).WriteErrorPageAsync(
+            _context,
+            WellKnownPageNames.InvitationInvalid,
+            StatusCodes.Status401Unauthorized);
+}

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_deciding_which_identity_completes_an_invitation/and_a_signed_in_caller_opens_it_where_one_provider_is_configured.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_deciding_which_identity_completes_an_invitation/and_a_signed_in_caller_opens_it_where_one_provider_is_configured.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.Invites.for_InviteMiddleware.when_deciding_which_identity_completes_an_invitation;
+
+/// <summary>
+/// With one provider configured there is nothing to choose between, yet a caller who already has a session
+/// is still shown the page rather than challenged straight through. The page names the account the
+/// organization is about to be bound to and makes the person act on it, and — being a terminal response —
+/// it cannot become a redirect loop if a deployment's invitation binding fails to survive the provider
+/// round-trip.
+/// </summary>
+public class and_a_signed_in_caller_opens_it_where_one_provider_is_configured : given.an_invitation_entry
+{
+    protected override IReadOnlyList<C.OidcProvider> Providers =>
+    [
+        new() { Name = "GitHub", Authority = "https://github.test", ClientId = "github-id", ClientSecret = "github-secret" }
+    ];
+
+    void Establish() => GivenAPreExistingSession();
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact]
+    void should_offer_the_provider_choice() =>
+        _errorPageProvider.Received(1).WriteErrorPageAsync(
+            _context,
+            WellKnownPageNames.InvitationSelectProvider,
+            StatusCodes.Status200OK);
+
+    [Fact]
+    void should_not_challenge_the_provider_silently() =>
+        _authenticationService.DidNotReceive().ChallengeAsync(
+            Arg.Any<HttpContext>(),
+            Arg.Any<string>(),
+            Arg.Any<AuthenticationProperties>());
+}

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_deciding_which_identity_completes_an_invitation/and_a_signed_in_caller_opens_the_invitation_link.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_deciding_which_identity_completes_an_invitation/and_a_signed_in_caller_opens_the_invitation_link.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Invites.for_InviteMiddleware.when_deciding_which_identity_completes_an_invitation;
+
+/// <summary>
+/// The production case this exists for: somebody already signed in with one provider opens an invitation to
+/// join an organization. They are offered the choice of provider, and nothing is exchanged with the session
+/// they arrived carrying.
+/// </summary>
+public class and_a_signed_in_caller_opens_the_invitation_link : given.an_invitation_entry
+{
+    void Establish() => GivenAPreExistingSession();
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact]
+    void should_offer_the_provider_choice() =>
+        _errorPageProvider.Received(1).WriteErrorPageAsync(
+            _context,
+            WellKnownPageNames.InvitationSelectProvider,
+            StatusCodes.Status200OK);
+
+    [Fact] void should_carry_the_invitation_across_the_choice() => _context.Response.Headers.SetCookie.ToString().ShouldContain(Cookies.InviteToken);
+    [Fact] void should_offer_every_configured_provider() => _context.Response.Headers.SetCookie.ToString().ShouldContain("Google");
+    [Fact] void should_not_continue_the_pipeline() => _nextCalled.ShouldBeFalse();
+}

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_deciding_which_identity_completes_an_invitation/and_an_anonymous_caller_is_challenged_for_the_invitation.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_deciding_which_identity_completes_an_invitation/and_an_anonymous_caller_is_challenged_for_the_invitation.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.Invites.for_InviteMiddleware.when_deciding_which_identity_completes_an_invitation;
+
+/// <summary>
+/// The other side of the same contract: the challenge started for an invitation carries that invitation's
+/// capability, which is the only thing that lets the session coming back be recognized as the one this
+/// invitation asked for. Without it every completed sign-in would be refused and no invitation could ever
+/// be accepted.
+/// </summary>
+public class and_an_anonymous_caller_is_challenged_for_the_invitation : given.an_invitation_entry
+{
+    protected override IReadOnlyList<C.OidcProvider> Providers =>
+    [
+        new() { Name = "GitHub", Authority = "https://github.test", ClientId = "github-id", ClientSecret = "github-secret" }
+    ];
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact]
+    void should_bind_the_invitation_capability_to_the_challenge() =>
+        _authenticationService.Received(1).ChallengeAsync(
+            _context,
+            OidcProviderScheme.FromName("GitHub"),
+            Arg.Is<AuthenticationProperties>(properties =>
+                properties.Items[InvitationAuthenticationState.CapabilityHashStateKey]
+                    == InvitationAuthenticationState.ComputeCapabilityHash(Capability)));
+}

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_deciding_which_identity_completes_an_invitation/and_the_session_answered_the_invitations_challenge.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_deciding_which_identity_completes_an_invitation/and_the_session_answered_the_invitations_challenge.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Invites.for_InviteMiddleware.when_deciding_which_identity_completes_an_invitation;
+
+/// <summary>
+/// The whole point of the flow: the caller went through the invitation's own provider challenge, came back,
+/// and the invitation completes with the identity they authenticated with — in one request, with no second
+/// trip past the provider.
+/// </summary>
+public class and_the_session_answered_the_invitations_challenge : given.an_invite_exchange
+{
+    void Establish()
+    {
+        GivenAuthenticatedUserWith();
+        GivenPendingInviteCookie(CreateSignedToken());
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_forward_to_the_exchange_endpoint() => _exchangeCalled.ShouldBeTrue();
+    [Fact] void should_continue_the_pipeline() => _nextCalled.ShouldBeTrue();
+    [Fact] void should_clear_the_pending_invitation() => _context.Response.Headers.SetCookie.ToString().ShouldContain(Cookies.InviteToken);
+    [Fact]
+    void should_not_serve_an_error_page() =>
+        _errorPageProvider.DidNotReceive().WriteErrorPageAsync(Arg.Any<HttpContext>(), Arg.Any<string>(), Arg.Any<int>());
+}

--- a/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_deciding_which_identity_completes_an_invitation/and_the_session_predates_the_invitation.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InviteMiddleware/when_deciding_which_identity_completes_an_invitation/and_the_session_predates_the_invitation.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Invites.for_InviteMiddleware.when_deciding_which_identity_completes_an_invitation;
+
+/// <summary>
+/// The account the browser was already signed in with is not the account the person chose for the
+/// invitation, and an invitation binds an organization to an identity permanently. A pre-existing session
+/// therefore completes nothing — and, because the person has not chosen yet, the invitation is left pending
+/// rather than consumed or refused.
+/// </summary>
+public class and_the_session_predates_the_invitation : given.an_invite_exchange
+{
+    void Establish()
+    {
+        GivenAuthenticatedUserWith();
+        GivenPendingInviteCookieOnAPreExistingSession(CreateSignedToken());
+    }
+
+    async Task Because() => await _middleware.InvokeAsync(_context);
+
+    [Fact] void should_not_forward_to_the_exchange_endpoint() => _exchangeCalled.ShouldBeFalse();
+    [Fact] void should_leave_the_invitation_pending() => _context.Response.Headers.SetCookie.ToString().ShouldNotContain(Cookies.InviteToken);
+    [Fact] void should_continue_the_pipeline() => _nextCalled.ShouldBeTrue();
+    [Fact]
+    void should_not_serve_an_error_page() =>
+        _errorPageProvider.DidNotReceive().WriteErrorPageAsync(Arg.Any<HttpContext>(), Arg.Any<string>(), Arg.Any<int>());
+}

--- a/Source/AuthProxy.Specs/Scenarios/when_invitation_link_is_used/AuthProxyFactory.cs
+++ b/Source/AuthProxy.Specs/Scenarios/when_invitation_link_is_used/AuthProxyFactory.cs
@@ -134,8 +134,16 @@ public class AuthProxyFactory : WebApplicationFactory<Program>
     /// </summary>
     /// <param name="authenticated">Whether the client should appear authenticated.</param>
     /// <param name="inviteTokenCookie">Optional invite token to send as a cookie.</param>
+    /// <param name="sessionEstablishedByTheInvitation">
+    /// Whether the session was established by the invitation's own challenge. Set this to
+    /// <see langword="false"/> to model the browser that was already signed in when the invitation
+    /// was opened — the session AuthProxy must refuse to complete an invitation with.
+    /// </param>
     /// <returns>A configured <see cref="HttpClient"/> that does not follow redirects.</returns>
-    public HttpClient CreateTestClient(bool authenticated = false, string? inviteTokenCookie = null)
+    public HttpClient CreateTestClient(
+        bool authenticated = false,
+        string? inviteTokenCookie = null,
+        bool sessionEstablishedByTheInvitation = true)
     {
         var client = CreateClient(new WebApplicationFactoryClientOptions
         {
@@ -145,6 +153,11 @@ public class AuthProxyFactory : WebApplicationFactory<Program>
         if (authenticated)
         {
             client.DefaultRequestHeaders.Add(TestAuthHandler.AuthHeader, "true");
+        }
+
+        if (!sessionEstablishedByTheInvitation)
+        {
+            client.DefaultRequestHeaders.Add(TestAuthHandler.PreExistingSessionHeader, "true");
         }
 
         if (!string.IsNullOrEmpty(inviteTokenCookie))
@@ -159,6 +172,12 @@ public class AuthProxyFactory : WebApplicationFactory<Program>
     /// <param name="options">The options monitor for authentication scheme options.</param>
     /// <param name="logger">The logger factory.</param>
     /// <param name="encoder">The URL encoder.</param>
+    /// <remarks>
+    /// A real provider handshake returns the challenge properties AuthProxy started it with, so a session
+    /// established for a pending invitation carries that invitation's capability binding. This stands in for
+    /// that, and <see cref="PreExistingSessionHeader"/> turns it off to model the opposite case: a browser
+    /// already signed in before the invitation was ever opened.
+    /// </remarks>
     public class TestAuthHandler(
         IOptionsMonitor<AuthenticationSchemeOptions> options,
         ILoggerFactory logger,
@@ -167,6 +186,7 @@ public class AuthProxyFactory : WebApplicationFactory<Program>
     {
         public const string Scheme = "TestScheme";
         public const string AuthHeader = "X-Test-Auth";
+        public const string PreExistingSessionHeader = "X-Test-Pre-Existing-Session";
 
         /// <inheritdoc/>
         protected override Task<AuthenticateResult> HandleAuthenticateAsync()
@@ -181,7 +201,16 @@ public class AuthProxyFactory : WebApplicationFactory<Program>
                 new Claim("oid", "test-user-id"),
             };
             var identity = new ClaimsIdentity(claims, Scheme);
-            var ticket = new AuthenticationTicket(new ClaimsPrincipal(identity), Scheme);
+            var properties = new AuthenticationProperties();
+
+            if (!Request.Headers.ContainsKey(PreExistingSessionHeader)
+                && Request.Cookies.TryGetValue(Cookies.InviteToken, out var invitation)
+                && !string.IsNullOrEmpty(invitation))
+            {
+                InvitationAuthenticationState.BindCapability(properties, invitation);
+            }
+
+            var ticket = new AuthenticationTicket(new ClaimsPrincipal(identity), properties, Scheme);
             return Task.FromResult(AuthenticateResult.Success(ticket));
         }
     }

--- a/Source/AuthProxy.Specs/Scenarios/when_invitation_link_is_used/and_the_session_predates_the_invitation.cs
+++ b/Source/AuthProxy.Specs/Scenarios/when_invitation_link_is_used/and_the_session_predates_the_invitation.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Invites;
+
+namespace Cratis.AuthProxy.Scenarios.when_invitation_link_is_used;
+
+/// <summary>
+/// End-to-end scenario: the browser carries a pending invite cookie and a session that was established
+/// before the invitation was ever opened. Nothing is exchanged, nothing is redirected to the lobby, and the
+/// pending invitation survives the request so the person can still complete it with the provider they
+/// choose.
+/// </summary>
+/// <param name="factory">The shared application factory.</param>
+public class and_the_session_predates_the_invitation(AuthProxyFactory factory) : IClassFixture<AuthProxyFactory>, IAsyncLifetime
+{
+    HttpResponseMessage? _response;
+    int _exchangeCallsBefore;
+
+    public async Task InitializeAsync()
+    {
+        var token = TokenFixture.CreateToken(
+            factory.InviteKeyPair.PrivateKey,
+            additionalClaims: [new Claim("jti", Guid.NewGuid().ToString())]);
+
+        _exchangeCallsBefore = factory.ExchangeCallCount;
+
+        using var client = factory.CreateTestClient(
+            authenticated: true,
+            inviteTokenCookie: token,
+            sessionEstablishedByTheInvitation: false);
+        _response = await client.GetAsync("/");
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public void should_not_call_the_exchange_endpoint() =>
+        Assert.Equal(_exchangeCallsBefore, factory.ExchangeCallCount);
+
+    [Fact]
+    public void should_not_redirect_to_the_lobby() =>
+        Assert.NotEqual(AuthProxyFactory.LobbyUrl, _response.Headers.Location?.ToString());
+
+    [Fact]
+    public void should_leave_the_pending_invitation_in_place()
+    {
+        _response.Headers.TryGetValues("Set-Cookie", out var cookies);
+        Assert.DoesNotContain(
+            cookies ?? [],
+            cookie => cookie.Contains(Cookies.InviteToken, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/Source/AuthProxy/Invites/InvitationAuthenticationState.cs
+++ b/Source/AuthProxy/Invites/InvitationAuthenticationState.cs
@@ -4,6 +4,7 @@
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.IdentityModel.Tokens;
 
 namespace Cratis.AuthProxy.Invites;
 
@@ -33,10 +34,22 @@ public static class InvitationAuthenticationState
     /// <param name="context">The current HTTP context.</param>
     /// <param name="properties">The provider challenge properties.</param>
     /// <returns><see langword="true"/> when no invitation is pending or valid invitation state was bound; otherwise <see langword="false"/>.</returns>
+    /// <remarks>
+    /// A pending invitation always binds its capability, staged or not. That binding is the only thing that
+    /// later tells the post-login exchange that the session coming back was established by <em>this</em>
+    /// invitation's own challenge — a deployment that has not enabled the attested protocol stages nothing,
+    /// and without it the exchange cannot tell the identity the person just authenticated with apart from
+    /// whatever session the browser was already carrying.
+    /// </remarks>
     public static bool TryBindPendingInvitation(HttpContext context, AuthenticationProperties properties)
     {
         if (!context.Request.Cookies.TryGetValue(Cookies.InvitationEntryState, out var protectedState))
         {
+            if (context.TryGetPendingInvitationToken(out var pendingInvitation))
+            {
+                BindCapability(properties, pendingInvitation);
+            }
+
             return true;
         }
 
@@ -63,6 +76,41 @@ public static class InvitationAuthenticationState
         properties.Items[ChallengeStateKey] = state.InvitationChallenge;
         properties.Items[CapabilityHashStateKey] = state.CapabilityHash;
     }
+
+    /// <summary>
+    /// Binds the exact invitation capability a provider challenge is being started for.
+    /// </summary>
+    /// <param name="properties">The provider challenge properties.</param>
+    /// <param name="invitationToken">The invitation capability the challenge answers.</param>
+    internal static void BindCapability(AuthenticationProperties properties, string invitationToken) =>
+        properties.Items[CapabilityHashStateKey] = ComputeCapabilityHash(invitationToken);
+
+    /// <summary>
+    /// Determines whether an authenticated session was established by the challenge started for one exact
+    /// invitation capability.
+    /// </summary>
+    /// <param name="properties">The properties of the session authenticating the request.</param>
+    /// <param name="invitationToken">The pending invitation capability.</param>
+    /// <returns><see langword="true"/> when the session answers that exact capability; otherwise <see langword="false"/>.</returns>
+    /// <remarks>
+    /// Properties travel inside the protected authentication ticket, so a value found here was put there by
+    /// AuthProxy when it started the challenge and returned by the provider with the session that challenge
+    /// established. A session that predates the invitation carries nothing, which is the answer that matters:
+    /// it is not evidence of anything about this invitation.
+    /// </remarks>
+    internal static bool WasEstablishedFor(AuthenticationProperties? properties, string invitationToken) =>
+        properties is not null
+        && properties.Items.TryGetValue(CapabilityHashStateKey, out var boundCapabilityHash)
+        && !string.IsNullOrEmpty(boundCapabilityHash)
+        && FixedTimeEquals(ComputeCapabilityHash(invitationToken), boundCapabilityHash);
+
+    /// <summary>
+    /// Computes the hash that identifies one exact invitation capability.
+    /// </summary>
+    /// <param name="invitationToken">The invitation capability.</param>
+    /// <returns>The capability hash.</returns>
+    internal static string ComputeCapabilityHash(string invitationToken) =>
+        Base64UrlEncoder.Encode(SHA256.HashData(Encoding.UTF8.GetBytes(invitationToken)));
 
     /// <summary>
     /// Determines whether authentication properties carry a complete protected invitation binding.

--- a/Source/AuthProxy/Invites/InviteMiddleware.cs
+++ b/Source/AuthProxy/Invites/InviteMiddleware.cs
@@ -13,7 +13,6 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.JsonWebTokens;
-using Microsoft.IdentityModel.Tokens;
 using C = Cratis.AuthProxy.Configuration;
 
 namespace Cratis.AuthProxy.Invites;
@@ -24,13 +23,15 @@ namespace Cratis.AuthProxy.Invites;
 ///   <item>
 ///     Handles <c>/invite/{token}</c> – validates the token, stores it in a short-lived
 ///     HTTP-only cookie and redirects the user to the OIDC login.
-///     If multiple identity providers are configured the invitation provider-selection page
-///     is served so the user can choose which provider to use.
+///     If multiple identity providers are configured — or the caller already carries a session, whose
+///     identity is not the one this invitation may bind — the invitation provider-selection page is served
+///     so the user chooses which provider to complete the invitation with.
 ///     If the token is expired the <c>invitation-expired.html</c> error page is returned.
 ///     If the token is malformed or has an invalid signature the <c>invitation-invalid.html</c> page is returned.
 ///   </item>
 ///   <item>
-///     After a successful OIDC login – detects the pending invite cookie, calls the Lobby invitation authority's
+///     After a successful OIDC login – detects the pending invite cookie, confirms the session was
+///     established by this invitation's own challenge, calls the Lobby invitation authority's
 ///     completion endpoint, deletes the cookie, and signals any required lobby redirect via
 ///     <see cref="LobbyRedirectUrlItemKey"/> in <see cref="HttpContext.Items"/> before
 ///     continuing the pipeline. Identity resolution and the actual redirect are handled by
@@ -149,88 +150,28 @@ public class InviteMiddleware(
             if (validationResult != InviteTokenValidationResult.Valid)
             {
                 logger.InviteExchangeTokenValidationFailed(validationResult);
-                context.Response.Cookies.Delete(Cookies.InviteToken);
-                context.Response.Cookies.Delete(Cookies.InvitationEntryState);
-                context.Response.Cookies.Delete(Cookies.InviteToken, new CookieOptions { Path = "/" });
-                context.Response.Cookies.Delete(Cookies.InvitationEntryState, new CookieOptions { Path = "/" });
-
-                var invalidPageName = validationResult == InviteTokenValidationResult.Expired
-                    ? WellKnownPageNames.InvitationExpired
-                    : WellKnownPageNames.InvitationInvalid;
-
-                await errorPageProvider.WriteErrorPageAsync(
-                    context,
-                    invalidPageName,
-                    StatusCodes.Status401Unauthorized);
+                await RejectPendingInvitation(context, validationResult);
                 return;
             }
 
-            var exchangeResult = IsAttestedProtocolEnabled()
-                ? await CompleteAttestedInvitation(context, inviteToken)
-                : await ExchangeInvite(context, inviteToken);
-            context.Response.Cookies.Delete(Cookies.InviteToken);
-            context.Response.Cookies.Delete(Cookies.InvitationEntryState);
-            context.Response.Cookies.Delete(Cookies.InviteToken, new CookieOptions { Path = "/" });
-            context.Response.Cookies.Delete(Cookies.InvitationEntryState, new CookieOptions { Path = "/" });
-
-            if (exchangeResult == InviteExchangeResult.EmailMismatch)
+            // "Authenticated" and "authenticated for this invitation" are different facts, and only the
+            // second one may complete it. An invitation binds an organization to an identity permanently,
+            // and the pre-existing session is the one that arrives first: a person already signed in with
+            // one provider who opens an invitation and picks another was otherwise bound to the provider
+            // they did not choose - silently, and with no way back. The session that answers the
+            // invitation's own challenge carries AuthProxy's capability binding; nothing else does, so
+            // nothing else is exchanged.
+            if (WasAuthenticatedForInvitation(context, inviteToken))
             {
-                await errorPageProvider.WriteErrorPageAsync(
-                    context,
-                    WellKnownPageNames.InvitationEmailMismatch,
-                    StatusCodes.Status403Forbidden);
-
+                await CompleteInvitation(context, inviteToken);
                 return;
             }
 
-            if (exchangeResult == InviteExchangeResult.EmailUnavailable)
-            {
-                await errorPageProvider.WriteErrorPageAsync(
-                    context,
-                    WellKnownPageNames.InvitationEmailUnavailable,
-                    StatusCodes.Status403Forbidden);
-
-                return;
-            }
-
-            if (exchangeResult == InviteExchangeResult.DuplicateSubject)
-            {
-                var subjectAlreadyExistsUrl = config.CurrentValue.Invite?.SubjectAlreadyExistsUrl;
-                if (!string.IsNullOrWhiteSpace(subjectAlreadyExistsUrl))
-                {
-                    context.Response.Redirect(subjectAlreadyExistsUrl);
-                }
-                else
-                {
-                    await errorPageProvider.WriteErrorPageAsync(
-                        context,
-                        WellKnownPageNames.InvitationSubjectAlreadyExists,
-                        StatusCodes.Status409Conflict);
-                }
-
-                return;
-            }
-
-            if (exchangeResult == InviteExchangeResult.Failed && IsAttestedProtocolEnabled())
-            {
-                await errorPageProvider.WriteErrorPageAsync(
-                    context,
-                    WellKnownPageNames.InvitationInvalid,
-                    StatusCodes.Status403Forbidden);
-                return;
-            }
-
-            if (exchangeResult == InviteExchangeResult.Success && !IsTenantIssuedInvite(inviteToken, context))
-            {
-                var lobbyUrl = config.CurrentValue.Invite?.Lobby?.Frontend?.BaseUrl;
-                if (!string.IsNullOrWhiteSpace(lobbyUrl))
-                {
-                    context.Items[LobbyRedirectUrlItemKey] = BuildLobbyRedirectUrlWithInvitationId(lobbyUrl, inviteToken);
-                }
-            }
-
-            await next(context);
-            return;
+            // Not a failure - the invitation is still pending and still valid, it just has no identity to
+            // bind yet. Falling through leaves the capability cookie in place and takes the caller to the
+            // invitation's own provider selection (Phase 1), or lets the pipeline reach the challenge
+            // endpoint the caller is already on their way to.
+            logger.InviteSessionWasNotEstablishedByTheInvitation();
         }
 
         // ── Phase 1: incoming invite URL ──────────────────────────────────────
@@ -322,7 +263,15 @@ public class InviteMiddleware(
                 });
             }
 
-            if (providers.Count > 1)
+            // A caller that already carries a session is never challenged straight through, however few
+            // providers are configured. The session it arrived with is not the identity this invitation may
+            // bind — that one is established by the challenge — and going straight to a provider gives the
+            // person no chance to see, let alone change, which account the organization ends up bound to.
+            // The click costs a moment; the wrong binding is permanent. A page is also terminal, so a
+            // deployment where the invitation binding fails to survive the provider round-trip stops here
+            // rather than bouncing the browser between the invitation and the provider forever.
+            var isAlreadyAuthenticated = context.User.Identity?.IsAuthenticated == true;
+            if (providers.Count > 1 || (providers.Count == 1 && isAlreadyAuthenticated))
             {
                 // Multiple providers: inject the providers cookie and serve the selection page.
                 var providersJson = JsonSerializer.Serialize(providers, _providerSerializerOptions);
@@ -355,7 +304,15 @@ public class InviteMiddleware(
                 {
                     InvitationAuthenticationState.Bind(properties, entryState);
                 }
-                else if (!InvitationAuthenticationState.TryBindPendingInvitation(context, properties))
+                else if (InvitationAuthenticationState.TryBindPendingInvitation(context, properties))
+                {
+                    // Nothing was staged, so bind the capability this challenge is being started for. It is
+                    // what proves, on the way back, that the session completing the invitation is the one
+                    // this invitation challenged for. The request's own cookie cannot say so — it is being
+                    // written by this very response.
+                    InvitationAuthenticationState.BindCapability(properties, token);
+                }
+                else
                 {
                     await errorPageProvider.WriteErrorPageAsync(
                         context,
@@ -363,6 +320,7 @@ public class InviteMiddleware(
                         StatusCodes.Status401Unauthorized);
                     return;
                 }
+
                 await context.ChallengeAsync(scheme, properties);
                 return;
             }
@@ -434,6 +392,36 @@ public class InviteMiddleware(
         {
             return false;
         }
+    }
+
+    /// <summary>
+    /// Determines whether the session authenticating this request was established by this invitation's own challenge.
+    /// </summary>
+    /// <param name="context">The current <see cref="HttpContext"/>.</param>
+    /// <param name="inviteToken">The pending invitation capability.</param>
+    /// <returns><see langword="true"/> when the session answers this invitation; otherwise <see langword="false"/>.</returns>
+    /// <remarks>
+    /// The evidence read is the authentication result that produced <see cref="HttpContext.User"/> — the
+    /// ticket the provider handshake signed in — rather than a second authentication call naming a scheme,
+    /// so the question asked is exactly "what established the identity this request is running as". A
+    /// deployment authenticating by any other means carries no invitation binding and is therefore refused,
+    /// which is the intended direction: the invite flow is a browser flow AuthProxy challenges for itself.
+    /// </remarks>
+    static bool WasAuthenticatedForInvitation(HttpContext context, string inviteToken) =>
+        InvitationAuthenticationState.WasEstablishedFor(
+            context.Features.Get<IAuthenticateResultFeature>()?.AuthenticateResult?.Properties,
+            inviteToken);
+
+    /// <summary>
+    /// Removes every cookie belonging to a pending invitation, at both the default and the root path.
+    /// </summary>
+    /// <param name="context">The current <see cref="HttpContext"/>.</param>
+    static void DeleteInvitationCookies(HttpContext context)
+    {
+        context.Response.Cookies.Delete(Cookies.InviteToken);
+        context.Response.Cookies.Delete(Cookies.InvitationEntryState);
+        context.Response.Cookies.Delete(Cookies.InviteToken, new CookieOptions { Path = "/" });
+        context.Response.Cookies.Delete(Cookies.InvitationEntryState, new CookieOptions { Path = "/" });
     }
 
     /// <summary>
@@ -579,9 +567,6 @@ public class InviteMiddleware(
         }
     }
 
-    static string ComputeCapabilityHash(string inviteToken) =>
-        Base64UrlEncoder.Encode(SHA256.HashData(Encoding.UTF8.GetBytes(inviteToken)));
-
     static bool ResolvedTenantMatchesWhenPresent(HttpContext context, string tenantId) =>
         !context.Items.TryGetValue(TenancyMiddleware.TenantIdItemKey, out var resolved)
         || resolved is not string resolvedTenantId
@@ -592,6 +577,99 @@ public class InviteMiddleware(
         CryptographicOperations.FixedTimeEquals(Encoding.UTF8.GetBytes(expected), Encoding.UTF8.GetBytes(actual));
 
     bool IsAttestedProtocolEnabled() => config.CurrentValue.Invite?.Attestation is not null;
+
+    /// <summary>
+    /// Answers a pending invitation whose capability no longer validates, and clears it from the browser.
+    /// </summary>
+    /// <param name="context">The current <see cref="HttpContext"/>.</param>
+    /// <param name="validationResult">The reason re-validation refused the capability.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+    async Task RejectPendingInvitation(HttpContext context, InviteTokenValidationResult validationResult)
+    {
+        DeleteInvitationCookies(context);
+
+        var invalidPageName = validationResult == InviteTokenValidationResult.Expired
+            ? WellKnownPageNames.InvitationExpired
+            : WellKnownPageNames.InvitationInvalid;
+
+        await errorPageProvider.WriteErrorPageAsync(
+            context,
+            invalidPageName,
+            StatusCodes.Status401Unauthorized);
+    }
+
+    /// <summary>
+    /// Completes a pending invitation with the identity that answered its challenge, and answers whatever
+    /// the completion produced.
+    /// </summary>
+    /// <param name="context">The current <see cref="HttpContext"/>.</param>
+    /// <param name="inviteToken">The re-validated invitation capability.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+    async Task CompleteInvitation(HttpContext context, string inviteToken)
+    {
+        var exchangeResult = IsAttestedProtocolEnabled()
+            ? await CompleteAttestedInvitation(context, inviteToken)
+            : await ExchangeInvite(context, inviteToken);
+        DeleteInvitationCookies(context);
+
+        if (exchangeResult == InviteExchangeResult.EmailMismatch)
+        {
+            await errorPageProvider.WriteErrorPageAsync(
+                context,
+                WellKnownPageNames.InvitationEmailMismatch,
+                StatusCodes.Status403Forbidden);
+
+            return;
+        }
+
+        if (exchangeResult == InviteExchangeResult.EmailUnavailable)
+        {
+            await errorPageProvider.WriteErrorPageAsync(
+                context,
+                WellKnownPageNames.InvitationEmailUnavailable,
+                StatusCodes.Status403Forbidden);
+
+            return;
+        }
+
+        if (exchangeResult == InviteExchangeResult.DuplicateSubject)
+        {
+            var subjectAlreadyExistsUrl = config.CurrentValue.Invite?.SubjectAlreadyExistsUrl;
+            if (!string.IsNullOrWhiteSpace(subjectAlreadyExistsUrl))
+            {
+                context.Response.Redirect(subjectAlreadyExistsUrl);
+            }
+            else
+            {
+                await errorPageProvider.WriteErrorPageAsync(
+                    context,
+                    WellKnownPageNames.InvitationSubjectAlreadyExists,
+                    StatusCodes.Status409Conflict);
+            }
+
+            return;
+        }
+
+        if (exchangeResult == InviteExchangeResult.Failed && IsAttestedProtocolEnabled())
+        {
+            await errorPageProvider.WriteErrorPageAsync(
+                context,
+                WellKnownPageNames.InvitationInvalid,
+                StatusCodes.Status403Forbidden);
+            return;
+        }
+
+        if (exchangeResult == InviteExchangeResult.Success && !IsTenantIssuedInvite(inviteToken, context))
+        {
+            var lobbyUrl = config.CurrentValue.Invite?.Lobby?.Frontend?.BaseUrl;
+            if (!string.IsNullOrWhiteSpace(lobbyUrl))
+            {
+                context.Items[LobbyRedirectUrlItemKey] = BuildLobbyRedirectUrlWithInvitationId(lobbyUrl, inviteToken);
+            }
+        }
+
+        await next(context);
+    }
 
     async Task<(bool Succeeded, InvitationEntryState? State)> StageInvitation(HttpContext context, string inviteToken)
     {
@@ -614,7 +692,7 @@ public class InviteMiddleware(
             invitationId,
             InvitationAttestationIssuer.CreateOpaqueValue(),
             InvitationAttestationIssuer.CreateOpaqueValue(),
-            ComputeCapabilityHash(inviteToken),
+            InvitationAuthenticationState.ComputeCapabilityHash(inviteToken),
             DateTimeOffset.UtcNow.AddMinutes(15));
         if (!attestationIssuer.TryIssueStage(entryState, out var attestation))
         {
@@ -658,7 +736,7 @@ public class InviteMiddleware(
             || !context.Request.Cookies.TryGetValue(Cookies.InvitationEntryState, out var protectedState)
             || !entryStateProtector.TryUnprotect(protectedState, out var entryState)
             || entryState.ExpiresAt <= DateTimeOffset.UtcNow
-            || !FixedTimeEquals(entryState.CapabilityHash, ComputeCapabilityHash(inviteToken))
+            || !FixedTimeEquals(entryState.CapabilityHash, InvitationAuthenticationState.ComputeCapabilityHash(inviteToken))
             || !TryGetSingleTokenClaim(inviteToken, JwtRegisteredClaimNames.Jti, out var invitationId)
             || !FixedTimeEquals(entryState.InvitationId, invitationId)
             || string.IsNullOrWhiteSpace(invite.TenantClaim)

--- a/Source/AuthProxy/Invites/InviteMiddlewareLogging.cs
+++ b/Source/AuthProxy/Invites/InviteMiddlewareLogging.cs
@@ -31,4 +31,7 @@ internal static partial class InviteMiddlewareLogging
 
     [LoggerMessage(LogLevel.Warning, "Invite exchange rejected because the authenticated subject is already associated with an existing user")]
     internal static partial void InviteSubjectAlreadyExists(this ILogger logger);
+
+    [LoggerMessage(LogLevel.Information, "Invitation not completed because the authenticated session was not established by this invitation's own challenge - taking the caller through provider selection instead")]
+    internal static partial void InviteSessionWasNotEstablishedByTheInvitation(this ILogger logger);
 }


### PR DESCRIPTION
## Fixed

- An invitation is now completed only with the identity that authenticated for that invitation. A session the browser was already carrying — from an earlier sign-in, possibly with a different provider — no longer completes a pending invitation, so an organization can no longer be bound permanently to an account the person did not choose for it.
- A caller who is already signed in and opens an invitation link is now always shown the invitation provider-selection page, including where only a single identity provider is configured, and the invitation completes with the identity that comes back from the provider they pick.
- A pending invitation is left in place when it cannot yet be completed, so it stays valid for the lifetime of the `.cratis-invite` cookie instead of being consumed by the wrong session.
- Invite-token re-validation at the post-login exchange is unchanged: a forged, expired, or otherwise invalid capability is still refused with `invitation-invalid.html` / `invitation-expired.html` and cleared from the browser before anything else is decided.
