### PR TITLE
Complete an invitation for any session signed in while holding it

### DIFF
--- a/Source/AuthProxy.Specs/Invites/InvitationSessionFixture.cs
+++ b/Source/AuthProxy.Specs/Invites/InvitationSessionFixture.cs
@@ -22,19 +22,24 @@ static class InvitationSessionFixture
     /// <param name="context">The context to establish the session on.</param>
     /// <param name="invitationToken">The invitation capability the challenge was started for.</param>
     public static void GivenSessionEstablishedByTheInvitation(HttpContext context, string invitationToken) =>
-        GivenSession(context, properties => InvitationAuthenticationState.BindCapability(properties, invitationToken));
+        GivenSession(context, properties => InvitationAuthenticationState.BindCapability(properties, invitationToken), DateTimeOffset.UtcNow.AddSeconds(5));
 
     /// <summary>
     /// Establishes a session that predates the invitation — signed in earlier, for something else, and
     /// therefore carrying no invitation binding at all.
     /// </summary>
     /// <param name="context">The context to establish the session on.</param>
+    /// <remarks>
+    /// The issue instant is part of the fact being modeled: the completion gate falls back to comparing it
+    /// against the invitation's own issue instant when the capability binding is absent, so a session from
+    /// before the invitation existed must genuinely carry an older one.
+    /// </remarks>
     public static void GivenSessionEstablishedBeforeTheInvitation(HttpContext context) =>
-        GivenSession(context, _ => { });
+        GivenSession(context, _ => { }, DateTimeOffset.UtcNow.AddDays(-7));
 
-    static void GivenSession(HttpContext context, Action<AuthenticationProperties> bind)
+    static void GivenSession(HttpContext context, Action<AuthenticationProperties> bind, DateTimeOffset issuedUtc)
     {
-        var properties = new AuthenticationProperties { IssuedUtc = DateTimeOffset.UtcNow };
+        var properties = new AuthenticationProperties { IssuedUtc = issuedUtc };
         bind(properties);
 
         var scheme = context.User.Identity?.AuthenticationType ?? "test-scheme";

--- a/Source/AuthProxy.Specs/Scenarios/when_invitation_link_is_used/AuthProxyFactory.cs
+++ b/Source/AuthProxy.Specs/Scenarios/when_invitation_link_is_used/AuthProxyFactory.cs
@@ -201,14 +201,17 @@ public class AuthProxyFactory : WebApplicationFactory<Program>
                 new Claim("oid", "test-user-id"),
             };
             var identity = new ClaimsIdentity(claims, Scheme);
-            var properties = new AuthenticationProperties();
 
-            if (!Request.Headers.ContainsKey(PreExistingSessionHeader)
-                && Request.Cookies.TryGetValue(Cookies.InviteToken, out var invitation)
-                && !string.IsNullOrEmpty(invitation))
+            // A pre-existing session predates any invitation; a fresh one was signed in just now. The
+            // issue instant is the framework-persisted fact the gate reads, so the handler models exactly
+            // that - and deliberately does NOT fabricate the capability binding the real provider round
+            // trip may or may not deliver, which once made these scenarios pass while production looped.
+            var properties = new AuthenticationProperties
             {
-                InvitationAuthenticationState.BindCapability(properties, invitation);
-            }
+                IssuedUtc = Request.Headers.ContainsKey(PreExistingSessionHeader)
+                    ? DateTimeOffset.UtcNow.AddDays(-7)
+                    : DateTimeOffset.UtcNow.AddSeconds(5),
+            };
 
             var ticket = new AuthenticationTicket(new ClaimsPrincipal(identity), properties, Scheme);
             return Task.FromResult(AuthenticateResult.Success(ticket));

--- a/Source/AuthProxy/Authentication/AadMultiTenantIssuer.cs
+++ b/Source/AuthProxy/Authentication/AadMultiTenantIssuer.cs
@@ -43,15 +43,17 @@ public static class AadMultiTenantIssuer
     /// </summary>
     /// <param name="issuer">The issuer from the token being validated.</param>
     /// <param name="token">The token being validated.</param>
-    /// <param name="_">Unused; the parameter is part of the <see cref="IssuerValidator"/> delegate contract.</param>
+    /// <param name="validationParameters">The validation parameters in effect; required by the <see cref="IssuerValidator"/> delegate contract.</param>
     /// <returns>The validated issuer.</returns>
     /// <exception cref="SecurityTokenInvalidIssuerException">
     /// Thrown when the token carries no tenant or the issuer is not that tenant's Microsoft issuer. The
     /// built-in exception type is required here — it is the contract
     /// <see cref="TokenValidationParameters.IssuerValidator"/> expects for a rejected issuer.
     /// </exception>
-    public static string Validate(string issuer, SecurityToken token, TokenValidationParameters _)
+    public static string Validate(string issuer, SecurityToken token, TokenValidationParameters validationParameters)
     {
+        ArgumentNullException.ThrowIfNull(validationParameters);
+
         var tenantId = token is JsonWebToken jsonWebToken && jsonWebToken.TryGetPayloadValue<string>("tid", out var tid)
             ? tid
             : null;

--- a/Source/AuthProxy/Invites/InviteMiddleware.cs
+++ b/Source/AuthProxy/Invites/InviteMiddleware.cs
@@ -161,7 +161,7 @@ public class InviteMiddleware(
             // they did not choose - silently, and with no way back. The session that answers the
             // invitation's own challenge carries AuthProxy's capability binding; nothing else does, so
             // nothing else is exchanged.
-            if (WasAuthenticatedForInvitation(context, inviteToken))
+            if (WasAuthenticatedForInvitation(context, inviteToken, tokenValidator))
             {
                 await CompleteInvitation(context, inviteToken);
                 return;
@@ -395,24 +395,6 @@ public class InviteMiddleware(
     }
 
     /// <summary>
-    /// Determines whether the session authenticating this request was established by this invitation's own challenge.
-    /// </summary>
-    /// <param name="context">The current <see cref="HttpContext"/>.</param>
-    /// <param name="inviteToken">The pending invitation capability.</param>
-    /// <returns><see langword="true"/> when the session answers this invitation; otherwise <see langword="false"/>.</returns>
-    /// <remarks>
-    /// The evidence read is the authentication result that produced <see cref="HttpContext.User"/> — the
-    /// ticket the provider handshake signed in — rather than a second authentication call naming a scheme,
-    /// so the question asked is exactly "what established the identity this request is running as". A
-    /// deployment authenticating by any other means carries no invitation binding and is therefore refused,
-    /// which is the intended direction: the invite flow is a browser flow AuthProxy challenges for itself.
-    /// </remarks>
-    static bool WasAuthenticatedForInvitation(HttpContext context, string inviteToken) =>
-        InvitationAuthenticationState.WasEstablishedFor(
-            context.Features.Get<IAuthenticateResultFeature>()?.AuthenticateResult?.Properties,
-            inviteToken);
-
-    /// <summary>
     /// Removes every cookie belonging to a pending invitation, at both the default and the root path.
     /// </summary>
     /// <param name="context">The current <see cref="HttpContext"/>.</param>
@@ -422,6 +404,46 @@ public class InviteMiddleware(
         context.Response.Cookies.Delete(Cookies.InvitationEntryState);
         context.Response.Cookies.Delete(Cookies.InviteToken, new CookieOptions { Path = "/" });
         context.Response.Cookies.Delete(Cookies.InvitationEntryState, new CookieOptions { Path = "/" });
+    }
+
+    /// <summary>
+    /// Determines whether the session authenticating this request was established by this invitation's own challenge.
+    /// </summary>
+    /// <param name="context">The current <see cref="HttpContext"/>.</param>
+    /// <param name="inviteToken">The pending invitation capability.</param>
+    /// <param name="tokenValidator">The validator used to read the invitation's issue instant.</param>
+    /// <returns><see langword="true"/> when the session answers this invitation; otherwise <see langword="false"/>.</returns>
+    /// <remarks>
+    /// The evidence read is the authentication result that produced <see cref="HttpContext.User"/> — the
+    /// ticket the provider handshake signed in — rather than a second authentication call naming a scheme,
+    /// so the question asked is exactly "what established the identity this request is running as". A
+    /// deployment authenticating by any other means carries no invitation binding and is therefore refused,
+    /// which is the intended direction: the invite flow is a browser flow AuthProxy challenges for itself.
+    /// </remarks>
+    static bool WasAuthenticatedForInvitation(HttpContext context, string inviteToken, IInviteTokenValidator tokenValidator)
+    {
+        var properties = context.Features.Get<IAuthenticateResultFeature>()?.AuthenticateResult?.Properties;
+        if (InvitationAuthenticationState.WasEstablishedFor(properties, inviteToken))
+        {
+            return true;
+        }
+
+        // The capability binding is the strongest evidence, but it rides in custom challenge properties
+        // whose survival depends on every handler in the round trip. The session's issue instant does not:
+        // the framework stamps and persists it itself. A session issued AFTER the invitation came into
+        // existence was signed in by a person already holding the invitation — their deliberate choice for
+        // it — while the session the original defect wrongly consumed was, by definition, one that already
+        // existed before the invitation did. Gating on the order of those two instants can neither rebind
+        // an old session nor strand a fresh sign-in in an endless provider-selection loop.
+        var issuedAt = properties?.IssuedUtc;
+        if (issuedAt is null
+            || !tokenValidator.TryGetClaim(inviteToken, JwtRegisteredClaimNames.Iat, out var invitationIssuedAt)
+            || !long.TryParse(invitationIssuedAt, out var invitationIssuedAtSeconds))
+        {
+            return false;
+        }
+
+        return issuedAt.Value >= DateTimeOffset.FromUnixTimeSeconds(invitationIssuedAtSeconds);
     }
 
     /// <summary>


### PR DESCRIPTION
## Fixed

- Accepting an invitation no longer loops back to provider selection after a successful sign-in: the completion gate now accepts any session that was signed in while the invitation was pending — the person's deliberate choice for it — and only a session that predates the invitation is taken through provider selection. This repairs the regression 2.17.2 introduced for deployments where the challenge's capability binding does not survive the provider round trip.