### PR TITLE
Answer invitations and registrations from their own middleware

### DIFF
--- a/Source/AuthProxy.Specs/Scenarios/when_invitation_link_is_used/FrontendRoutedAuthProxyFactory.cs
+++ b/Source/AuthProxy.Specs/Scenarios/when_invitation_link_is_used/FrontendRoutedAuthProxyFactory.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+namespace Cratis.AuthProxy.Scenarios.when_invitation_link_is_used;
+
+/// <summary>
+/// Extends <see cref="MultipleProvidersAuthProxyFactory"/> with a frontend endpoint, so the deployment is
+/// routed the way a real one is.
+/// </summary>
+/// <remarks>
+/// Every other scenario here declares a backend and nothing else, and a backend-only service is routed at
+/// <c>/api/{**catch-all}</c> alone — so an invitation path matches no route, is selected onto no endpoint,
+/// and reaches the invite middleware whatever the authorization step would have done with it. A real
+/// deployment declares a frontend as well (Studio sets <c>Services:{key}:Frontend:BaseUrl</c> alongside the
+/// backend), and a frontend is routed at <c>/{**catch-all}</c> — which matches every path there is,
+/// including the two the proxy answers itself.
+/// <para>
+/// That single configuration difference is why an invitation link looped in production while every
+/// invitation spec passed: the scenarios were run on the one routing shape in which the defect cannot
+/// occur. Declaring the frontend here is the whole point of this factory — it is what makes these
+/// scenarios exercise the pipeline a deployment actually runs.
+/// </para>
+/// </remarks>
+public class FrontendRoutedAuthProxyFactory : MultipleProvidersAuthProxyFactory
+{
+    /// <summary>The frontend endpoint whose catch-all route covers every path.</summary>
+    public const string FrontendBaseUrl = "http://frontend.test/";
+
+    /// <inheritdoc/>
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        // The development settings declare a second service of their own, and a plain catch-all is only
+        // emitted for a deployment that has exactly one - so leaving them loaded means every route is
+        // selected by a header or query parameter, a browser's invitation request matches none of them, and
+        // the scenario silently stops covering the routing shape it exists to cover.
+        builder.UseEnvironment(Environments.Production);
+        base.ConfigureWebHost(builder);
+        builder.ConfigureAppConfiguration((_, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"{C.AuthProxy.SectionKey}:Services:test:Frontend:BaseUrl"] = FrontendBaseUrl,
+            });
+        });
+    }
+}

--- a/Source/AuthProxy.Specs/Scenarios/when_invitation_link_is_used/and_a_frontend_route_covers_every_path.cs
+++ b/Source/AuthProxy.Specs/Scenarios/when_invitation_link_is_used/and_a_frontend_route_covers_every_path.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net;
+using Cratis.AuthProxy.Invites;
+
+namespace Cratis.AuthProxy.Scenarios.when_invitation_link_is_used;
+
+/// <summary>
+/// Pins that a deployment whose frontend catch-all route covers every path still answers an invitation with
+/// the invitation flow.
+/// </summary>
+/// <remarks>
+/// The catch-all is generated with the default authorization policy — <c>RequireAuthenticatedUser</c> — and
+/// the invite middleware is registered after <c>UseAuthorization</c>. Without releasing the proxy-owned
+/// flows from the route that matched them, authorization refused the request first and redirected the
+/// browser to provider selection: no invitation staged, and no pending-invitation cookie, so the sign-in
+/// that followed carried no capability binding and the invitation could only complete on a later pass.
+/// Landing on a provider-selection page either way is what made this so easy to miss — the assertion that
+/// separates the two is the pending-invitation cookie, which only the invite flow plants.
+/// </remarks>
+/// <param name="factory">The single-service, frontend-routed proxy this scenario runs against.</param>
+public class and_a_frontend_route_covers_every_path(FrontendRoutedAuthProxyFactory factory)
+    : IClassFixture<FrontendRoutedAuthProxyFactory>, IAsyncLifetime
+{
+    HttpResponseMessage? _response;
+    HttpResponseMessage? _registration;
+    string? _responseBody;
+
+    public async Task InitializeAsync()
+    {
+        var token = TokenFixture.CreateToken(
+            factory.InviteKeyPair.PrivateKey,
+            additionalClaims: [new Claim("jti", Guid.NewGuid().ToString())]);
+
+        using var client = factory.CreateTestClient();
+        _response = await client.GetAsync($"/invite/{token}");
+        _responseBody = await _response.Content.ReadAsStringAsync();
+        _registration = await client.GetAsync("/register");
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public void should_not_redirect_the_invitation_to_the_login_page() =>
+        Assert.NotEqual(HttpStatusCode.Redirect, _response.StatusCode);
+
+    [Fact]
+    public void should_serve_the_invitation_provider_selection_page() =>
+        Assert.Contains("Select Provider", _responseBody);
+
+    [Fact]
+    public void should_return_200_for_the_invitation() =>
+        Assert.Equal(HttpStatusCode.OK, _response.StatusCode);
+
+    [Fact]
+    public void should_stage_the_invitation_by_setting_the_pending_invitation_cookie()
+    {
+        _response.Headers.TryGetValues("Set-Cookie", out var cookies);
+        Assert.True(
+            cookies?.Any(_ => _.StartsWith(Cookies.InviteToken, StringComparison.OrdinalIgnoreCase)),
+            $"Expected Set-Cookie header containing '{Cookies.InviteToken}' — without it the sign-in that follows carries no capability binding");
+    }
+
+    [Fact]
+    public void should_not_redirect_registration_to_the_login_page() =>
+        Assert.NotEqual(HttpStatusCode.Redirect, _registration.StatusCode);
+}

--- a/Source/AuthProxy/HttpContextExtensions.cs
+++ b/Source/AuthProxy/HttpContextExtensions.cs
@@ -60,6 +60,24 @@ public static class HttpContextExtensions
     public static bool IsRegistration(this HttpContext context) => context.Request.Path.StartsWithSegments(WellKnownPaths.Registration);
 
     /// <summary>
+    /// Determines whether the request targets one of the flows AuthProxy answers itself, from its own
+    /// middleware, rather than proxying to a service.
+    /// </summary>
+    /// <param name="context">The <see cref="HttpContext"/> to evaluate.</param>
+    /// <returns><see langword="true"/> if the request belongs to a proxy-owned flow; otherwise <see langword="false"/>.</returns>
+    /// <remarks>
+    /// These two prefixes are reserved (<see cref="AnonymousPathPolicy"/>) precisely because they are never
+    /// routed to a backend — the invitation and registration middlewares answer them in full, validating
+    /// their own capabilities as they go. Both middlewares run after <c>UseAuthorization</c>, so the
+    /// reverse proxy's catch-all route would otherwise select an endpoint carrying the default
+    /// <c>RequireAuthenticatedUser</c> policy and the request would be challenged before either of them
+    /// ever saw it: an invitation link would redirect to provider selection instead of staging the
+    /// invitation, and the flow could only complete on a second pass once a cookie it never planted
+    /// happened to exist.
+    /// </remarks>
+    public static bool IsProxyOwnedFlow(this HttpContext context) => context.IsInvitation() || context.IsRegistration();
+
+    /// <summary>
     /// Determines whether the request targets one of the login endpoints.
     /// </summary>
     /// <param name="context">The <see cref="HttpContext"/> to evaluate.</param>

--- a/Source/AuthProxy/IngressExtensions.cs
+++ b/Source/AuthProxy/IngressExtensions.cs
@@ -168,6 +168,12 @@ public static class IngressExtensions
         app.UseMiddleware<LogoutMiddleware>();
         app.UseMiddleware<Authentication.SelectProviderMiddleware>();
         app.UseMiddleware<LinkMiddleware>();
+
+        // The invitation and registration flows are answered by their own middleware further down, and both
+        // sit after this authorization step. Without releasing them from the catch-all route that matched
+        // them, the default RequireAuthenticatedUser policy refuses them here and neither middleware ever
+        // runs — the defect that made an invitation link answer with provider selection twice.
+        app.UseMiddleware<ProxyOwnedFlowMiddleware>();
         app.UseAuthorization();
         app.UseMiddleware<AccessControlMiddleware>();
         app.UseMiddleware<TenantSelectionMiddleware>();

--- a/Source/AuthProxy/ProxyOwnedFlowMiddleware.cs
+++ b/Source/AuthProxy/ProxyOwnedFlowMiddleware.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.AuthProxy;
+
+/// <summary>
+/// Releases the flows AuthProxy answers itself from the route the reverse proxy selected for them, so the
+/// middleware that owns each flow is what answers it.
+/// </summary>
+/// <param name="next">The next middleware in the pipeline.</param>
+/// <remarks>
+/// <see cref="IngressExtensions.UseIngress"/> anchors endpoint matching at <c>UseRouting</c>, and YARP's
+/// catch-all route matches every path — including the two prefixes that are reserved from every service
+/// precisely because no service ever serves them. Those routes are generated with the default authorization
+/// policy, which is <c>RequireAuthenticatedUser</c>, so <c>UseAuthorization</c> refused an invitation or a
+/// registration before <see cref="Invites.InviteMiddleware"/> or
+/// <see cref="Registrations.RegistrationMiddleware"/> — both registered after it — could run at all. The
+/// visible symptom was an invitation link that answered with provider selection and no pending-invitation
+/// cookie: the sign-in that followed carried no capability binding, so the callback had nothing to complete
+/// and the person was offered provider selection a second time, the first pass having finally planted the
+/// cookie the second one needed.
+/// <para>
+/// The endpoint is cleared rather than the authorization step skipped. Skipping it would leave the
+/// catch-all's authorization metadata on a request that never evaluated it, which
+/// <c>EndpointMiddleware</c> refuses outright; clearing it removes the claim on the path instead, leaving
+/// <c>UseAuthorization</c> to find nothing to enforce and pass the request on. That says what is true —
+/// these paths belong to the proxy, not to a route — and makes it impossible for one to be proxied to a
+/// backend by a route that matched it only for want of a more specific one.
+/// </para>
+/// <para>
+/// Nothing else is relaxed. Both flows re-validate their own capability — signature, issuer, audience and
+/// lifetime — on every phase, and <see cref="Identity.IdentityForwardingGuardMiddleware"/> remains the
+/// fail-closed backstop that no request reaches a service without a forwardable identity.
+/// </para>
+/// </remarks>
+public class ProxyOwnedFlowMiddleware(RequestDelegate next)
+{
+    /// <inheritdoc cref="IMiddleware.InvokeAsync"/>
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (context.IsProxyOwnedFlow())
+        {
+            context.SetEndpoint(null);
+        }
+
+        await next(context);
+    }
+}


### PR DESCRIPTION
# Summary

An invitation link asked the person to pick an identity provider twice. The first
choice signed them in and returned them to a second, identical selection page;
only the pass after that completed the invitation and reached the application.

A deployment that declares a frontend is routed with a catch-all covering every
path, and that route carries the default `RequireAuthenticatedUser` policy. It
matched `/invite/{token}` and `/register` too, so authorization refused both
before the middleware that owns each flow ever ran. Nothing was staged and no
pending-invitation cookie was set, so the sign-in that followed carried no
capability binding and the invitation could not complete — until a later pass,
by which time the first one had finally planted the cookie it needed.

## Fixed

- An invitation link no longer asks for an identity provider a second time after signing in, and completes on the first attempt.
- `/invite` and `/register` are answered by the invitation and registration flows in every deployment, instead of being redirected to provider selection wherever a catch-all route covers them.