### PR TITLE
Complete an invitation on the sign-in callback itself

### DIFF
--- a/Source/AuthProxy.Specs/Invites/for_InvitationAuthenticationState/when_marking_an_invitation_completed.cs
+++ b/Source/AuthProxy.Specs/Invites/for_InvitationAuthenticationState/when_marking_an_invitation_completed.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.Invites.for_InvitationAuthenticationState;
+
+/// <summary>
+/// Completing an invitation replaces the pending capability binding with the completion record: the session
+/// stops claiming to have been established <em>for</em> the invitation — that claim would re-run the
+/// exchange the moment a stale pending cookie replays — and instead carries proof it already completed it.
+/// </summary>
+public class when_marking_an_invitation_completed : Specification
+{
+    const string Capability = "completed-capability";
+
+    AuthenticationProperties _properties;
+
+    void Establish()
+    {
+        _properties = new AuthenticationProperties();
+        _properties.Items[InvitationAuthenticationState.TransactionStateKey] = "transaction";
+        _properties.Items[InvitationAuthenticationState.ChallengeStateKey] = "challenge";
+        InvitationAuthenticationState.BindCapability(_properties, Capability);
+    }
+
+    void Because() => InvitationAuthenticationState.MarkCompleted(_properties, Capability);
+
+    [Fact]
+    void should_record_the_completed_capability() =>
+        _properties.Items[InvitationAuthenticationState.CompletedCapabilityHashStateKey]
+            .ShouldEqual(InvitationAuthenticationState.ComputeCapabilityHash(Capability));
+
+    [Fact]
+    void should_no_longer_claim_the_session_was_established_for_the_invitation() =>
+        InvitationAuthenticationState.WasEstablishedFor(_properties, Capability).ShouldBeFalse();
+
+    [Fact]
+    void should_remove_the_transaction() =>
+        _properties.Items.ContainsKey(InvitationAuthenticationState.TransactionStateKey).ShouldBeFalse();
+
+    [Fact]
+    void should_remove_the_challenge() =>
+        _properties.Items.ContainsKey(InvitationAuthenticationState.ChallengeStateKey).ShouldBeFalse();
+
+    [Fact]
+    void should_answer_completed_for_the_exact_capability() =>
+        InvitationAuthenticationState.WasCompletedFor(_properties, Capability).ShouldBeTrue();
+
+    [Fact]
+    void should_not_answer_completed_for_another_capability() =>
+        InvitationAuthenticationState.WasCompletedFor(_properties, "another-capability").ShouldBeFalse();
+
+    [Fact]
+    void should_not_answer_completed_for_a_session_without_the_record() =>
+        InvitationAuthenticationState.WasCompletedFor(new AuthenticationProperties(), Capability).ShouldBeFalse();
+}

--- a/Source/AuthProxy.Specs/Scenarios/when_invitation_completes_on_the_callback/CallbackAuthProxyFactory.cs
+++ b/Source/AuthProxy.Specs/Scenarios/when_invitation_completes_on_the_callback/CallbackAuthProxyFactory.cs
@@ -1,0 +1,253 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net;
+using Cratis.AuthProxy.Invites;
+using Microsoft.AspNetCore.Authentication.OAuth;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Cratis.AuthProxy.Scenarios.when_invitation_completes_on_the_callback;
+
+/// <summary>
+/// WebApplicationFactory that keeps AuthProxy's real authentication stack — the cookie scheme and one
+/// configured OAuth provider — and fakes only what lives outside the proxy: the identity provider's token
+/// and user-information endpoints, the invitation exchange endpoint, and the identity backend.
+/// </summary>
+/// <remarks>
+/// The provider handshake is driven for real: the invitation challenge protects its state (including the
+/// invitation capability binding) with the same machinery production uses, and the callback unprotects it
+/// the same way. Nothing fabricates the binding — a session only carries it because the challenge that
+/// established the session bound it, which is exactly the evidence the callback completion trusts.
+/// </remarks>
+public class CallbackAuthProxyFactory : WebApplicationFactory<Program>
+{
+    public const string ProviderName = "TestIdp";
+    public const string ProviderScheme = "testidp";
+    public const string ExchangeUrl = "http://exchange.test/invites/exchange";
+    public const string IdentityBackendBaseUrl = "http://identity.test/";
+    public const string LobbyUrl = "http://lobby.test/";
+    public const string SubjectAlreadyExistsUrl = "http://lobby.test/already-a-member";
+    public const string TenantId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    public const string TenantClaim = "tenant_id";
+    public const string SessionCookieName = ".Cratis.AuthProxy.Auth.v2";
+
+    readonly string _pagesPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+    int _exchangeCallCount;
+
+    /// <summary>Initializes a new instance of the <see cref="CallbackAuthProxyFactory"/> class.</summary>
+    public CallbackAuthProxyFactory()
+    {
+        Directory.CreateDirectory(_pagesPath);
+        File.WriteAllText(Path.Combine(_pagesPath, "invitation-expired.html"), "<html><body><h1>Invitation Expired</h1></body></html>");
+        File.WriteAllText(Path.Combine(_pagesPath, "invitation-invalid.html"), "<html><body><h1>Invitation Invalid</h1></body></html>");
+        File.WriteAllText(Path.Combine(_pagesPath, "invitation-select-provider.html"), "<html><body><h1>Select Provider</h1></body></html>");
+        File.WriteAllText(Path.Combine(_pagesPath, "invitation-subject-already-exists.html"), "<html><body><h1>Already A Member</h1></body></html>");
+    }
+
+    public (RsaSecurityKey PrivateKey, string PublicKeyPem) InviteKeyPair { get; } = TokenFixture.GenerateKeyPair();
+
+    public int ExchangeCallCount => _exchangeCallCount;
+
+    /// <summary>Gets or sets the status the faked invitation exchange endpoint answers with.</summary>
+    public HttpStatusCode ExchangeStatusCode { get; set; } = HttpStatusCode.OK;
+
+    /// <summary>
+    /// Extracts the reusable <c>name=value</c> cookie pairs a response set, skipping deletions.
+    /// </summary>
+    /// <param name="response">The response whose cookies to collect.</param>
+    /// <returns>The cookie pairs, ready for a <c>Cookie</c> request header.</returns>
+    public static IReadOnlyList<string> CookiesFrom(HttpResponseMessage response) =>
+        response.Headers.TryGetValues("Set-Cookie", out var setCookies)
+            ? setCookies
+                .Select(setCookie => setCookie.Split(';')[0])
+                .Where(pair => pair.Split('=', 2) is [_, { Length: > 0 }])
+                .ToArray()
+            : [];
+
+    /// <summary>
+    /// Creates an <see cref="HttpClient"/> that does not follow redirects, so every hop of the flow can be
+    /// inspected and its cookies carried forward explicitly — the way a spec plays the browser.
+    /// </summary>
+    /// <returns>A configured <see cref="HttpClient"/>.</returns>
+    public HttpClient CreateBrowser() =>
+        CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+    /// <summary>
+    /// Starts the provider challenge at <paramref name="path"/> and answers it on the callback, exactly as
+    /// the browser and the identity provider would between them.
+    /// </summary>
+    /// <param name="browser">The client playing the browser.</param>
+    /// <param name="path">The path that starts the challenge (an invitation URL or a login endpoint).</param>
+    /// <param name="extraCallbackCookie">An additional cookie pair the browser presents on the callback only.</param>
+    /// <returns>The whole round trip: both responses and the cookies each one set.</returns>
+    public async Task<ProviderSignIn> SignInThroughProvider(HttpClient browser, string path, string? extraCallbackCookie = null)
+    {
+        var challenge = await browser.GetAsync(path);
+        var challengeCookies = CookiesFrom(challenge);
+        var state = ExtractState(challenge.Headers.Location);
+
+        using var callbackRequest = new HttpRequestMessage(HttpMethod.Get, $"/signin-{ProviderScheme}?code=test-code&state={state}");
+        var callbackCookies = challengeCookies.ToList();
+        if (extraCallbackCookie is not null)
+        {
+            callbackCookies.Add(extraCallbackCookie);
+        }
+
+        if (callbackCookies.Count > 0)
+        {
+            callbackRequest.Headers.Add("Cookie", string.Join("; ", callbackCookies));
+        }
+
+        var callback = await browser.SendAsync(callbackRequest);
+        return new ProviderSignIn(challenge, callback, challengeCookies, CookiesFrom(callback));
+    }
+
+    /// <inheritdoc/>
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        // The Development appsettings ship a placeholder Microsoft provider; running as Production keeps
+        // the configured TestIdp provider the invitation's only one, so the challenge goes straight to it.
+        builder.UseEnvironment("Production");
+
+        // Provider registration happens inside Program before deferred configuration callbacks run, so the
+        // configuration is supplied through settings - those reach WebApplication.CreateBuilder itself and
+        // are visible when the authentication stack reads them at startup.
+        foreach (var (key, value) in new Dictionary<string, string?>
+        {
+            [$"{C.AuthProxy.SectionKey}:Invite:PublicKeyPem"] = InviteKeyPair.PublicKeyPem,
+            [$"{C.AuthProxy.SectionKey}:Invite:ExchangeUrl"] = ExchangeUrl,
+            [$"{C.AuthProxy.SectionKey}:Invite:Lobby:Frontend:BaseUrl"] = LobbyUrl,
+            [$"{C.AuthProxy.SectionKey}:Invite:SubjectAlreadyExistsUrl"] = SubjectAlreadyExistsUrl,
+            [$"{C.AuthProxy.SectionKey}:Invite:TenantClaim"] = TenantClaim,
+            [$"{C.AuthProxy.SectionKey}:Invite:AppendInvitationIdToQueryString"] = "true",
+            [$"{C.AuthProxy.SectionKey}:TenantResolutions:0:Strategy"] = nameof(C.TenantSourceIdentifierResolverType.Specified),
+            [$"{C.AuthProxy.SectionKey}:TenantResolutions:0:Options:TenantId"] = TenantId,
+            [$"{C.AuthProxy.SectionKey}:PagesPath"] = _pagesPath,
+            [$"{C.Authentication.SectionKey}:OAuthProviders:0:Name"] = ProviderName,
+            [$"{C.Authentication.SectionKey}:OAuthProviders:0:AuthorizationEndpoint"] = "http://idp.test/authorize",
+            [$"{C.Authentication.SectionKey}:OAuthProviders:0:TokenEndpoint"] = "http://idp.test/token",
+            [$"{C.Authentication.SectionKey}:OAuthProviders:0:UserInformationEndpoint"] = "http://idp.test/user",
+            [$"{C.Authentication.SectionKey}:OAuthProviders:0:ClientId"] = "test-client",
+            [$"{C.Authentication.SectionKey}:OAuthProviders:0:ClientSecret"] = "test-secret",
+            [$"{C.Authentication.SectionKey}:OAuthProviders:0:ClaimMappings:sub"] = "id",
+            [$"{C.Authentication.SectionKey}:OAuthProviders:0:ClaimMappings:email"] = "email",
+            [$"{C.Authentication.SectionKey}:OAuthProviders:0:ClaimMappings:email_verified"] = "email_verified",
+        })
+        {
+            builder.UseSetting(key, value);
+        }
+
+        builder.ConfigureTestServices(services =>
+        {
+            // The identity provider's back channel - the token and user-information endpoints the OAuth
+            // handler calls during the real handshake.
+            services.PostConfigure<OAuthOptions>(ProviderScheme, options =>
+                options.Backchannel = new HttpClient(new FakeIdentityProvider()) { Timeout = TimeSpan.FromSeconds(10) });
+
+            // Everything AuthProxy itself calls out to: the invitation exchange and the identity backend.
+            services.AddSingleton<IHttpClientFactory>(new TestHttpClientFactory(request =>
+            {
+                var url = request.RequestUri?.ToString() ?? string.Empty;
+
+                if (url.StartsWith(ExchangeUrl, StringComparison.OrdinalIgnoreCase))
+                {
+                    Interlocked.Increment(ref _exchangeCallCount);
+                    return new HttpResponseMessage(ExchangeStatusCode);
+                }
+
+                if (url.StartsWith(IdentityBackendBaseUrl, StringComparison.OrdinalIgnoreCase))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(/*lang=json,strict*/ "{\"displayName\":\"Test User\"}")
+                    };
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            }));
+        });
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        if (disposing && Directory.Exists(_pagesPath))
+        {
+            Directory.Delete(_pagesPath, recursive: true);
+        }
+    }
+
+    static string ExtractState(Uri? location)
+    {
+        foreach (var pair in (location?.Query ?? string.Empty).TrimStart('?').Split('&'))
+        {
+            if (pair.StartsWith("state=", StringComparison.Ordinal))
+            {
+                return pair["state=".Length..];
+            }
+        }
+
+        throw new InvalidOperationException($"No state parameter on the challenge redirect '{location}'");
+    }
+
+    /// <summary>One full provider round trip: the challenge, the callback, and the cookies each set.</summary>
+    /// <param name="Challenge">The response that redirected the browser to the identity provider.</param>
+    /// <param name="Callback">The response answering the provider callback.</param>
+    /// <param name="ChallengeCookies">The cookie pairs the challenge set.</param>
+    /// <param name="CallbackCookies">The cookie pairs the callback set.</param>
+    public sealed record ProviderSignIn(
+        HttpResponseMessage Challenge,
+        HttpResponseMessage Callback,
+        IReadOnlyList<string> ChallengeCookies,
+        IReadOnlyList<string> CallbackCookies);
+
+    sealed class FakeIdentityProvider : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var url = request.RequestUri?.ToString() ?? string.Empty;
+
+            if (url.StartsWith("http://idp.test/token", StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        /*lang=json,strict*/ "{\"access_token\":\"test-access-token\",\"token_type\":\"Bearer\"}",
+                        System.Text.Encoding.UTF8,
+                        "application/json")
+                });
+            }
+
+            if (url.StartsWith("http://idp.test/user", StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        /*lang=json,strict*/ "{\"id\":\"provider-user-1\",\"email\":\"invitee@example.com\",\"email_verified\":\"true\"}",
+                        System.Text.Encoding.UTF8,
+                        "application/json")
+                });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+    }
+
+    sealed class TestHttpClientFactory(Func<HttpRequestMessage, HttpResponseMessage> handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) =>
+            new(new DispatchingHandler(handler)) { Timeout = TimeSpan.FromSeconds(10) };
+
+        sealed class DispatchingHandler(Func<HttpRequestMessage, HttpResponseMessage> handler) : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+                Task.FromResult(handler(request));
+        }
+    }
+}

--- a/Source/AuthProxy.Specs/Scenarios/when_invitation_completes_on_the_callback/and_the_browser_replays_the_pending_invitation_cookie.cs
+++ b/Source/AuthProxy.Specs/Scenarios/when_invitation_completes_on_the_callback/and_the_browser_replays_the_pending_invitation_cookie.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Invites;
+
+namespace Cratis.AuthProxy.Scenarios.when_invitation_completes_on_the_callback;
+
+/// <summary>
+/// End-to-end scenario: the invitation completed on the callback, but the browser replays the invitation
+/// URL together with a stale pending-invitation cookie — the very cookie lag that motivated completing on
+/// the callback. The session carries the completion record, so nothing is exchanged again and nothing is
+/// offered for selection again: the stale cookie is cleared and the browser lands at the lobby, exactly
+/// where the completed invitation leads.
+/// </summary>
+/// <param name="factory">The shared application factory.</param>
+public class and_the_browser_replays_the_pending_invitation_cookie(CallbackAuthProxyFactory factory) : IClassFixture<CallbackAuthProxyFactory>, IAsyncLifetime
+{
+    string _invitationId;
+    HttpResponseMessage _replay;
+    int _exchangeCallsDuringFlow;
+
+    public async Task InitializeAsync()
+    {
+        _invitationId = Guid.NewGuid().ToString();
+        var token = TokenFixture.CreateToken(
+            factory.InviteKeyPair.PrivateKey,
+            additionalClaims: [new Claim("jti", _invitationId)]);
+
+        using var browser = factory.CreateBrowser();
+        var exchangeCallsBefore = factory.ExchangeCallCount;
+        var signIn = await factory.SignInThroughProvider(browser, $"/invite/{token}");
+
+        using var replayRequest = new HttpRequestMessage(HttpMethod.Get, $"/invite/{token}");
+        replayRequest.Headers.Add(
+            "Cookie",
+            string.Join("; ", signIn.CallbackCookies.Append($"{Cookies.InviteToken}={token}")));
+        _replay = await browser.SendAsync(replayRequest);
+        _exchangeCallsDuringFlow = factory.ExchangeCallCount - exchangeCallsBefore;
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public void should_not_exchange_a_second_time() =>
+        Assert.Equal(1, _exchangeCallsDuringFlow);
+
+    [Fact]
+    public void should_redirect_the_replay_to_the_lobby() =>
+        Assert.Equal(
+            $"{CallbackAuthProxyFactory.LobbyUrl}?invitationId={_invitationId}",
+            _replay.Headers.Location?.ToString());
+
+    [Fact]
+    public void should_clear_the_stale_pending_invitation_cookie()
+    {
+        _replay.Headers.TryGetValues("Set-Cookie", out var cookies);
+        Assert.Contains(
+            cookies ?? [],
+            cookie => cookie.StartsWith($"{Cookies.InviteToken}=;", StringComparison.Ordinal));
+    }
+}

--- a/Source/AuthProxy.Specs/Scenarios/when_invitation_completes_on_the_callback/and_the_capability_does_not_survive_the_round_trip.cs
+++ b/Source/AuthProxy.Specs/Scenarios/when_invitation_completes_on_the_callback/and_the_capability_does_not_survive_the_round_trip.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Invites;
+
+namespace Cratis.AuthProxy.Scenarios.when_invitation_completes_on_the_callback;
+
+/// <summary>
+/// End-to-end scenario: a provider callback arrives with a pending invitation cookie but without the
+/// invitation's own capability binding — the challenge was started for something else entirely. Nothing is
+/// exchanged on the callback and the pending invitation is left alone; the post-login middleware remains the
+/// one to answer it, and does, on the follow-up request the real session cookie authenticates.
+/// </summary>
+/// <param name="factory">The shared application factory.</param>
+public class and_the_capability_does_not_survive_the_round_trip(CallbackAuthProxyFactory factory) : IClassFixture<CallbackAuthProxyFactory>, IAsyncLifetime
+{
+    string _invitationId;
+    string _token;
+    CallbackAuthProxyFactory.ProviderSignIn _signIn;
+    HttpResponseMessage _followUp;
+    int _exchangeCallsDuringCallback;
+    int _exchangeCallsDuringFollowUp;
+
+    public async Task InitializeAsync()
+    {
+        _invitationId = Guid.NewGuid().ToString();
+        _token = TokenFixture.CreateToken(
+            factory.InviteKeyPair.PrivateKey,
+            additionalClaims: [new Claim("jti", _invitationId)]);
+
+        using var browser = factory.CreateBrowser();
+
+        // The challenge starts from the plain login endpoint, so its state carries no invitation binding;
+        // the pending invitation cookie appears on the callback only - opened in another tab meanwhile.
+        var exchangeCallsBefore = factory.ExchangeCallCount;
+        _signIn = await factory.SignInThroughProvider(
+            browser,
+            $"/.cratis/login/{CallbackAuthProxyFactory.ProviderScheme}?returnUrl=/",
+            extraCallbackCookie: $"{Cookies.InviteToken}={_token}");
+        _exchangeCallsDuringCallback = factory.ExchangeCallCount - exchangeCallsBefore;
+
+        using var followUpRequest = new HttpRequestMessage(HttpMethod.Get, "/");
+        followUpRequest.Headers.Add(
+            "Cookie",
+            string.Join("; ", _signIn.CallbackCookies.Append($"{Cookies.InviteToken}={_token}")));
+        _followUp = await browser.SendAsync(followUpRequest);
+        _exchangeCallsDuringFollowUp = factory.ExchangeCallCount - exchangeCallsBefore - _exchangeCallsDuringCallback;
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public void should_redirect_the_callback_to_its_own_return_url() =>
+        Assert.Equal("/", _signIn.Callback.Headers.Location?.ToString());
+
+    [Fact]
+    public void should_leave_the_pending_invitation_in_place_on_the_callback()
+    {
+        _signIn.Callback.Headers.TryGetValues("Set-Cookie", out var cookies);
+        Assert.DoesNotContain(
+            cookies ?? [],
+            cookie => cookie.StartsWith($"{Cookies.InviteToken}=;", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void should_not_exchange_on_the_callback() =>
+        Assert.Equal(0, _exchangeCallsDuringCallback);
+
+    [Fact]
+    public void should_complete_the_invitation_through_the_middleware_on_the_follow_up() =>
+        Assert.Equal(
+            $"{CallbackAuthProxyFactory.LobbyUrl}?invitationId={_invitationId}",
+            _followUp.Headers.Location?.ToString());
+
+    [Fact]
+    public void should_exchange_exactly_once_on_the_follow_up() =>
+        Assert.Equal(1, _exchangeCallsDuringFollowUp);
+}

--- a/Source/AuthProxy.Specs/Scenarios/when_invitation_completes_on_the_callback/and_the_capability_survives_the_round_trip.cs
+++ b/Source/AuthProxy.Specs/Scenarios/when_invitation_completes_on_the_callback/and_the_capability_survives_the_round_trip.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Invites;
+
+namespace Cratis.AuthProxy.Scenarios.when_invitation_completes_on_the_callback;
+
+/// <summary>
+/// End-to-end scenario: an invitation is opened, its single provider is challenged, and the provider calls
+/// back with the challenge's own capability binding intact. The invitation is exchanged on the callback
+/// itself — before any redirect is answered — so no follow-up request, and no cookie round-trip, stands
+/// between the sign-in and the completed invitation. The browser is signed in and sent straight to the
+/// lobby, never to a second provider selection.
+/// </summary>
+/// <param name="factory">The shared application factory.</param>
+public class and_the_capability_survives_the_round_trip(CallbackAuthProxyFactory factory) : IClassFixture<CallbackAuthProxyFactory>, IAsyncLifetime
+{
+    string _invitationId;
+    CallbackAuthProxyFactory.ProviderSignIn _signIn;
+    int _exchangeCallsDuringFlow;
+
+    public async Task InitializeAsync()
+    {
+        _invitationId = Guid.NewGuid().ToString();
+        var token = TokenFixture.CreateToken(
+            factory.InviteKeyPair.PrivateKey,
+            additionalClaims: [new Claim("jti", _invitationId)]);
+
+        using var browser = factory.CreateBrowser();
+        var exchangeCallsBefore = factory.ExchangeCallCount;
+        _signIn = await factory.SignInThroughProvider(browser, $"/invite/{token}");
+        _exchangeCallsDuringFlow = factory.ExchangeCallCount - exchangeCallsBefore;
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public void should_challenge_the_provider_for_the_invitation() =>
+        Assert.StartsWith("http://idp.test/authorize", _signIn.Challenge.Headers.Location?.ToString());
+
+    [Fact]
+    public void should_call_the_exchange_endpoint_on_the_callback() =>
+        Assert.Equal(1, _exchangeCallsDuringFlow);
+
+    [Fact]
+    public void should_redirect_the_callback_to_the_lobby_with_the_invitation_id() =>
+        Assert.Equal(
+            $"{CallbackAuthProxyFactory.LobbyUrl}?invitationId={_invitationId}",
+            _signIn.Callback.Headers.Location?.ToString());
+
+    [Fact]
+    public void should_establish_the_session()
+    {
+        Assert.Contains(
+            _signIn.CallbackCookies,
+            cookie => cookie.StartsWith(CallbackAuthProxyFactory.SessionCookieName, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void should_delete_the_pending_invitation_cookie()
+    {
+        _signIn.Callback.Headers.TryGetValues("Set-Cookie", out var cookies);
+        Assert.Contains(
+            cookies ?? [],
+            cookie => cookie.StartsWith($"{Cookies.InviteToken}=;", StringComparison.Ordinal));
+    }
+}

--- a/Source/AuthProxy.Specs/Scenarios/when_invitation_completes_on_the_callback/and_the_invitation_is_tenant_issued.cs
+++ b/Source/AuthProxy.Specs/Scenarios/when_invitation_completes_on_the_callback/and_the_invitation_is_tenant_issued.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.Invites;
+
+namespace Cratis.AuthProxy.Scenarios.when_invitation_completes_on_the_callback;
+
+/// <summary>
+/// End-to-end scenario: the invitation was issued by the tenant the request is served for, so a completed
+/// invitation does not leave for the lobby — the exchange still runs on the callback, but the browser is
+/// redirected to the challenge's own return URL exactly as any other sign-in would be.
+/// </summary>
+/// <param name="factory">The shared application factory.</param>
+public class and_the_invitation_is_tenant_issued(CallbackAuthProxyFactory factory) : IClassFixture<CallbackAuthProxyFactory>, IAsyncLifetime
+{
+    string _token;
+    CallbackAuthProxyFactory.ProviderSignIn _signIn;
+    int _exchangeCallsDuringFlow;
+
+    public async Task InitializeAsync()
+    {
+        _token = TokenFixture.CreateToken(
+            factory.InviteKeyPair.PrivateKey,
+            additionalClaims:
+            [
+                new Claim("jti", Guid.NewGuid().ToString()),
+                new Claim(CallbackAuthProxyFactory.TenantClaim, CallbackAuthProxyFactory.TenantId),
+            ]);
+
+        using var browser = factory.CreateBrowser();
+        var exchangeCallsBefore = factory.ExchangeCallCount;
+        _signIn = await factory.SignInThroughProvider(browser, $"/invite/{_token}");
+        _exchangeCallsDuringFlow = factory.ExchangeCallCount - exchangeCallsBefore;
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public void should_call_the_exchange_endpoint_on_the_callback() =>
+        Assert.Equal(1, _exchangeCallsDuringFlow);
+
+    [Fact]
+    public void should_preserve_the_return_url() =>
+        Assert.Equal($"/invite/{_token}", _signIn.Callback.Headers.Location?.ToString());
+
+    [Fact]
+    public void should_establish_the_session()
+    {
+        Assert.Contains(
+            _signIn.CallbackCookies,
+            cookie => cookie.StartsWith(CallbackAuthProxyFactory.SessionCookieName, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void should_delete_the_pending_invitation_cookie()
+    {
+        _signIn.Callback.Headers.TryGetValues("Set-Cookie", out var cookies);
+        Assert.Contains(
+            cookies ?? [],
+            cookie => cookie.StartsWith($"{Cookies.InviteToken}=;", StringComparison.Ordinal));
+    }
+}

--- a/Source/AuthProxy.Specs/Scenarios/when_invitation_completes_on_the_callback/and_the_subject_already_exists.cs
+++ b/Source/AuthProxy.Specs/Scenarios/when_invitation_completes_on_the_callback/and_the_subject_already_exists.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net;
+using Cratis.AuthProxy.Invites;
+
+namespace Cratis.AuthProxy.Scenarios.when_invitation_completes_on_the_callback;
+
+/// <summary>
+/// End-to-end scenario: the exchange on the callback answers with a conflict — the authenticated subject
+/// already belongs to an existing user. The callback produces the same outcome the post-login exchange
+/// produces today: the pending invitation is cleared and the signed-in browser is redirected to the
+/// configured subject-already-exists page.
+/// </summary>
+/// <param name="factory">The shared application factory.</param>
+public class and_the_subject_already_exists(CallbackAuthProxyFactory factory) : IClassFixture<CallbackAuthProxyFactory>, IAsyncLifetime
+{
+    CallbackAuthProxyFactory.ProviderSignIn _signIn;
+    int _exchangeCallsDuringFlow;
+
+    public async Task InitializeAsync()
+    {
+        factory.ExchangeStatusCode = HttpStatusCode.Conflict;
+        var token = TokenFixture.CreateToken(
+            factory.InviteKeyPair.PrivateKey,
+            additionalClaims: [new Claim("jti", Guid.NewGuid().ToString())]);
+
+        using var browser = factory.CreateBrowser();
+        var exchangeCallsBefore = factory.ExchangeCallCount;
+        _signIn = await factory.SignInThroughProvider(browser, $"/invite/{token}");
+        _exchangeCallsDuringFlow = factory.ExchangeCallCount - exchangeCallsBefore;
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public void should_call_the_exchange_endpoint_on_the_callback() =>
+        Assert.Equal(1, _exchangeCallsDuringFlow);
+
+    [Fact]
+    public void should_redirect_to_the_subject_already_exists_page() =>
+        Assert.Equal(CallbackAuthProxyFactory.SubjectAlreadyExistsUrl, _signIn.Callback.Headers.Location?.ToString());
+
+    [Fact]
+    public void should_still_establish_the_session()
+    {
+        Assert.Contains(
+            _signIn.CallbackCookies,
+            cookie => cookie.StartsWith(CallbackAuthProxyFactory.SessionCookieName, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void should_delete_the_pending_invitation_cookie()
+    {
+        _signIn.Callback.Headers.TryGetValues("Set-Cookie", out var cookies);
+        Assert.Contains(
+            cookies ?? [],
+            cookie => cookie.StartsWith($"{Cookies.InviteToken}=;", StringComparison.Ordinal));
+    }
+}

--- a/Source/AuthProxy/Authentication/AuthenticationServiceCollectionExtensions.cs
+++ b/Source/AuthProxy/Authentication/AuthenticationServiceCollectionExtensions.cs
@@ -475,7 +475,18 @@ public static class AuthenticationServiceCollectionExtensions
         var notifier = context.HttpContext.RequestServices.GetRequiredService<ISignInNotifier>();
         await notifier.Notify(context.HttpContext, context.Principal, context.Scheme.Name);
 
-        if (context.Properties is not null
+        // A callback answering a pending invitation's own challenge completes the invitation here, on the
+        // callback itself, so no follow-up request — and no cookie round-trip — stands between the sign-in
+        // and the completed invitation. Every other callback, including one whose invitation binding did not
+        // survive the provider round-trip, is untouched and remains the invite middleware's to answer.
+        var inviteCompletion = await InviteCallbackCompletion.TryComplete(context);
+        if (inviteCompletion == InviteCallbackCompletionResult.ResponseHandled)
+        {
+            return;
+        }
+
+        if (inviteCompletion != InviteCallbackCompletionResult.CompletedWithRedirect
+            && context.Properties is not null
             && TenantAuthenticationState.TryResolvePostAuthenticationRedirectUri(
                 context.HttpContext,
                 context.Properties,

--- a/Source/AuthProxy/Invites/IInviteCompletion.cs
+++ b/Source/AuthProxy/Invites/IInviteCompletion.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.Invites;
+
+/// <summary>
+/// Defines the one implementation of the invitation exchange — the call that hands a validated invitation
+/// capability and the identity that answered its challenge to the invitation authority.
+/// </summary>
+/// <remarks>
+/// Two callers complete invitations and must produce identical exchanges: <see cref="InviteMiddleware"/>
+/// completes them on the first authenticated request that carries the pending invitation (Phase 2), and
+/// <see cref="InviteCallbackCompletion"/> completes them on the provider callback itself so no follow-up
+/// request — and no cookie round-trip — stands between the sign-in and the completed invitation.
+/// </remarks>
+interface IInviteCompletion
+{
+    /// <summary>
+    /// Runs the invitation exchange for a request whose session was already established — the post-login
+    /// middleware path.
+    /// </summary>
+    /// <param name="context">The current <see cref="HttpContext"/>.</param>
+    /// <param name="inviteToken">The re-validated invitation capability.</param>
+    /// <returns>The outcome of the exchange.</returns>
+    Task<InviteExchangeResult> ExchangeForRequest(HttpContext context, string inviteToken);
+
+    /// <summary>
+    /// Runs the invitation exchange for a freshly received provider ticket — the callback path, where the
+    /// session is about to be established rather than already authenticated.
+    /// </summary>
+    /// <param name="context">The current <see cref="HttpContext"/>.</param>
+    /// <param name="inviteToken">The re-validated invitation capability.</param>
+    /// <param name="principal">The freshly authenticated principal from the ticket.</param>
+    /// <param name="properties">The round-tripped challenge properties from the ticket.</param>
+    /// <returns>The outcome of the exchange.</returns>
+    Task<InviteExchangeResult> ExchangeForTicket(HttpContext context, string inviteToken, ClaimsPrincipal principal, AuthenticationProperties properties);
+
+    /// <summary>
+    /// Resolves where a successfully completed, non-tenant-issued invitation should take the browser.
+    /// </summary>
+    /// <param name="context">The current <see cref="HttpContext"/>.</param>
+    /// <param name="inviteToken">The completed invitation capability.</param>
+    /// <param name="lobbyRedirectUrl">The lobby frontend URL, with the invitation id appended when configured.</param>
+    /// <returns>
+    /// <see langword="true"/> when the invitation is not tenant-issued and a lobby frontend is configured;
+    /// otherwise <see langword="false"/>, meaning the browser stays on its current course.
+    /// </returns>
+    bool TryResolveLobbyRedirect(HttpContext context, string inviteToken, out string lobbyRedirectUrl);
+}

--- a/Source/AuthProxy/Invites/InvitationAuthenticationState.cs
+++ b/Source/AuthProxy/Invites/InvitationAuthenticationState.cs
@@ -29,6 +29,12 @@ public static class InvitationAuthenticationState
     public const string CapabilityHashStateKey = "Cratis.AuthProxy.InvitationCapabilityHash";
 
     /// <summary>
+    /// The authentication-properties key recording the exact invitation capability a session has already
+    /// completed the exchange for.
+    /// </summary>
+    public const string CompletedCapabilityHashStateKey = "Cratis.AuthProxy.InvitationCompletedCapabilityHash";
+
+    /// <summary>
     /// Adds protected pending-invitation values to provider challenge properties when an invitation is in progress.
     /// </summary>
     /// <param name="context">The current HTTP context.</param>
@@ -103,6 +109,38 @@ public static class InvitationAuthenticationState
         && properties.Items.TryGetValue(CapabilityHashStateKey, out var boundCapabilityHash)
         && !string.IsNullOrEmpty(boundCapabilityHash)
         && FixedTimeEquals(ComputeCapabilityHash(invitationToken), boundCapabilityHash);
+
+    /// <summary>
+    /// Records on a session's authentication properties that its invitation exchange has completed, so no
+    /// later request can run the exchange for the same capability again.
+    /// </summary>
+    /// <param name="properties">The properties of the session that completed the invitation.</param>
+    /// <param name="invitationToken">The invitation capability that was completed.</param>
+    /// <remarks>
+    /// The pending binding is replaced rather than kept alongside the completion record: a capability that
+    /// has been exchanged is no longer pending, and a session still claiming to have been established
+    /// <em>for</em> it would re-run the exchange the moment a stale pending-invitation cookie replays — the
+    /// application answers that with a duplicate-subject conflict for an invitation that actually succeeded.
+    /// </remarks>
+    internal static void MarkCompleted(AuthenticationProperties properties, string invitationToken)
+    {
+        properties.Items.Remove(TransactionStateKey);
+        properties.Items.Remove(ChallengeStateKey);
+        properties.Items.Remove(CapabilityHashStateKey);
+        properties.Items[CompletedCapabilityHashStateKey] = ComputeCapabilityHash(invitationToken);
+    }
+
+    /// <summary>
+    /// Determines whether a session has already completed the exchange for one exact invitation capability.
+    /// </summary>
+    /// <param name="properties">The properties of the session authenticating the request.</param>
+    /// <param name="invitationToken">The invitation capability being offered.</param>
+    /// <returns><see langword="true"/> when the session already completed that exact capability; otherwise <see langword="false"/>.</returns>
+    internal static bool WasCompletedFor(AuthenticationProperties? properties, string invitationToken) =>
+        properties is not null
+        && properties.Items.TryGetValue(CompletedCapabilityHashStateKey, out var completedCapabilityHash)
+        && !string.IsNullOrEmpty(completedCapabilityHash)
+        && FixedTimeEquals(ComputeCapabilityHash(invitationToken), completedCapabilityHash);
 
     /// <summary>
     /// Computes the hash that identifies one exact invitation capability.

--- a/Source/AuthProxy/Invites/InvitationCompletionSession.cs
+++ b/Source/AuthProxy/Invites/InvitationCompletionSession.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.AuthProxy.Invites;
+
+/// <summary>
+/// The authenticated-session evidence offered for an invitation exchange.
+/// </summary>
+/// <param name="Succeeded">Whether the session authenticated successfully.</param>
+/// <param name="Principal">The authenticated principal the invitation would be completed with.</param>
+/// <param name="Properties">The authentication properties that establish the session.</param>
+/// <param name="AuthenticatedAt">The instant the session was authenticated.</param>
+/// <remarks>
+/// The two callers of <see cref="IInviteCompletion"/> hold this evidence in different shapes. The post-login
+/// middleware reads the established cookie session, whose properties carry the framework-stamped issue
+/// instant. The provider callback holds the freshly received ticket instead — its properties are the
+/// round-tripped challenge properties, which no handler has stamped yet, so the callback supplies the moment
+/// the ticket was received as the authentication instant: that is literally when this authentication
+/// happened.
+/// </remarks>
+sealed record InvitationCompletionSession(
+    bool Succeeded,
+    ClaimsPrincipal? Principal,
+    AuthenticationProperties? Properties,
+    DateTimeOffset? AuthenticatedAt);

--- a/Source/AuthProxy/Invites/InviteCallbackCompletion.cs
+++ b/Source/AuthProxy/Invites/InviteCallbackCompletion.cs
@@ -1,0 +1,180 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.AuthProxy.ErrorPages;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+using C = Cratis.AuthProxy.Configuration;
+
+namespace Cratis.AuthProxy.Invites;
+
+/// <summary>
+/// Completes a pending invitation on the provider callback itself, so no follow-up request stands between
+/// the sign-in and the completed invitation.
+/// </summary>
+/// <remarks>
+/// The post-login exchange in <see cref="InviteMiddleware"/> depends on the browser presenting the fresh
+/// session cookie on the request after the callback's redirect — and browsers have been observed to send
+/// that follow-up request without it. The middleware then sees an unauthenticated request and serves the
+/// invitation's provider selection a second time, which is how every invitation acceptance grew a second,
+/// confusing selection page. Completing on the callback removes the dependency: the exchange runs while the
+/// freshly authenticated ticket is in hand, before any redirect is answered.
+/// <para>
+/// A callback is an invitation's own only when the round-tripped challenge properties carry the capability
+/// binding for the exact pending invitation — the binding placed there when the challenge was started
+/// (<see cref="InvitationAuthenticationState"/>). A callback without it — a deployment where the binding
+/// does not survive the provider round-trip, a sign-in unrelated to the pending invitation — is left
+/// entirely alone, and the middleware's Phase 2 answers the follow-up request exactly as it always has.
+/// </para>
+/// <para>
+/// Unlike the credential-link flow (<see cref="Links.LinkCallbackCompletion"/>), an invitation sign-in is a
+/// genuine sign-in: the remote handler's cookie sign-in is never suppressed on the completion paths. Where a
+/// terminal failure page must be written instead of the handler's redirect, the session is signed in here
+/// first — the middleware writes those same pages to an already-authenticated request, and the person did
+/// authenticate successfully; it is the invitation completion that failed.
+/// </para>
+/// <para>
+/// Where the middleware signals the lobby redirect through
+/// <see cref="InviteMiddleware.LobbyRedirectUrlItemKey"/> for <see cref="InviteRedirectMiddleware"/> to
+/// answer, the callback owns its response directly: the handler redirects wherever
+/// <see cref="TicketReceivedContext.ReturnUri"/> points after sign-in, so the lobby target is placed there
+/// and no item key is involved.
+/// </para>
+/// </remarks>
+static class InviteCallbackCompletion
+{
+    /// <summary>
+    /// Completes the pending invitation this callback answers, when it answers one.
+    /// </summary>
+    /// <param name="context">The ticket-received context raised by the remote authentication handler.</param>
+    /// <returns>What was decided, and therefore what remains for the handler to do.</returns>
+    public static async Task<InviteCallbackCompletionResult> TryComplete(TicketReceivedContext context)
+    {
+        var httpContext = context.HttpContext;
+        var properties = context.Properties;
+        if (properties is null
+            || context.Principal is null
+            || !httpContext.TryGetPendingInvitationToken(out var inviteToken)
+            || !InvitationAuthenticationState.WasEstablishedFor(properties, inviteToken))
+        {
+            // Not this invitation's own challenge coming back - including the known deployments where the
+            // capability binding does not survive the provider round-trip. Nothing is exchanged here; the
+            // post-login middleware remains the answer for those, exactly as before.
+            return InviteCallbackCompletionResult.NotCompleted;
+        }
+
+        var services = httpContext.RequestServices;
+        var logger = GetLogger(httpContext);
+
+        // Re-validate the capability exactly as the post-login exchange does before forwarding it. A
+        // capability that no longer validates is not answered here: the middleware already owns the
+        // expired/invalid answers, and the follow-up request reaches them unchanged.
+        var tokenValidator = services.GetRequiredService<IInviteTokenValidator>();
+        var validationResult = tokenValidator.ValidateDetailed(inviteToken);
+        if (validationResult != InviteTokenValidationResult.Valid)
+        {
+            logger.InvitationCallbackTokenNoLongerValidates(context.Scheme.Name, validationResult);
+            return InviteCallbackCompletionResult.NotCompleted;
+        }
+
+        var completion = services.GetRequiredService<IInviteCompletion>();
+        var exchangeResult = await completion.ExchangeForTicket(httpContext, inviteToken, context.Principal, properties);
+        return exchangeResult switch
+        {
+            InviteExchangeResult.Success => CompleteSuccessfully(context, completion, inviteToken, logger),
+            InviteExchangeResult.DuplicateSubject => await AnswerDuplicateSubject(context, logger),
+            InviteExchangeResult.EmailMismatch => await AnswerWithPage(context, logger, exchangeResult, WellKnownPageNames.InvitationEmailMismatch, StatusCodes.Status403Forbidden),
+            InviteExchangeResult.EmailUnavailable => await AnswerWithPage(context, logger, exchangeResult, WellKnownPageNames.InvitationEmailUnavailable, StatusCodes.Status403Forbidden),
+            _ => await AnswerFailure(context, logger),
+        };
+    }
+
+    static InviteCallbackCompletionResult CompleteSuccessfully(
+        TicketReceivedContext context,
+        IInviteCompletion completion,
+        string inviteToken,
+        ILogger logger)
+    {
+        var httpContext = context.HttpContext;
+        PendingInvitationCookies.Delete(httpContext);
+
+        // The completion travels in the session about to be signed in, so any follow-up request that
+        // replays a stale pending-invitation cookie - or navigates back to the invitation URL - is
+        // recognized as already answered instead of being offered provider selection or a second exchange.
+        InvitationAuthenticationState.MarkCompleted(context.Properties!, inviteToken);
+        logger.InvitationCompletedOnCallback(context.Scheme.Name);
+
+        if (completion.TryResolveLobbyRedirect(httpContext, inviteToken, out var lobbyRedirectUrl))
+        {
+            context.ReturnUri = lobbyRedirectUrl;
+            return InviteCallbackCompletionResult.CompletedWithRedirect;
+        }
+
+        // Tenant-issued (or no lobby configured): the challenge's own return URL stands, and the handler's
+        // normal post-sign-in redirect resolution still applies to it.
+        return InviteCallbackCompletionResult.CompletedTowardReturnUrl;
+    }
+
+    static async Task<InviteCallbackCompletionResult> AnswerDuplicateSubject(TicketReceivedContext context, ILogger logger)
+    {
+        logger.InvitationCallbackExchangeDidNotSucceed(context.Scheme.Name, InviteExchangeResult.DuplicateSubject);
+        PendingInvitationCookies.Delete(context.HttpContext);
+
+        var config = context.HttpContext.RequestServices.GetRequiredService<IOptionsMonitor<C.AuthProxy>>().CurrentValue;
+        var subjectAlreadyExistsUrl = config.Invite?.SubjectAlreadyExistsUrl;
+        if (!string.IsNullOrWhiteSpace(subjectAlreadyExistsUrl))
+        {
+            context.ReturnUri = subjectAlreadyExistsUrl;
+            return InviteCallbackCompletionResult.CompletedWithRedirect;
+        }
+
+        return await WritePage(context, WellKnownPageNames.InvitationSubjectAlreadyExists, StatusCodes.Status409Conflict);
+    }
+
+    static async Task<InviteCallbackCompletionResult> AnswerWithPage(
+        TicketReceivedContext context,
+        ILogger logger,
+        InviteExchangeResult exchangeResult,
+        string pageName,
+        int statusCode)
+    {
+        logger.InvitationCallbackExchangeDidNotSucceed(context.Scheme.Name, exchangeResult);
+        PendingInvitationCookies.Delete(context.HttpContext);
+        return await WritePage(context, pageName, statusCode);
+    }
+
+    static async Task<InviteCallbackCompletionResult> AnswerFailure(TicketReceivedContext context, ILogger logger)
+    {
+        var config = context.HttpContext.RequestServices.GetRequiredService<IOptionsMonitor<C.AuthProxy>>().CurrentValue;
+        if (config.Invite?.Attestation is not null)
+        {
+            return await AnswerWithPage(context, logger, InviteExchangeResult.Failed, WellKnownPageNames.InvitationInvalid, StatusCodes.Status403Forbidden);
+        }
+
+        // A legacy-protocol failure writes no page in the middleware - the request simply continues down
+        // the pipeline. That continuation cannot be reproduced from inside the authentication handler, so
+        // the pending invitation is deliberately left in place and the sign-in completes normally: the
+        // follow-up request runs the middleware's own exchange and produces exactly today's outcome.
+        logger.InvitationCallbackExchangeDidNotSucceed(context.Scheme.Name, InviteExchangeResult.Failed);
+        return InviteCallbackCompletionResult.NotCompleted;
+    }
+
+    static async Task<InviteCallbackCompletionResult> WritePage(TicketReceivedContext context, string pageName, int statusCode)
+    {
+        // The page replaces the handler's own sign-in-and-redirect, but the sign-in itself still happened -
+        // the middleware writes this same page to an already-authenticated request, and the person did
+        // authenticate; it is the invitation completion that failed. Sign the ticket in exactly as the
+        // handler would have before answering.
+        await context.HttpContext.SignInAsync(context.Options.SignInScheme, context.Principal!, context.Properties);
+
+        var errorPageProvider = context.HttpContext.RequestServices.GetRequiredService<IErrorPageProvider>();
+        await errorPageProvider.WriteErrorPageAsync(context.HttpContext, pageName, statusCode);
+        context.HandleResponse();
+        return InviteCallbackCompletionResult.ResponseHandled;
+    }
+
+    static ILogger GetLogger(HttpContext context) =>
+        context.RequestServices
+            .GetRequiredService<ILoggerFactory>()
+            .CreateLogger(typeof(InviteCallbackCompletion).FullName!);
+}

--- a/Source/AuthProxy/Invites/InviteCallbackCompletionLogging.cs
+++ b/Source/AuthProxy/Invites/InviteCallbackCompletionLogging.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Invites;
+
+internal static partial class InviteCallbackCompletionLogging
+{
+    [LoggerMessage(LogLevel.Information, "Invitation completed on the provider callback for scheme {Scheme}")]
+    internal static partial void InvitationCompletedOnCallback(this ILogger logger, string scheme);
+
+    [LoggerMessage(LogLevel.Warning, "Invitation exchange on the provider callback for scheme {Scheme} ended in {Result} - answering with the same outcome the post-login exchange produces")]
+    internal static partial void InvitationCallbackExchangeDidNotSucceed(this ILogger logger, string scheme, InviteExchangeResult result);
+
+    [LoggerMessage(LogLevel.Information, "Invitation capability on the provider callback for scheme {Scheme} no longer validates: {Reason} - leaving it to the post-login middleware to answer")]
+    internal static partial void InvitationCallbackTokenNoLongerValidates(this ILogger logger, string scheme, InviteTokenValidationResult reason);
+}

--- a/Source/AuthProxy/Invites/InviteCallbackCompletionResult.cs
+++ b/Source/AuthProxy/Invites/InviteCallbackCompletionResult.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Invites;
+
+/// <summary>
+/// Tells the provider-callback handler what <see cref="InviteCallbackCompletion"/> decided, and therefore
+/// what remains for the handler to do.
+/// </summary>
+enum InviteCallbackCompletionResult
+{
+    /// <summary>
+    /// The callback does not answer a pending invitation's own challenge — or its outcome is deliberately
+    /// left to the post-login middleware. The handler proceeds exactly as before invitations completed on
+    /// the callback.
+    /// </summary>
+    NotCompleted = 0,
+
+    /// <summary>
+    /// The invitation completed and the browser stays on the challenge's own return URL, so the handler's
+    /// normal post-sign-in redirect resolution still applies.
+    /// </summary>
+    CompletedTowardReturnUrl = 1,
+
+    /// <summary>
+    /// The invitation reached a terminal answer and the redirect target has been decided — the handler signs
+    /// the session in and redirects there, resolving nothing further.
+    /// </summary>
+    CompletedWithRedirect = 2,
+
+    /// <summary>
+    /// The response has been written and the remote handler must not touch it further; the session was
+    /// signed in here before answering.
+    /// </summary>
+    ResponseHandled = 3,
+}

--- a/Source/AuthProxy/Invites/InviteCompletion.cs
+++ b/Source/AuthProxy/Invites/InviteCompletion.cs
@@ -1,0 +1,540 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using Cratis.AuthProxy.Authentication;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.JsonWebTokens;
+using C = Cratis.AuthProxy.Configuration;
+
+namespace Cratis.AuthProxy.Invites;
+
+/// <summary>
+/// The one implementation of the invitation exchange, shared by the post-login middleware and the provider
+/// callback so both complete an invitation identically — claims forwarding, recipient binding, tenant
+/// matching and duplicate-subject handling included.
+/// </summary>
+/// <param name="tokenValidator">The validator for invite JWT tokens.</param>
+/// <param name="config">The auth proxy configuration monitor.</param>
+/// <param name="authConfig">The authentication configuration monitor.</param>
+/// <param name="tenantResolver">The tenant resolver, consulted when the tenancy middleware has not run for the current request.</param>
+/// <param name="httpClientFactory">The HTTP client factory used for the exchange call.</param>
+/// <param name="logger">The logger.</param>
+/// <param name="canonicalIdentityResolver">The shared canonical identity resolver, or <see langword="null"/> for legacy-compatible direct construction.</param>
+/// <param name="attestationIssuer">The signed invitation-attestation issuer, or <see langword="null"/> for legacy-compatible direct construction.</param>
+/// <param name="entryStateProtector">The protected invitation-entry state service, or <see langword="null"/> for legacy-compatible direct construction.</param>
+class InviteCompletion(
+    IInviteTokenValidator tokenValidator,
+    IOptionsMonitor<C.AuthProxy> config,
+    IOptionsMonitor<C.Authentication> authConfig,
+    ITenantResolver tenantResolver,
+    IHttpClientFactory httpClientFactory,
+    ILogger logger,
+    ICanonicalIdentityResolver? canonicalIdentityResolver,
+    IInvitationAttestationIssuer? attestationIssuer,
+    IInvitationEntryStateProtector? entryStateProtector) : IInviteCompletion
+{
+    /// <summary>
+    /// The upper bound on an attested invitation capability's length, applied before any parsing of it.
+    /// </summary>
+    internal const int MaximumAttestedInvitationTokenLength = 4096;
+
+    /// <inheritdoc/>
+    public async Task<InviteExchangeResult> ExchangeForRequest(HttpContext context, string inviteToken) =>
+        IsAttestedProtocolEnabled()
+            ? await CompleteAttestedInvitation(
+                context,
+                inviteToken,
+                async () =>
+                {
+                    // The evidence is the established cookie session, authenticated by name so the question
+                    // asked is exactly "what session is this request running as".
+                    var authentication = await context.AuthenticateAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+                    return new InvitationCompletionSession(
+                        authentication.Succeeded,
+                        authentication.Principal,
+                        authentication.Properties,
+                        authentication.Properties?.IssuedUtc);
+                })
+            : await ExchangeInvite(inviteToken, context.User);
+
+    /// <inheritdoc/>
+    public async Task<InviteExchangeResult> ExchangeForTicket(HttpContext context, string inviteToken, ClaimsPrincipal principal, AuthenticationProperties properties) =>
+        IsAttestedProtocolEnabled()
+            ? await CompleteAttestedInvitation(
+                context,
+                inviteToken,
+                () => Task.FromResult(new InvitationCompletionSession(
+                    Succeeded: true,
+                    principal,
+                    properties,
+
+                    // The ticket was received this instant; no handler has stamped an issue instant yet.
+                    properties.IssuedUtc ?? DateTimeOffset.UtcNow)))
+            : await ExchangeInvite(inviteToken, principal);
+
+    /// <inheritdoc/>
+    public bool TryResolveLobbyRedirect(HttpContext context, string inviteToken, out string lobbyRedirectUrl)
+    {
+        lobbyRedirectUrl = string.Empty;
+        if (IsTenantIssuedInvite(inviteToken, context))
+        {
+            return false;
+        }
+
+        var lobbyUrl = config.CurrentValue.Invite?.Lobby?.Frontend?.BaseUrl;
+        if (string.IsNullOrWhiteSpace(lobbyUrl))
+        {
+            return false;
+        }
+
+        lobbyRedirectUrl = BuildLobbyRedirectUrlWithInvitationId(lobbyUrl, inviteToken);
+        return true;
+    }
+
+    /// <summary>
+    /// Reads a claim that must occur exactly once in a token, refusing duplicates, padding and oversized values.
+    /// </summary>
+    /// <param name="token">The raw JWT string.</param>
+    /// <param name="claimType">The claim type to look up.</param>
+    /// <param name="value">The single exact claim value when accepted.</param>
+    /// <returns><see langword="true"/> when the claim occurs exactly once with an acceptable value; otherwise <see langword="false"/>.</returns>
+    internal static bool TryGetSingleTokenClaim(string token, string claimType, out string value)
+    {
+        value = string.Empty;
+        try
+        {
+            var claims = new JsonWebTokenHandler().ReadJsonWebToken(token).Claims
+                .Where(_ => string.Equals(_.Type, claimType, StringComparison.Ordinal))
+                .ToArray();
+            if (claims.Length != 1
+                || string.IsNullOrWhiteSpace(claims[0].Value)
+                || claims[0].Value.Length > 2048
+                || !string.Equals(claims[0].Value, claims[0].Value.Trim(), StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            value = claims[0].Value;
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Determines whether the tenant the request is being served for matches an expected tenant, when one
+    /// can be resolved at all.
+    /// </summary>
+    /// <param name="context">The current <see cref="HttpContext"/>.</param>
+    /// <param name="tenantId">The tenant the invitation names.</param>
+    /// <returns><see langword="true"/> when no tenant resolves for the request or the resolved tenant matches; otherwise <see langword="false"/>.</returns>
+    internal bool ResolvedTenantMatchesWhenPresent(HttpContext context, string tenantId) =>
+        !TryResolveTenant(context, out var resolvedTenantId)
+        || FixedTimeEquals(tenantId, resolvedTenantId);
+
+    /// <summary>
+    /// Resolves the authenticating account's email and its provider-supplied verification status.
+    /// </summary>
+    /// <param name="principal">The authenticated principal completing the invitation.</param>
+    /// <param name="emailVerified">
+    /// The value of the provider's <c>email_verified</c> claim when present; otherwise <see langword="null"/>.
+    /// </param>
+    /// <returns>The authenticated email, or an empty string when none is available.</returns>
+    /// <remarks>
+    /// <c>preferred_username</c> is a username, not an address — for a GitHub OAuth provider it is conventionally
+    /// mapped from <c>login</c>. It is read only when it actually holds an address, which several OIDC providers
+    /// put there (Entra's is the user principal name). Returning a login name here would make a provider that
+    /// supplied no address at all indistinguishable from one that supplied somebody else's.
+    /// </remarks>
+    static string ResolveAuthenticatedEmail(ClaimsPrincipal principal, out bool? emailVerified)
+    {
+        emailVerified = bool.TryParse(principal.FindFirst("email_verified")?.Value, out var verified)
+            ? verified
+            : null;
+
+        var preferredUsername = principal.FindFirst("preferred_username")?.Value;
+
+        return principal.FindFirst("email")?.Value
+            ?? principal.FindFirst(ClaimTypes.Email)?.Value
+            ?? (InviteMiddleware.IsAnEmailAddress(preferredUsername) ? preferredUsername : null)
+            ?? string.Empty;
+    }
+
+    static bool TryGetSingleExactClaim(ClaimsPrincipal principal, string claimType, out string value)
+    {
+        var claims = principal.Claims.Where(_ => string.Equals(_.Type, claimType, StringComparison.Ordinal)).ToArray();
+        if (claims.Length != 1
+            || string.IsNullOrWhiteSpace(claims[0].Value)
+            || claims[0].Value.Length > 2048
+            || !string.Equals(claims[0].Value, claims[0].Value.Trim(), StringComparison.Ordinal))
+        {
+            value = string.Empty;
+            return false;
+        }
+
+        value = claims[0].Value;
+        return true;
+    }
+
+    static bool FixedTimeEquals(string expected, string actual) =>
+        CryptographicOperations.FixedTimeEquals(Encoding.UTF8.GetBytes(expected), Encoding.UTF8.GetBytes(actual));
+
+    async Task<InviteExchangeResult> CompleteAttestedInvitation(HttpContext context, string inviteToken, Func<Task<InvitationCompletionSession>> sessionFactory)
+    {
+        var invite = config.CurrentValue.Invite;
+        if (invite is null
+            || canonicalIdentityResolver is null
+            || attestationIssuer is null
+            || entryStateProtector is null
+            || inviteToken.Length > MaximumAttestedInvitationTokenLength
+            || !context.Request.Cookies.TryGetValue(Cookies.InvitationEntryState, out var protectedState)
+            || !entryStateProtector.TryUnprotect(protectedState, out var entryState)
+            || entryState.ExpiresAt <= DateTimeOffset.UtcNow
+            || !FixedTimeEquals(entryState.CapabilityHash, InvitationAuthenticationState.ComputeCapabilityHash(inviteToken))
+            || !TryGetSingleTokenClaim(inviteToken, JwtRegisteredClaimNames.Jti, out var invitationId)
+            || !FixedTimeEquals(entryState.InvitationId, invitationId)
+            || string.IsNullOrWhiteSpace(invite.TenantClaim)
+            || !TryGetSingleTokenClaim(inviteToken, invite.TenantClaim, out var tenantId)
+            || !FixedTimeEquals(entryState.TenantId, tenantId)
+            || !InviteMiddleware.TryResolveRecipientMode(inviteToken, invite.EmailClaim, out var recipientProviderKey)
+            || !ResolvedTenantMatchesWhenPresent(context, tenantId))
+        {
+            return InviteExchangeResult.Failed;
+        }
+
+        var session = await sessionFactory();
+        if (!session.Succeeded
+            || !InvitationAuthenticationState.Matches(entryState, session.Properties)
+            || !TryResolveVerifiedIdentity(session, recipientProviderKey, out var identity)
+            || (string.IsNullOrEmpty(recipientProviderKey)
+                && EvaluateInvitedEmailBinding(inviteToken, identity.Email!, true) != InviteExchangeResult.Success)
+            || !attestationIssuer.TryIssueComplete(entryState, identity, out var attestation))
+        {
+            return InviteExchangeResult.Failed;
+        }
+
+        using var client = httpClientFactory.CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Post, invite.ExchangeUrl);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", attestation);
+        request.Content = JsonContent.Create(new InvitationCompleteRequest(entryState.InvitationTransaction));
+
+        try
+        {
+            using var response = await client.SendAsync(request, context.RequestAborted);
+            if (response.StatusCode == System.Net.HttpStatusCode.Conflict)
+            {
+                return InviteExchangeResult.DuplicateSubject;
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                logger.InviteExchangeEndpointFailed((int)response.StatusCode);
+                return InviteExchangeResult.Failed;
+            }
+
+            logger.InviteExchangedSuccessfully();
+            return InviteExchangeResult.Success;
+        }
+        catch (Exception exception)
+        {
+            logger.FailedToCallInviteExchangeEndpoint(exception, invite.ExchangeUrl);
+            return InviteExchangeResult.Failed;
+        }
+    }
+
+    bool TryResolveVerifiedIdentity(
+        InvitationCompletionSession session,
+        string recipientProviderKey,
+        out InvitationVerifiedIdentity identity)
+    {
+        identity = default!;
+        var principal = session.Principal;
+        if (principal is null)
+        {
+            return false;
+        }
+
+        var resolution = canonicalIdentityResolver!.Resolve(principal, principal.Identity?.AuthenticationType);
+        if (!resolution.IsConfigured || !resolution.Succeeded || resolution.Identity is null)
+        {
+            return false;
+        }
+
+        var canonical = resolution.Identity;
+        var providers = authConfig.CurrentValue.OidcProviders
+            .Where(_ => string.Equals(_.CanonicalIdentity?.ProviderKey, canonical.ProviderKey, StringComparison.Ordinal))
+            .Select(_ => _.CanonicalIdentity!)
+            .Concat(authConfig.CurrentValue.OAuthProviders
+                .Where(_ => string.Equals(_.CanonicalIdentity?.ProviderKey, canonical.ProviderKey, StringComparison.Ordinal))
+                .Select(_ => _.CanonicalIdentity!))
+            .ToArray();
+        if (providers.Length != 1
+            || !TryGetSingleExactClaim(principal, providers[0].AssuranceClaimType, out var assurance)
+            || session.AuthenticatedAt is not { } authenticatedAt)
+        {
+            return false;
+        }
+
+        string? email = null;
+        if (string.IsNullOrEmpty(recipientProviderKey))
+        {
+            if (!providers[0].InvitationCompletionEnabled
+                || !TryGetSingleExactClaim(principal, providers[0].EmailClaimType, out email)
+                || !InviteMiddleware.IsAnEmailAddress(email)
+                || !TryGetSingleExactClaim(principal, providers[0].EmailVerifiedClaimType, out var emailVerified)
+                || !bool.TryParse(emailVerified, out var verified)
+                || !verified)
+            {
+                return false;
+            }
+        }
+        else if (!providers[0].InvitationIdentityBindingCompletionEnabled
+                 || !FixedTimeEquals(canonical.ProviderKey, recipientProviderKey))
+        {
+            return false;
+        }
+
+        identity = new InvitationVerifiedIdentity(
+            canonical.ProviderKey,
+            canonical.NormalizedIssuer,
+            canonical.Subject,
+            email,
+            assurance,
+            authenticatedAt);
+        return true;
+    }
+
+    async Task<InviteExchangeResult> ExchangeInvite(string inviteToken, ClaimsPrincipal principal)
+    {
+        var exchangeUrl = config.CurrentValue.Invite?.ExchangeUrl;
+        if (string.IsNullOrWhiteSpace(exchangeUrl))
+        {
+            logger.InviteExchangeUrlNotConfigured();
+            return InviteExchangeResult.Failed;
+        }
+
+        var canonicalResolution = canonicalIdentityResolver?.Resolve(principal, principal.Identity?.AuthenticationType)
+            ?? CanonicalIdentityResolution.SanitizedLegacy(principal);
+        if (canonicalResolution.IsConfigured && (!canonicalResolution.Succeeded || canonicalResolution.Identity is null))
+        {
+            return InviteExchangeResult.Failed;
+        }
+
+        var subject = canonicalResolution.Identity?.Subject
+            ?? principal.FindFirst("sub")?.Value
+            ?? principal.FindFirst("oid")?.Value
+            ?? principal.FindFirst(ClaimTypes.NameIdentifier)?.Value
+            ?? principal.FindFirst("id")?.Value
+            ?? string.Empty;
+
+        var identityProvider = canonicalResolution.Identity?.ProviderKey
+            ?? principal.FindFirst("iss")?.Value
+            ?? principal.FindFirst("identity_provider")?.Value
+            ?? principal.FindFirst("http://schemas.microsoft.com/accesscontrolservice/2010/07/claims/identityprovider")?.Value
+            ?? principal.Identity?.AuthenticationType
+            ?? string.Empty;
+
+        var email = ResolveAuthenticatedEmail(principal, out var emailVerified);
+
+        // An invitation is otherwise a pure bearer link - anyone with the URL could sign in with their
+        // own account and be provisioned as the invited user. Bind the invite to its intended recipient by
+        // requiring provider-supplied authenticated-session email evidence to match the invited email.
+        var binding = EvaluateInvitedEmailBinding(inviteToken, email, emailVerified);
+        if (binding == InviteExchangeResult.EmailUnavailable)
+        {
+            logger.InviteEmailUnavailable();
+            return binding;
+        }
+
+        if (binding == InviteExchangeResult.EmailMismatch)
+        {
+            logger.InviteEmailMismatch();
+            return binding;
+        }
+
+        using var client = httpClientFactory.CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Post, exchangeUrl);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", inviteToken);
+
+        // Forward the provider-supplied authenticated-session email evidence and any email_verified value so the
+        // backend can perform its own defense-in-depth check at accept time. The value can be true, false, or null;
+        // OAuth providers may not supply an independent email verification claim.
+        request.Content = canonicalResolution.Identity is { } canonicalIdentity
+            ? JsonContent.Create(new
+            {
+                subject,
+                providerKey = canonicalIdentity.ProviderKey,
+                issuer = canonicalIdentity.NormalizedIssuer,
+                identityProvider,
+                email,
+                emailVerified
+            })
+            : JsonContent.Create(new { subject, identityProvider, email, emailVerified });
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await client.SendAsync(request);
+        }
+        catch (Exception ex)
+        {
+            logger.FailedToCallInviteExchangeEndpoint(ex, exchangeUrl);
+            return InviteExchangeResult.Failed;
+        }
+
+        if (response.StatusCode == System.Net.HttpStatusCode.Conflict)
+        {
+            logger.InviteSubjectAlreadyExists();
+            return InviteExchangeResult.DuplicateSubject;
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            logger.InviteExchangeEndpointFailed((int)response.StatusCode);
+            return InviteExchangeResult.Failed;
+        }
+
+        logger.InviteExchangedSuccessfully();
+        return InviteExchangeResult.Success;
+    }
+
+    /// <summary>
+    /// Evaluates the invite against the authenticated account, enforcing that the invited email (when the
+    /// token carries one) matches provider-supplied authenticated-session email evidence.
+    /// </summary>
+    /// <param name="inviteToken">The validated invite token.</param>
+    /// <param name="authenticatedEmail">The authenticating account's email.</param>
+    /// <param name="emailVerified">
+    /// The provider's <c>email_verified</c> value: <see langword="true"/>, <see langword="false"/>, or
+    /// <see langword="null"/> when the provider supplies no independent verification claim.
+    /// </param>
+    /// <returns>
+    /// <see cref="InviteExchangeResult.Success"/> when the invite is not bound to a specific email or the
+    /// authenticated email matches it; <see cref="InviteExchangeResult.EmailUnavailable"/> when the provider
+    /// supplied no address to bind against; otherwise <see cref="InviteExchangeResult.EmailMismatch"/>.
+    /// </returns>
+    /// <remarks>
+    /// The two failures are kept apart deliberately. A provider that cannot tell us who this is and a provider
+    /// that told us it is somebody else are different facts, and collapsing them reports a specific, wrong cause
+    /// to an invitee whose account and address are both correct — leaving them no action that could work.
+    /// </remarks>
+    InviteExchangeResult EvaluateInvitedEmailBinding(string inviteToken, string authenticatedEmail, bool? emailVerified)
+    {
+        var emailClaim = config.CurrentValue.Invite?.EmailClaim;
+        if (string.IsNullOrWhiteSpace(emailClaim)
+            || !tokenValidator.TryGetClaim(inviteToken, emailClaim, out var invitedEmail)
+            || string.IsNullOrWhiteSpace(invitedEmail))
+        {
+            // The invite does not target a specific email - there is nothing to bind against.
+            return InviteExchangeResult.Success;
+        }
+
+        if (string.IsNullOrWhiteSpace(authenticatedEmail))
+        {
+            return InviteExchangeResult.EmailUnavailable;
+        }
+
+        // The invite is bound to a specific email, so the account must own that email and the provider
+        // must not have flagged it as unverified.
+        if (emailVerified == false)
+        {
+            return InviteExchangeResult.EmailMismatch;
+        }
+
+        return string.Equals(invitedEmail, authenticatedEmail, StringComparison.OrdinalIgnoreCase)
+            ? InviteExchangeResult.Success
+            : InviteExchangeResult.EmailMismatch;
+    }
+
+    bool IsTenantIssuedInvite(string inviteToken, HttpContext context)
+    {
+        var tenantClaim = config.CurrentValue.Invite?.TenantClaim;
+        if (string.IsNullOrEmpty(tenantClaim))
+        {
+            return false;
+        }
+
+        if (!tokenValidator.TryGetClaim(inviteToken, tenantClaim, out var tokenTenantIdStr))
+        {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(tokenTenantIdStr))
+        {
+            return false;
+        }
+
+        if (!TryResolveTenant(context, out var resolvedTenantId))
+        {
+            return false;
+        }
+
+        return string.Equals(tokenTenantIdStr, resolvedTenantId, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Resolves the tenant the current request is being served for.
+    /// </summary>
+    /// <param name="context">The current <see cref="HttpContext"/>.</param>
+    /// <param name="tenantId">The resolved tenant when one exists.</param>
+    /// <returns><see langword="true"/> when a tenant resolves for the request; otherwise <see langword="false"/>.</returns>
+    /// <remarks>
+    /// On the middleware path <see cref="TenancyMiddleware"/> has already resolved the tenant into
+    /// <see cref="HttpContext.Items"/>. The provider callback is answered inside authentication, before that
+    /// middleware runs, so the same resolver is consulted directly there — it reads the same request facts
+    /// the follow-up request would have presented, so both paths answer the tenant question identically.
+    /// </remarks>
+    bool TryResolveTenant(HttpContext context, out string tenantId)
+    {
+        if (context.Items.TryGetValue(TenancyMiddleware.TenantIdItemKey, out var resolved)
+            && resolved is string resolvedTenantId
+            && !string.IsNullOrWhiteSpace(resolvedTenantId))
+        {
+            tenantId = resolvedTenantId;
+            return true;
+        }
+
+        if (!context.Items.ContainsKey(TenancyMiddleware.TenantIdItemKey)
+            && tenantResolver.TryResolve(context, out string directlyResolved)
+            && !string.IsNullOrWhiteSpace(directlyResolved))
+        {
+            tenantId = directlyResolved;
+            return true;
+        }
+
+        tenantId = string.Empty;
+        return false;
+    }
+
+    string BuildLobbyRedirectUrlWithInvitationId(string lobbyUrl, string inviteToken)
+    {
+        var inviteConfig = config.CurrentValue.Invite;
+        if (inviteConfig?.AppendInvitationIdToQueryString != true)
+        {
+            return lobbyUrl;
+        }
+
+        var queryKey = string.IsNullOrWhiteSpace(inviteConfig.InvitationIdQueryStringKey)
+            ? "invitationId"
+            : inviteConfig.InvitationIdQueryStringKey;
+
+        if (!tokenValidator.TryGetClaim(inviteToken, "jti", out var invitationId)
+            || string.IsNullOrWhiteSpace(invitationId))
+        {
+            return lobbyUrl;
+        }
+
+        var separator = lobbyUrl.Contains('?') ? '&' : '?';
+        return $"{lobbyUrl}{separator}{Uri.EscapeDataString(queryKey)}={Uri.EscapeDataString(invitationId)}";
+    }
+
+    bool IsAttestedProtocolEnabled() => config.CurrentValue.Invite?.Attestation is not null;
+}

--- a/Source/AuthProxy/Invites/InviteMiddleware.cs
+++ b/Source/AuthProxy/Invites/InviteMiddleware.cs
@@ -37,8 +37,12 @@ namespace Cratis.AuthProxy.Invites;
 ///     respectively.
 ///   </item>
 /// </list>
-/// The exchange itself lives in <see cref="IInviteCompletion"/>, so every caller completes an invitation
-/// identically.
+/// The exchange itself lives in <see cref="IInviteCompletion"/>, shared with
+/// <see cref="InviteCallbackCompletion"/> — which completes an invitation on the provider callback itself
+/// whenever the challenge's capability binding survives the round trip. Phase 2 here remains fully intact as
+/// the fallback for every callback that binding does not come back on, and both phases additionally
+/// recognize a session that already completed its invitation on the callback so a stale pending cookie or a
+/// return visit to the invitation URL never re-runs the exchange or re-offers provider selection.
 /// </summary>
 /// <param name="next">The next middleware in the pipeline.</param>
 /// <param name="tokenValidator">The validator for invite JWT tokens.</param>
@@ -72,6 +76,11 @@ public class InviteMiddleware(
     /// Set by Phase 2 when exchange succeeds and the invite is not tenant-issued.
     /// Read by <see cref="InviteRedirectMiddleware"/> to perform the actual redirect.
     /// </summary>
+    /// <remarks>
+    /// This mechanism belongs to the middleware pipeline alone. When an invitation completes on the provider
+    /// callback instead, <see cref="InviteCallbackCompletion"/> owns the response directly and places the
+    /// lobby target on the remote handler's return URI — no item key is involved there.
+    /// </remarks>
     public const string LobbyRedirectUrlItemKey = "Cratis.InviteLobbyRedirectUrl";
 
     static readonly JsonSerializerOptions _providerSerializerOptions = new()
@@ -163,6 +172,15 @@ public class InviteMiddleware(
                 return;
             }
 
+            // A session that already completed this exact invitation on its own provider callback is never
+            // exchanged again - the cookie arriving here is a stale copy the browser had not yet dropped.
+            // Clear it and take the caller where the completed invitation leads.
+            if (WasInvitationCompletedByThisSession(context, inviteToken))
+            {
+                await ContinueCompletedInvitation(context, inviteToken);
+                return;
+            }
+
             // "Authenticated" and "authenticated for this invitation" are different facts, and only the
             // second one may complete it. An invitation binds an organization to an identity permanently,
             // and the pre-existing session is the one that arrives first: a person already signed in with
@@ -205,6 +223,16 @@ public class InviteMiddleware(
                     context,
                     pageName,
                     StatusCodes.Status401Unauthorized);
+                return;
+            }
+
+            // A signed-in caller returning to an invitation URL their own session has already completed -
+            // the provider callback completed it before redirecting here - is never re-staged and never
+            // offered provider selection again; they continue to where the completed invitation leads.
+            if (context.User.Identity?.IsAuthenticated == true
+                && WasInvitationCompletedByThisSession(context, token))
+            {
+                await ContinueCompletedInvitation(context, token);
                 return;
             }
 
@@ -455,6 +483,19 @@ public class InviteMiddleware(
     }
 
     /// <summary>
+    /// Determines whether the session authenticating this request has already completed the exchange for
+    /// this exact invitation — on its own provider callback.
+    /// </summary>
+    /// <param name="context">The current <see cref="HttpContext"/>.</param>
+    /// <param name="inviteToken">The invitation capability being presented.</param>
+    /// <returns><see langword="true"/> when this session already completed that capability; otherwise <see langword="false"/>.</returns>
+    static bool WasInvitationCompletedByThisSession(HttpContext context, string inviteToken)
+    {
+        var properties = context.Features.Get<IAuthenticateResultFeature>()?.AuthenticateResult?.Properties;
+        return InvitationAuthenticationState.WasCompletedFor(properties, inviteToken);
+    }
+
+    /// <summary>
     /// Aggregates all configured OIDC and OAuth providers into a single enumerable of <see cref="OidcProviderInfo"/>.
     /// </summary>
     /// <param name="config">The authentication configuration containing the provider lists.</param>
@@ -540,6 +581,26 @@ public class InviteMiddleware(
             context,
             invalidPageName,
             StatusCodes.Status401Unauthorized);
+    }
+
+    /// <summary>
+    /// Continues a request whose session has already completed the invitation it presents: the stale pending
+    /// state is cleared and the caller is taken where the completed invitation leads — the lobby for a
+    /// non-tenant-issued invitation, the pipeline's own course otherwise.
+    /// </summary>
+    /// <param name="context">The current <see cref="HttpContext"/>.</param>
+    /// <param name="inviteToken">The already-completed invitation capability.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+    async Task ContinueCompletedInvitation(HttpContext context, string inviteToken)
+    {
+        PendingInvitationCookies.Delete(context);
+
+        if (_completion.TryResolveLobbyRedirect(context, inviteToken, out var lobbyRedirectUrl))
+        {
+            context.Items[LobbyRedirectUrlItemKey] = lobbyRedirectUrl;
+        }
+
+        await next(context);
     }
 
     /// <summary>

--- a/Source/AuthProxy/Invites/InviteMiddleware.cs
+++ b/Source/AuthProxy/Invites/InviteMiddleware.cs
@@ -3,13 +3,11 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Http.Headers;
-using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
 using Cratis.AuthProxy.Authentication;
 using Cratis.AuthProxy.ErrorPages;
 using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.JsonWebTokens;
@@ -39,6 +37,8 @@ namespace Cratis.AuthProxy.Invites;
 ///     respectively.
 ///   </item>
 /// </list>
+/// The exchange itself lives in <see cref="IInviteCompletion"/>, so every caller completes an invitation
+/// identically.
 /// </summary>
 /// <param name="next">The next middleware in the pipeline.</param>
 /// <param name="tokenValidator">The validator for invite JWT tokens.</param>
@@ -74,13 +74,22 @@ public class InviteMiddleware(
     /// </summary>
     public const string LobbyRedirectUrlItemKey = "Cratis.InviteLobbyRedirectUrl";
 
-    const int MaximumAttestedInvitationTokenLength = 4096;
-
     static readonly JsonSerializerOptions _providerSerializerOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         Converters = { new JsonStringEnumConverter() }
     };
+
+    readonly InviteCompletion _completion = new(
+        tokenValidator,
+        config,
+        authConfig,
+        tenantResolver,
+        httpClientFactory,
+        logger,
+        canonicalIdentityResolver,
+        attestationIssuer,
+        entryStateProtector);
 
     /// <summary>
     /// Initializes a legacy-compatible instance that sanitizes reserved canonical claims without resolving canonical providers.
@@ -395,15 +404,14 @@ public class InviteMiddleware(
     }
 
     /// <summary>
-    /// Removes every cookie belonging to a pending invitation, at both the default and the root path.
+    /// Determines whether a claim value is an email address rather than a username.
     /// </summary>
-    /// <param name="context">The current <see cref="HttpContext"/>.</param>
-    static void DeleteInvitationCookies(HttpContext context)
+    /// <param name="value">The claim value to check.</param>
+    /// <returns><see langword="true"/> when the value carries a local part and a domain; otherwise <see langword="false"/>.</returns>
+    internal static bool IsAnEmailAddress([NotNullWhen(true)] string? value)
     {
-        context.Response.Cookies.Delete(Cookies.InviteToken);
-        context.Response.Cookies.Delete(Cookies.InvitationEntryState);
-        context.Response.Cookies.Delete(Cookies.InviteToken, new CookieOptions { Path = "/" });
-        context.Response.Cookies.Delete(Cookies.InvitationEntryState, new CookieOptions { Path = "/" });
+        var at = value?.IndexOf('@', StringComparison.Ordinal) ?? -1;
+        return at > 0 && at < value!.Length - 1;
     }
 
     /// <summary>
@@ -485,45 +493,6 @@ public class InviteMiddleware(
               && string.Equals(identity.ProviderKey, recipientProviderKey, StringComparison.Ordinal);
     }
 
-    /// <summary>
-    /// Resolves the authenticating account's email and its provider-supplied verification status.
-    /// </summary>
-    /// <param name="context">The current <see cref="HttpContext"/>.</param>
-    /// <param name="emailVerified">
-    /// The value of the provider's <c>email_verified</c> claim when present; otherwise <see langword="null"/>.
-    /// </param>
-    /// <returns>The authenticated email, or an empty string when none is available.</returns>
-    /// <remarks>
-    /// <c>preferred_username</c> is a username, not an address — for a GitHub OAuth provider it is conventionally
-    /// mapped from <c>login</c>. It is read only when it actually holds an address, which several OIDC providers
-    /// put there (Entra's is the user principal name). Returning a login name here would make a provider that
-    /// supplied no address at all indistinguishable from one that supplied somebody else's.
-    /// </remarks>
-    static string ResolveAuthenticatedEmail(HttpContext context, out bool? emailVerified)
-    {
-        emailVerified = bool.TryParse(context.User.FindFirst("email_verified")?.Value, out var verified)
-            ? verified
-            : null;
-
-        var preferredUsername = context.User.FindFirst("preferred_username")?.Value;
-
-        return context.User.FindFirst("email")?.Value
-            ?? context.User.FindFirst(ClaimTypes.Email)?.Value
-            ?? (IsAnEmailAddress(preferredUsername) ? preferredUsername : null)
-            ?? string.Empty;
-    }
-
-    /// <summary>
-    /// Determines whether a claim value is an email address rather than a username.
-    /// </summary>
-    /// <param name="value">The claim value to check.</param>
-    /// <returns><see langword="true"/> when the value carries a local part and a domain; otherwise <see langword="false"/>.</returns>
-    static bool IsAnEmailAddress([NotNullWhen(true)] string? value)
-    {
-        var at = value?.IndexOf('@', StringComparison.Ordinal) ?? -1;
-        return at > 0 && at < value!.Length - 1;
-    }
-
     static bool IsCanonicalProviderKey(string value) =>
         value.Length is >= 1 and <= 64
         && value[0] is (>= 'a' and <= 'z') or (>= '0' and <= '9')
@@ -548,53 +517,6 @@ public class InviteMiddleware(
         }
     }
 
-    static bool TryGetSingleExactClaim(ClaimsPrincipal principal, string claimType, out string value)
-    {
-        var claims = principal.Claims.Where(_ => string.Equals(_.Type, claimType, StringComparison.Ordinal)).ToArray();
-        if (claims.Length != 1
-            || string.IsNullOrWhiteSpace(claims[0].Value)
-            || claims[0].Value.Length > 2048
-            || !string.Equals(claims[0].Value, claims[0].Value.Trim(), StringComparison.Ordinal))
-        {
-            value = string.Empty;
-            return false;
-        }
-
-        value = claims[0].Value;
-        return true;
-    }
-
-    static bool TryGetSingleTokenClaim(string token, string claimType, out string value)
-    {
-        value = string.Empty;
-        try
-        {
-            var claims = new JsonWebTokenHandler().ReadJsonWebToken(token).Claims
-                .Where(_ => string.Equals(_.Type, claimType, StringComparison.Ordinal))
-                .ToArray();
-            if (claims.Length != 1
-                || string.IsNullOrWhiteSpace(claims[0].Value)
-                || claims[0].Value.Length > 2048
-                || !string.Equals(claims[0].Value, claims[0].Value.Trim(), StringComparison.Ordinal))
-            {
-                return false;
-            }
-
-            value = claims[0].Value;
-            return true;
-        }
-        catch (ArgumentException)
-        {
-            return false;
-        }
-    }
-
-    static bool ResolvedTenantMatchesWhenPresent(HttpContext context, string tenantId) =>
-        !context.Items.TryGetValue(TenancyMiddleware.TenantIdItemKey, out var resolved)
-        || resolved is not string resolvedTenantId
-        || string.IsNullOrWhiteSpace(resolvedTenantId)
-        || FixedTimeEquals(tenantId, resolvedTenantId);
-
     static bool FixedTimeEquals(string expected, string actual) =>
         CryptographicOperations.FixedTimeEquals(Encoding.UTF8.GetBytes(expected), Encoding.UTF8.GetBytes(actual));
 
@@ -608,7 +530,7 @@ public class InviteMiddleware(
     /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
     async Task RejectPendingInvitation(HttpContext context, InviteTokenValidationResult validationResult)
     {
-        DeleteInvitationCookies(context);
+        PendingInvitationCookies.Delete(context);
 
         var invalidPageName = validationResult == InviteTokenValidationResult.Expired
             ? WellKnownPageNames.InvitationExpired
@@ -629,10 +551,8 @@ public class InviteMiddleware(
     /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
     async Task CompleteInvitation(HttpContext context, string inviteToken)
     {
-        var exchangeResult = IsAttestedProtocolEnabled()
-            ? await CompleteAttestedInvitation(context, inviteToken)
-            : await ExchangeInvite(context, inviteToken);
-        DeleteInvitationCookies(context);
+        var exchangeResult = await _completion.ExchangeForRequest(context, inviteToken);
+        PendingInvitationCookies.Delete(context);
 
         if (exchangeResult == InviteExchangeResult.EmailMismatch)
         {
@@ -681,13 +601,10 @@ public class InviteMiddleware(
             return;
         }
 
-        if (exchangeResult == InviteExchangeResult.Success && !IsTenantIssuedInvite(inviteToken, context))
+        if (exchangeResult == InviteExchangeResult.Success
+            && _completion.TryResolveLobbyRedirect(context, inviteToken, out var lobbyRedirectUrl))
         {
-            var lobbyUrl = config.CurrentValue.Invite?.Lobby?.Frontend?.BaseUrl;
-            if (!string.IsNullOrWhiteSpace(lobbyUrl))
-            {
-                context.Items[LobbyRedirectUrlItemKey] = BuildLobbyRedirectUrlWithInvitationId(lobbyUrl, inviteToken);
-            }
+            context.Items[LobbyRedirectUrlItemKey] = lobbyRedirectUrl;
         }
 
         await next(context);
@@ -699,12 +616,12 @@ public class InviteMiddleware(
         if (invite is null
             || attestationIssuer is null
             || entryStateProtector is null
-            || inviteToken.Length > MaximumAttestedInvitationTokenLength
+            || inviteToken.Length > InviteCompletion.MaximumAttestedInvitationTokenLength
             || string.IsNullOrWhiteSpace(invite.StageUrl)
             || string.IsNullOrWhiteSpace(invite.TenantClaim)
-            || !TryGetSingleTokenClaim(inviteToken, JwtRegisteredClaimNames.Jti, out var invitationId)
-            || !TryGetSingleTokenClaim(inviteToken, invite.TenantClaim, out var tenantId)
-            || !ResolvedTenantMatchesWhenPresent(context, tenantId))
+            || !InviteCompletion.TryGetSingleTokenClaim(inviteToken, JwtRegisteredClaimNames.Jti, out var invitationId)
+            || !InviteCompletion.TryGetSingleTokenClaim(inviteToken, invite.TenantClaim, out var tenantId)
+            || !_completion.ResolvedTenantMatchesWhenPresent(context, tenantId))
         {
             return (false, null);
         }
@@ -745,322 +662,5 @@ public class InviteMiddleware(
         }
 
         return (false, null);
-    }
-
-    async Task<InviteExchangeResult> CompleteAttestedInvitation(HttpContext context, string inviteToken)
-    {
-        var invite = config.CurrentValue.Invite;
-        if (invite is null
-            || canonicalIdentityResolver is null
-            || attestationIssuer is null
-            || entryStateProtector is null
-            || inviteToken.Length > MaximumAttestedInvitationTokenLength
-            || !context.Request.Cookies.TryGetValue(Cookies.InvitationEntryState, out var protectedState)
-            || !entryStateProtector.TryUnprotect(protectedState, out var entryState)
-            || entryState.ExpiresAt <= DateTimeOffset.UtcNow
-            || !FixedTimeEquals(entryState.CapabilityHash, InvitationAuthenticationState.ComputeCapabilityHash(inviteToken))
-            || !TryGetSingleTokenClaim(inviteToken, JwtRegisteredClaimNames.Jti, out var invitationId)
-            || !FixedTimeEquals(entryState.InvitationId, invitationId)
-            || string.IsNullOrWhiteSpace(invite.TenantClaim)
-            || !TryGetSingleTokenClaim(inviteToken, invite.TenantClaim, out var tenantId)
-            || !FixedTimeEquals(entryState.TenantId, tenantId)
-            || !TryResolveRecipientMode(inviteToken, invite.EmailClaim, out var recipientProviderKey)
-            || !ResolvedTenantMatchesWhenPresent(context, tenantId))
-        {
-            return InviteExchangeResult.Failed;
-        }
-
-        var authentication = await context.AuthenticateAsync(CookieAuthenticationDefaults.AuthenticationScheme);
-        if (!authentication.Succeeded
-            || !InvitationAuthenticationState.Matches(entryState, authentication.Properties)
-            || !TryResolveVerifiedIdentity(authentication, recipientProviderKey, out var identity)
-            || (string.IsNullOrEmpty(recipientProviderKey)
-                && EvaluateInvitedEmailBinding(inviteToken, identity.Email!, true) != InviteExchangeResult.Success)
-            || !attestationIssuer.TryIssueComplete(entryState, identity, out var attestation))
-        {
-            return InviteExchangeResult.Failed;
-        }
-
-        using var client = httpClientFactory.CreateClient();
-        using var request = new HttpRequestMessage(HttpMethod.Post, invite.ExchangeUrl);
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", attestation);
-        request.Content = JsonContent.Create(new InvitationCompleteRequest(entryState.InvitationTransaction));
-
-        try
-        {
-            using var response = await client.SendAsync(request, context.RequestAborted);
-            if (response.StatusCode == System.Net.HttpStatusCode.Conflict)
-            {
-                return InviteExchangeResult.DuplicateSubject;
-            }
-
-            if (!response.IsSuccessStatusCode)
-            {
-                logger.InviteExchangeEndpointFailed((int)response.StatusCode);
-                return InviteExchangeResult.Failed;
-            }
-
-            logger.InviteExchangedSuccessfully();
-            return InviteExchangeResult.Success;
-        }
-        catch (Exception exception)
-        {
-            logger.FailedToCallInviteExchangeEndpoint(exception, invite.ExchangeUrl);
-            return InviteExchangeResult.Failed;
-        }
-    }
-
-    bool TryResolveVerifiedIdentity(
-        AuthenticateResult authentication,
-        string recipientProviderKey,
-        out InvitationVerifiedIdentity identity)
-    {
-        identity = default!;
-        var principal = authentication.Principal;
-        if (principal is null)
-        {
-            return false;
-        }
-
-        var resolution = canonicalIdentityResolver!.Resolve(principal, principal.Identity?.AuthenticationType);
-        if (!resolution.IsConfigured || !resolution.Succeeded || resolution.Identity is null)
-        {
-            return false;
-        }
-
-        var canonical = resolution.Identity;
-        var providers = authConfig.CurrentValue.OidcProviders
-            .Where(_ => string.Equals(_.CanonicalIdentity?.ProviderKey, canonical.ProviderKey, StringComparison.Ordinal))
-            .Select(_ => _.CanonicalIdentity!)
-            .Concat(authConfig.CurrentValue.OAuthProviders
-                .Where(_ => string.Equals(_.CanonicalIdentity?.ProviderKey, canonical.ProviderKey, StringComparison.Ordinal))
-                .Select(_ => _.CanonicalIdentity!))
-            .ToArray();
-        if (providers.Length != 1
-            || !TryGetSingleExactClaim(principal, providers[0].AssuranceClaimType, out var assurance)
-            || authentication.Properties?.IssuedUtc is not { } authenticatedAt)
-        {
-            return false;
-        }
-
-        string? email = null;
-        if (string.IsNullOrEmpty(recipientProviderKey))
-        {
-            if (!providers[0].InvitationCompletionEnabled
-                || !TryGetSingleExactClaim(principal, providers[0].EmailClaimType, out email)
-                || !IsAnEmailAddress(email)
-                || !TryGetSingleExactClaim(principal, providers[0].EmailVerifiedClaimType, out var emailVerified)
-                || !bool.TryParse(emailVerified, out var verified)
-                || !verified)
-            {
-                return false;
-            }
-        }
-        else if (!providers[0].InvitationIdentityBindingCompletionEnabled
-                 || !FixedTimeEquals(canonical.ProviderKey, recipientProviderKey))
-        {
-            return false;
-        }
-
-        identity = new InvitationVerifiedIdentity(
-            canonical.ProviderKey,
-            canonical.NormalizedIssuer,
-            canonical.Subject,
-            email,
-            assurance,
-            authenticatedAt);
-        return true;
-    }
-
-    async Task<InviteExchangeResult> ExchangeInvite(HttpContext context, string inviteToken)
-    {
-        var exchangeUrl = config.CurrentValue.Invite?.ExchangeUrl;
-        if (string.IsNullOrWhiteSpace(exchangeUrl))
-        {
-            logger.InviteExchangeUrlNotConfigured();
-            return InviteExchangeResult.Failed;
-        }
-
-        var canonicalResolution = canonicalIdentityResolver?.Resolve(context.User, context.User.Identity?.AuthenticationType)
-            ?? CanonicalIdentityResolution.SanitizedLegacy(context.User);
-        if (canonicalResolution.IsConfigured && (!canonicalResolution.Succeeded || canonicalResolution.Identity is null))
-        {
-            return InviteExchangeResult.Failed;
-        }
-
-        var subject = canonicalResolution.Identity?.Subject
-            ?? context.User.FindFirst("sub")?.Value
-            ?? context.User.FindFirst("oid")?.Value
-            ?? context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value
-            ?? context.User.FindFirst("id")?.Value
-            ?? string.Empty;
-
-        var identityProvider = canonicalResolution.Identity?.ProviderKey
-            ?? context.User.FindFirst("iss")?.Value
-            ?? context.User.FindFirst("identity_provider")?.Value
-            ?? context.User.FindFirst("http://schemas.microsoft.com/accesscontrolservice/2010/07/claims/identityprovider")?.Value
-            ?? context.User.Identity?.AuthenticationType
-            ?? string.Empty;
-
-        var email = ResolveAuthenticatedEmail(context, out var emailVerified);
-
-        // An invitation is otherwise a pure bearer link - anyone with the URL could sign in with their
-        // own account and be provisioned as the invited user. Bind the invite to its intended recipient by
-        // requiring provider-supplied authenticated-session email evidence to match the invited email.
-        var binding = EvaluateInvitedEmailBinding(inviteToken, email, emailVerified);
-        if (binding == InviteExchangeResult.EmailUnavailable)
-        {
-            logger.InviteEmailUnavailable();
-            return binding;
-        }
-
-        if (binding == InviteExchangeResult.EmailMismatch)
-        {
-            logger.InviteEmailMismatch();
-            return binding;
-        }
-
-        using var client = httpClientFactory.CreateClient();
-        using var request = new HttpRequestMessage(HttpMethod.Post, exchangeUrl);
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", inviteToken);
-
-        // Forward the provider-supplied authenticated-session email evidence and any email_verified value so the
-        // backend can perform its own defense-in-depth check at accept time. The value can be true, false, or null;
-        // OAuth providers may not supply an independent email verification claim.
-        request.Content = canonicalResolution.Identity is { } canonicalIdentity
-            ? JsonContent.Create(new
-            {
-                subject,
-                providerKey = canonicalIdentity.ProviderKey,
-                issuer = canonicalIdentity.NormalizedIssuer,
-                identityProvider,
-                email,
-                emailVerified
-            })
-            : JsonContent.Create(new { subject, identityProvider, email, emailVerified });
-
-        HttpResponseMessage response;
-        try
-        {
-            response = await client.SendAsync(request);
-        }
-        catch (Exception ex)
-        {
-            logger.FailedToCallInviteExchangeEndpoint(ex, exchangeUrl);
-            return InviteExchangeResult.Failed;
-        }
-
-        if (response.StatusCode == System.Net.HttpStatusCode.Conflict)
-        {
-            logger.InviteSubjectAlreadyExists();
-            return InviteExchangeResult.DuplicateSubject;
-        }
-
-        if (!response.IsSuccessStatusCode)
-        {
-            logger.InviteExchangeEndpointFailed((int)response.StatusCode);
-            return InviteExchangeResult.Failed;
-        }
-
-        logger.InviteExchangedSuccessfully();
-        return InviteExchangeResult.Success;
-    }
-
-    /// <summary>
-    /// Evaluates the invite against the authenticated account, enforcing that the invited email (when the
-    /// token carries one) matches provider-supplied authenticated-session email evidence.
-    /// </summary>
-    /// <param name="inviteToken">The validated invite token.</param>
-    /// <param name="authenticatedEmail">The authenticating account's email.</param>
-    /// <param name="emailVerified">
-    /// The provider's <c>email_verified</c> value: <see langword="true"/>, <see langword="false"/>, or
-    /// <see langword="null"/> when the provider supplies no independent verification claim.
-    /// </param>
-    /// <returns>
-    /// <see cref="InviteExchangeResult.Success"/> when the invite is not bound to a specific email or the
-    /// authenticated email matches it; <see cref="InviteExchangeResult.EmailUnavailable"/> when the provider
-    /// supplied no address to bind against; otherwise <see cref="InviteExchangeResult.EmailMismatch"/>.
-    /// </returns>
-    /// <remarks>
-    /// The two failures are kept apart deliberately. A provider that cannot tell us who this is and a provider
-    /// that told us it is somebody else are different facts, and collapsing them reports a specific, wrong cause
-    /// to an invitee whose account and address are both correct — leaving them no action that could work.
-    /// </remarks>
-    InviteExchangeResult EvaluateInvitedEmailBinding(string inviteToken, string authenticatedEmail, bool? emailVerified)
-    {
-        var emailClaim = config.CurrentValue.Invite?.EmailClaim;
-        if (string.IsNullOrWhiteSpace(emailClaim)
-            || !tokenValidator.TryGetClaim(inviteToken, emailClaim, out var invitedEmail)
-            || string.IsNullOrWhiteSpace(invitedEmail))
-        {
-            // The invite does not target a specific email - there is nothing to bind against.
-            return InviteExchangeResult.Success;
-        }
-
-        if (string.IsNullOrWhiteSpace(authenticatedEmail))
-        {
-            return InviteExchangeResult.EmailUnavailable;
-        }
-
-        // The invite is bound to a specific email, so the account must own that email and the provider
-        // must not have flagged it as unverified.
-        if (emailVerified == false)
-        {
-            return InviteExchangeResult.EmailMismatch;
-        }
-
-        return string.Equals(invitedEmail, authenticatedEmail, StringComparison.OrdinalIgnoreCase)
-            ? InviteExchangeResult.Success
-            : InviteExchangeResult.EmailMismatch;
-    }
-
-    bool IsTenantIssuedInvite(string inviteToken, HttpContext context)
-    {
-        var tenantClaim = config.CurrentValue.Invite?.TenantClaim;
-        if (string.IsNullOrEmpty(tenantClaim))
-        {
-            return false;
-        }
-
-        if (!tokenValidator.TryGetClaim(inviteToken, tenantClaim, out var tokenTenantIdStr))
-        {
-            return false;
-        }
-
-        if (string.IsNullOrWhiteSpace(tokenTenantIdStr))
-        {
-            return false;
-        }
-
-        if (!context.Items.TryGetValue(TenancyMiddleware.TenantIdItemKey, out var resolvedTenantObj)
-            || resolvedTenantObj is not string resolvedTenantId
-            || string.IsNullOrWhiteSpace(resolvedTenantId))
-        {
-            return false;
-        }
-
-        return string.Equals(tokenTenantIdStr, resolvedTenantId, StringComparison.OrdinalIgnoreCase);
-    }
-
-    string BuildLobbyRedirectUrlWithInvitationId(string lobbyUrl, string inviteToken)
-    {
-        var inviteConfig = config.CurrentValue.Invite;
-        if (inviteConfig?.AppendInvitationIdToQueryString != true)
-        {
-            return lobbyUrl;
-        }
-
-        var queryKey = string.IsNullOrWhiteSpace(inviteConfig.InvitationIdQueryStringKey)
-            ? "invitationId"
-            : inviteConfig.InvitationIdQueryStringKey;
-
-        if (!tokenValidator.TryGetClaim(inviteToken, "jti", out var invitationId)
-            || string.IsNullOrWhiteSpace(invitationId))
-        {
-            return lobbyUrl;
-        }
-
-        var separator = lobbyUrl.Contains('?') ? '&' : '?';
-        return $"{lobbyUrl}{separator}{Uri.EscapeDataString(queryKey)}={Uri.EscapeDataString(invitationId)}";
     }
 }

--- a/Source/AuthProxy/Invites/InvitesServiceCollectionExtensions.cs
+++ b/Source/AuthProxy/Invites/InvitesServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.AuthProxy.Authentication;
 using Microsoft.Extensions.Options;
 
 namespace Cratis.AuthProxy.Invites;
@@ -11,7 +12,7 @@ namespace Cratis.AuthProxy.Invites;
 public static class InvitesServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers the <see cref="IInviteTokenValidator"/>.
+    /// Registers the <see cref="IInviteTokenValidator"/> and the shared invitation completion.
     /// </summary>
     /// <param name="builder">The <see cref="WebApplicationBuilder"/> to configure.</param>
     /// <returns>The same <see cref="WebApplicationBuilder"/> for chaining.</returns>
@@ -22,6 +23,16 @@ public static class InvitesServiceCollectionExtensions
         builder.Services.AddSingleton<IInvitationAttestationIssuer, InvitationAttestationIssuer>();
         builder.Services.AddSingleton<IInvitationEntryStateProtector, InvitationEntryStateProtector>();
         builder.Services.AddSingleton<IValidateOptions<Configuration.AuthProxy>, InvitationAttestationConfigurationValidator>();
+        builder.Services.AddSingleton<IInviteCompletion>(sp => new InviteCompletion(
+            sp.GetRequiredService<IInviteTokenValidator>(),
+            sp.GetRequiredService<IOptionsMonitor<Configuration.AuthProxy>>(),
+            sp.GetRequiredService<IOptionsMonitor<Configuration.Authentication>>(),
+            sp.GetRequiredService<ITenantResolver>(),
+            sp.GetRequiredService<IHttpClientFactory>(),
+            sp.GetRequiredService<ILogger<InviteCompletion>>(),
+            sp.GetRequiredService<ICanonicalIdentityResolver>(),
+            sp.GetRequiredService<IInvitationAttestationIssuer>(),
+            sp.GetRequiredService<IInvitationEntryStateProtector>()));
 
         return builder;
     }

--- a/Source/AuthProxy/Invites/PendingInvitationCookies.cs
+++ b/Source/AuthProxy/Invites/PendingInvitationCookies.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy.Invites;
+
+/// <summary>
+/// Removes the cookies that carry a pending invitation across the provider round-trip.
+/// </summary>
+/// <remarks>
+/// Shared between <see cref="InviteMiddleware"/> and <see cref="InviteCallbackCompletion"/> so the pending
+/// state is cleared identically wherever an invitation reaches its terminal answer.
+/// </remarks>
+public static class PendingInvitationCookies
+{
+    /// <summary>
+    /// Removes every cookie belonging to a pending invitation, at both the default and the root path.
+    /// </summary>
+    /// <param name="context">The current <see cref="HttpContext"/>.</param>
+    public static void Delete(HttpContext context)
+    {
+        context.Response.Cookies.Delete(Cookies.InviteToken);
+        context.Response.Cookies.Delete(Cookies.InvitationEntryState);
+        context.Response.Cookies.Delete(Cookies.InviteToken, new CookieOptions { Path = "/" });
+        context.Response.Cookies.Delete(Cookies.InvitationEntryState, new CookieOptions { Path = "/" });
+    }
+}


### PR DESCRIPTION
## Fixed

- Accepting an invitation no longer shows a second provider-selection page: the invitation now completes on the provider sign-in callback itself, so it no longer depends on the browser presenting the fresh session cookie on the follow-up request.
- After a completed invitation, the sign-in redirects straight to the lobby for a create-organization invitation and to the original return URL for a tenant-issued one; a failed exchange on the callback answers with the same page or redirect the post-login exchange produces.
- A browser replaying the invitation URL or a stale pending-invitation cookie after completion is recognized as already answered instead of being offered provider selection again or re-running the exchange.